### PR TITLE
Releasing version 2.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.20.0 - 2022-03-22
+### Added
+- Support for getting the storage utilization of a deployment on deployment list and get operations in the GoldenGate service
+- Support for virtual machines, bare metal machines, and Exadata databases with private endpoints in the Operations Insights service
+- Support for setting deletion policies on database systems in the MySQL Database service
+
+### Breaking Changes
+- Support for retries by default on operations in the Data Labeling service (data plane and control plane)
+
 ## 2.19.1 - 2022-03-15
 ### Added
 - Support for Ubuntu platforms and unlimited installation keys in the Management Agent Cloud service

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -85,6 +85,7 @@ jackson-jaxrs-base
 jakarta.ws.rs-api
 * Copyright © Eclipse Foundation
 * License: Eclipse Public License 2.0
+           GNU General Public License 2.0 with Classpath Exception
 * Source code: https://github.com/eclipse-ee4j/jaxrs-api
 * Project home: https://projects.eclipse.org/projects/ee4j.jaxrs
 
@@ -92,7 +93,7 @@ jersey-client
 * Copyright © Eclipse Foundation
 * License: Eclipse Public License 2.0
            GNU General Public License 2.0 with Classpath Exception
-* Source code: https://github.com/javaee/jersey
+* Source code: https://github.com/eclipse-ee4j/jersey
 * Project home: https://projects.eclipse.org/projects/ee4j.jersey
 
 jersey-hk2
@@ -313,7 +314,8 @@ org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec
 
 org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec
 * Copyright © 2011, 2019 Oracle and/or its affiliates. All rights reserved.
-* License: Eclipse Public License 2.0
+* License: GNU General Public License 2.0 with Classpath Exception
+* Source code: https://github.com/jboss/jboss-jaxrs-api_spec
 
 org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec
 * Copyright © 2018, 2019 Oracle and/or its affiliates. All rights reserved.
@@ -1721,6 +1723,196 @@ Currently two Open Source licenses are available for use:
 * Lesser/Library General Public License (LGPL 2.1)
 
 These licenses have proven adequate to cover all current use cases.
+
+------------------------------------------------------------------------
+
+jakarta.ws.rs-api
+
+# Notices for Jakarta RESTful Web Services
+
+This content is produced and maintained by the **Jakarta RESTful Web Services**
+project.
+
+* Project home: https://projects.eclipse.org/projects/ee4j.jaxrs
+
+## Trademarks
+
+**Jakarta RESTful Web Services** is a trademark of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License v. 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0. This Source Code may also be made
+available under the following Secondary Licenses when the conditions for such
+availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath Exception which is
+available at https://www.gnu.org/software/classpath/license.html.
+
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-ee4j/jaxrs-api
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+javaee-api (7.0)
+
+* License: Apache-2.0 AND W3C
+
+JUnit (4.11)
+
+* License: Common Public License 1.0
+
+Mockito (2.16.0)
+
+* Project: http://site.mockito.org
+* Source: https://github.com/mockito/mockito/releases/tag/v2.16.0
+
+## Cryptography
+
+Content may contain encryption software. The country in which you are currently
+may have restrictions on the import, possession, and use, and/or re-export to
+another country, of encryption software. BEFORE using any encryption software,
+please check the country's laws, regulations and policies concerning the import,
+possession, or use, and re-export of encryption software, to see if this is
+permitted.
+
+------------------------------------------------------------------------
+
+jersey-client
+jersey-hk2
+jersey-media-json-jackson
+
+# Notice for Jersey
+This content is produced and maintained by the Eclipse Jersey project.
+
+*  Project home: https://projects.eclipse.org/projects/ee4j.jersey
+
+## Trademarks
+Eclipse Jersey is a trademark of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License v. 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0. This Source Code may also be made
+available under the following Secondary Licenses when the conditions for such
+availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath Exception which is
+available at https://www.gnu.org/software/classpath/license.html.
+
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+## Source Code
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-ee4j/jersey
+
+## Third-party Content
+
+Angular JS, v1.6.6
+* License MIT (http://www.opensource.org/licenses/mit-license.php)
+* Project: http://angularjs.org
+* Coyright: (c) 2010-2017 Google, Inc.
+
+aopalliance Version 1
+* License: all the source code provided by AOP Alliance is Public Domain.
+* Project: http://aopalliance.sourceforge.net
+* Copyright: Material in the public domain is not protected by copyright
+
+Bean Validation API 2.0.2
+* License: Apache License, 2.0
+* Project: http://beanvalidation.org/1.1/
+* Copyright: 2009, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag.
+
+Hibernate Validator CDI, 6.1.2.Final 
+* License: Apache License, 2.0
+* Project: https://beanvalidation.org/
+* Repackaged in org.glassfish.jersey.server.validation.internal.hibernate
+
+Bootstrap v3.3.7
+* License: MIT license (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+* Project: http://getbootstrap.com
+* Copyright: 2011-2016 Twitter, Inc
+
+Google Guava Version 18.0
+* License: Apache License, 2.0
+* Copyright (C) 2009 The Guava Authors
+
+javax.inject Version: 1
+* License: Apache License, 2.0
+* Copyright (C) 2009 The JSR-330 Expert Group
+
+Javassist Version 3.25.0-GA
+* License: Apache License, 2.0
+* Project: http://www.javassist.org/
+* Copyright (C) 1999- Shigeru Chiba. All Rights Reserved.
+
+Jackson JAX-RS Providers Version 2.10.1
+* License: Apache License, 2.0
+* Project: https://github.com/FasterXML/jackson-jaxrs-providers
+* Copyright: (c) 2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
+
+jQuery v1.12.4
+* License: jquery.org/license
+* Project: jquery.org
+* Copyright: (c) jQuery Foundation
+
+jQuery Barcode plugin 0.3
+* License: MIT & GPL (http://www.opensource.org/licenses/mit-license.php &
+http://www.gnu.org/licenses/gpl.html)
+* Project:  http://www.pasella.it/projects/jQuery/barcode
+* Copyright: (c) 2009 Antonello Pasella antonello.pasella@gmail.com
+
+JSR-166 Extension - JEP 266
+* License: CC0
+* No copyright
+* Written by Doug Lea with assistance from members of JCP JSR-166 Expert Group and
+released to the public domain, as explained at http://creativecommons.org/publicdomain/zero/1.0/
+
+KineticJS, v4.7.1
+* License: MIT license (http://www.opensource.org/licenses/mit-license.php)
+* Project: http://www.kineticjs.com, https://github.com/ericdrowell/KineticJS
+* Copyright: Eric Rowell
+
+org.objectweb.asm Version 8.0
+* License: Modified BSD (https://asm.ow2.io/license.html)
+* Copyright (c) 2000-2011 INRIA, France Telecom. All rights reserved.
+
+org.osgi.core version 6.0.0
+* License: Apache License, 2.0
+* Copyright (c) OSGi Alliance (2005, 2008). All Rights Reserved.
+
+org.glassfish.jersey.server.internal.monitoring.core
+* License: Apache License, 2.0
+* Copyright (c) 2015-2018 Oracle and/or its affiliates. All rights reserved.
+* Copyright 2010-2013 Coda Hale and Yammer, Inc.
+
+W3.org documents
+* License: W3C License
+* Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts
+Institute of Technology, Institut National de Recherche en Informatique et en
+Automatique, Keio University). All Rights Reserved.
+http://www.w3.org/Consortium/Legal/
 
 ------------------------------------------------------------------------
 

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aispeech/pom.xml
+++ b/bmc-aispeech/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aispeech</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aivision/pom.xml
+++ b/bmc-aivision/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aivision</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-appmgmtcontrol/pom.xml
+++ b/bmc-appmgmtcontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,636 +19,636 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificates</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usage</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasetools</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ospgateway</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identitydataplane</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-visualbuilder</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubusage</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubsubscription</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dashboardservice</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-threatintelligence</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aivision</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aispeech</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataconnectivity</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificates/pom.xml
+++ b/bmc-certificates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificates</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificatesmanagement/pom.xml
+++ b/bmc-certificatesmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-common/src/main/java/com/oracle/bmc/util/CircuitBreakerUtils.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/util/CircuitBreakerUtils.java
@@ -38,6 +38,46 @@ public class CircuitBreakerUtils {
     private static final String OCI_SDK_DEFAULT_CIRCUITBREAKER_ENABLED_ENV_VAR =
             "OCI_SDK_DEFAULT_CIRCUITBREAKER_ENABLED";
 
+    /**
+     * Gets the user defined CircuitBreaker
+     * @return the user defined CircuitBreaker
+     */
+    @Deprecated
+    public static JaxRsCircuitBreaker getUserDefinedCircuitBreaker(
+            ClientConfiguration configuration) {
+        JaxRsCircuitBreaker circuitBreaker = null;
+        if (configuration != null) {
+            if (configuration.getCircuitBreakerConfiguration() != null
+                    && configuration.getCircuitBreaker() != null) {
+                throw new IllegalArgumentException(
+                        "Invalid CircuitBreaker setting. Please provide either CircuitBreaker configuration or CircuitBreaker and not both");
+            }
+
+            if (configuration.getCircuitBreakerConfiguration() != null) {
+                circuitBreaker =
+                        new JaxRsCircuitBreakerImpl(configuration.getCircuitBreakerConfiguration());
+            } else if (configuration.getCircuitBreaker() != null)
+                circuitBreaker = configuration.getCircuitBreaker();
+        } else {
+            JaxRsCircuitBreaker userGlobalCircuitBreaker = null;
+            CircuitBreakerConfiguration globalCircuitBreakerConfiguration =
+                    CircuitBreakerUtils.getDefaultCircuitBreakerConfiguration();
+            if (globalCircuitBreakerConfiguration != null) {
+                userGlobalCircuitBreaker =
+                        new JaxRsCircuitBreakerImpl(globalCircuitBreakerConfiguration);
+            } else if (isEnvBasedDefaultCircuitBreakerEnabled()) {
+                userGlobalCircuitBreaker = DEFAULT_CIRCUIT_BREAKER;
+            }
+            circuitBreaker = userGlobalCircuitBreaker;
+        }
+        LOG.debug("Circuit breaker in use: {}", circuitBreaker);
+        return circuitBreaker;
+    }
+
+    /**
+     * Gets the user defined CircuitBreakerConfiguration
+     * @return the user defined CircuitBreakerConfiguration
+     */
     public static CircuitBreakerConfiguration getUserDefinedCircuitBreakerConfiguration(
             ClientConfiguration configuration) {
         CircuitBreakerConfiguration circuitBreakerConfiguration = null;

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dashboardservice/pom.xml
+++ b/bmc-dashboardservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dashboardservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasetools/pom.xml
+++ b/bmc-databasetools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasetools</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataconnectivity/pom.xml
+++ b/bmc-dataconnectivity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataconnectivity</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/DataLabelingManagement.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/DataLabelingManagement.java
@@ -52,7 +52,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/AddDatasetLabelsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use AddDatasetLabels API.
@@ -64,7 +64,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/ChangeDatasetCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeDatasetCompartment API.
@@ -78,7 +78,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/CreateDatasetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateDataset API.
@@ -90,7 +90,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/DeleteDatasetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteDataset API.
@@ -102,7 +102,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/GenerateDatasetRecordsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GenerateDatasetRecords API.
@@ -114,7 +114,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/GetDatasetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetDataset API.
@@ -126,7 +126,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
@@ -138,7 +138,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/ListAnnotationFormatsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAnnotationFormats API.
@@ -151,7 +151,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/ListDatasetsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDatasets API.
@@ -164,7 +164,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestErrors API.
@@ -177,7 +177,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestLogs API.
@@ -190,7 +190,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.
@@ -203,7 +203,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/RemoveDatasetLabelsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RemoveDatasetLabels API.
@@ -216,7 +216,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/RenameDatasetLabelsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RenameDatasetLabels API.
@@ -230,7 +230,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/SnapshotDatasetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SnapshotDataset API.
@@ -242,7 +242,7 @@ public interface DataLabelingManagement extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservice/UpdateDatasetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateDataset API.

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/DataLabelingManagementClient.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/DataLabelingManagementClient.java
@@ -474,7 +474,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -509,7 +509,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -542,7 +542,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -576,7 +576,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -607,7 +607,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -640,7 +640,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -669,7 +669,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -699,7 +699,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -728,7 +728,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -758,7 +758,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -787,7 +787,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -816,7 +816,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -845,7 +845,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -879,7 +879,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -913,7 +913,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -947,7 +947,7 @@ public class DataLabelingManagementClient implements DataLabelingManagement {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/DataLabeling.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/DataLabeling.java
@@ -65,7 +65,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/CreateRecordExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateRecord API.
@@ -78,7 +78,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/DeleteAnnotationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteAnnotation API.
@@ -91,7 +91,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/DeleteRecordExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteRecord API.
@@ -104,7 +104,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/GetAnnotationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAnnotation API.
@@ -116,7 +116,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/GetDatasetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetDataset API.
@@ -129,7 +129,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/GetRecordExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetRecord API.
@@ -142,7 +142,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/GetRecordContentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetRecordContent API.
@@ -155,7 +155,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/GetRecordPreviewContentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetRecordPreviewContent API.
@@ -168,7 +168,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/ListAnnotationsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAnnotations API.
@@ -181,7 +181,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/ListRecordsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListRecords API.
@@ -194,7 +194,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/SummarizeAnnotationAnalyticsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAnnotationAnalytics API.
@@ -208,7 +208,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/SummarizeRecordAnalyticsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeRecordAnalytics API.
@@ -222,7 +222,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/UpdateAnnotationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateAnnotation API.
@@ -235,7 +235,7 @@ public interface DataLabeling extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datalabelingservicedataplane/UpdateRecordExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateRecord API.

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/DataLabelingClient.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/DataLabelingClient.java
@@ -507,7 +507,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -541,7 +541,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -571,7 +571,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -601,7 +601,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -629,7 +629,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -657,7 +657,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -696,7 +696,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -736,7 +736,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -765,7 +765,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -794,7 +794,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -825,7 +825,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -855,7 +855,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -884,7 +884,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -917,7 +917,7 @@ public class DataLabelingClient implements DataLabeling {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/ClientConfigurationTimeoutExample.java
+++ b/bmc-examples/src/main/java/ClientConfigurationTimeoutExample.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+import com.oracle.bmc.ClientConfiguration;
+import com.oracle.bmc.ConfigFileReader;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.identity.IdentityClient;
+import com.oracle.bmc.identity.model.AvailabilityDomain;
+import com.oracle.bmc.identity.requests.ListAvailabilityDomainsRequest;
+import com.oracle.bmc.identity.responses.ListAvailabilityDomainsResponse;
+
+/**
+ * A sample to demonstrate how to configure connection timeout and read timeout using client configuration.
+ */
+public class ClientConfigurationTimeoutExample {
+
+    private static final int CONNECTION_TIMEOUT_IN_MILLISECONDS = 20000;
+    private static final int READ_TIMEOUT_IN_MILLISECONDS = 30000;
+
+    public static void main(String[] args) throws Exception {
+
+        final ConfigFileReader.ConfigFile configFile = ConfigFileReader.parseDefault();
+        final AuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(configFile);
+
+        ClientConfiguration clientConfiguration =
+                ClientConfiguration.builder()
+                        .connectionTimeoutMillis(CONNECTION_TIMEOUT_IN_MILLISECONDS)
+                        .readTimeoutMillis(READ_TIMEOUT_IN_MILLISECONDS)
+                        .build();
+
+        System.out.println(
+                "Connection timeout set to " + CONNECTION_TIMEOUT_IN_MILLISECONDS + "ms");
+        System.out.println("Read timeout set to " + READ_TIMEOUT_IN_MILLISECONDS + "ms");
+
+        final IdentityClient identityClient = new IdentityClient(provider, clientConfiguration);
+
+        // TODO: Pass in the compartment ID as an argument, or enter the value directly here (if known)
+        final String compartmentId = args[0];
+        System.out.println(compartmentId);
+
+        final ListAvailabilityDomainsRequest request =
+                ListAvailabilityDomainsRequest.builder().compartmentId(compartmentId).build();
+        ListAvailabilityDomainsResponse listAvailabilityDomainsResponse =
+                identityClient.listAvailabilityDomains(request);
+        for (AvailabilityDomain domain : listAvailabilityDomainsResponse.getItems()) {
+            System.out.println(domain.toString());
+        }
+        identityClient.close();
+    }
+}

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/CreateDeploymentDetails.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/CreateDeploymentDetails.java
@@ -313,8 +313,7 @@ public class CreateDeploymentDetails {
     Boolean isAutoScalingEnabled;
 
     /**
-     * The type of deployment, the value determines the exact 'type' of service executed in the Deployment. NOTE: Use of the value OGG is maintained for backward compatibility purposes.  Its use is discouraged
-     *       in favor of the equivalent DATABASE_ORACLE value.
+     * The deployment type.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("deploymentType")

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/Deployment.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/Deployment.java
@@ -260,6 +260,25 @@ public class Deployment {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("storageUtilizationInBytes")
+        private Long storageUtilizationInBytes;
+
+        public Builder storageUtilizationInBytes(Long storageUtilizationInBytes) {
+            this.storageUtilizationInBytes = storageUtilizationInBytes;
+            this.__explicitlySet__.add("storageUtilizationInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isStorageUtilizationLimitExceeded")
+        private Boolean isStorageUtilizationLimitExceeded;
+
+        public Builder isStorageUtilizationLimitExceeded(
+                Boolean isStorageUtilizationLimitExceeded) {
+            this.isStorageUtilizationLimitExceeded = isStorageUtilizationLimitExceeded;
+            this.__explicitlySet__.add("isStorageUtilizationLimitExceeded");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("deploymentType")
         private DeploymentType deploymentType;
 
@@ -310,6 +329,8 @@ public class Deployment {
                             systemTags,
                             isLatestVersion,
                             timeUpgradeRequired,
+                            storageUtilizationInBytes,
+                            isStorageUtilizationLimitExceeded,
                             deploymentType,
                             oggData);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -345,6 +366,9 @@ public class Deployment {
                             .systemTags(o.getSystemTags())
                             .isLatestVersion(o.getIsLatestVersion())
                             .timeUpgradeRequired(o.getTimeUpgradeRequired())
+                            .storageUtilizationInBytes(o.getStorageUtilizationInBytes())
+                            .isStorageUtilizationLimitExceeded(
+                                    o.getIsStorageUtilizationLimitExceeded())
                             .deploymentType(o.getDeploymentType())
                             .oggData(o.getOggData());
 
@@ -546,8 +570,21 @@ public class Deployment {
     java.util.Date timeUpgradeRequired;
 
     /**
-     * The type of deployment, the value determines the exact 'type' of service executed in the Deployment. NOTE: Use of the value OGG is maintained for backward compatibility purposes.  Its use is discouraged
-     *       in favor of the equivalent DATABASE_ORACLE value.
+     * The amount of storage being utilized (in bytes)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("storageUtilizationInBytes")
+    Long storageUtilizationInBytes;
+
+    /**
+     * Indicator will be true if the amount of storage being utilized exceeds the allowable storage utilization limit.  Exceeding the limit may be an indication of a misconfiguration of the deployment's GoldenGate service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isStorageUtilizationLimitExceeded")
+    Boolean isStorageUtilizationLimitExceeded;
+
+    /**
+     * The deployment type.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("deploymentType")

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentSummary.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentSummary.java
@@ -244,6 +244,25 @@ public class DeploymentSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("storageUtilizationInBytes")
+        private Long storageUtilizationInBytes;
+
+        public Builder storageUtilizationInBytes(Long storageUtilizationInBytes) {
+            this.storageUtilizationInBytes = storageUtilizationInBytes;
+            this.__explicitlySet__.add("storageUtilizationInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isStorageUtilizationLimitExceeded")
+        private Boolean isStorageUtilizationLimitExceeded;
+
+        public Builder isStorageUtilizationLimitExceeded(
+                Boolean isStorageUtilizationLimitExceeded) {
+            this.isStorageUtilizationLimitExceeded = isStorageUtilizationLimitExceeded;
+            this.__explicitlySet__.add("isStorageUtilizationLimitExceeded");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -273,7 +292,9 @@ public class DeploymentSummary {
                             systemTags,
                             isLatestVersion,
                             timeUpgradeRequired,
-                            deploymentType);
+                            deploymentType,
+                            storageUtilizationInBytes,
+                            isStorageUtilizationLimitExceeded);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -304,7 +325,10 @@ public class DeploymentSummary {
                             .systemTags(o.getSystemTags())
                             .isLatestVersion(o.getIsLatestVersion())
                             .timeUpgradeRequired(o.getTimeUpgradeRequired())
-                            .deploymentType(o.getDeploymentType());
+                            .deploymentType(o.getDeploymentType())
+                            .storageUtilizationInBytes(o.getStorageUtilizationInBytes())
+                            .isStorageUtilizationLimitExceeded(
+                                    o.getIsStorageUtilizationLimitExceeded());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -483,12 +507,25 @@ public class DeploymentSummary {
     java.util.Date timeUpgradeRequired;
 
     /**
-     * The type of deployment, the value determines the exact 'type' of service executed in the Deployment. NOTE: Use of the value OGG is maintained for backward compatibility purposes.  Its use is discouraged
-     *       in favor of the equivalent DATABASE_ORACLE value.
+     * The deployment type.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("deploymentType")
     DeploymentType deploymentType;
+
+    /**
+     * The amount of storage being utilized (in bytes)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("storageUtilizationInBytes")
+    Long storageUtilizationInBytes;
+
+    /**
+     * Indicator will be true if the amount of storage being utilized exceeds the allowable storage utilization limit.  Exceeding the limit may be an indication of a misconfiguration of the deployment's GoldenGate service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isStorageUtilizationLimitExceeded")
+    Boolean isStorageUtilizationLimitExceeded;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identitydataplane/pom.xml
+++ b/bmc-identitydataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-identitydataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateDbSystemDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateDbSystemDetails.java
@@ -226,6 +226,15 @@ public class CreateDbSystemDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+        private CreateDeletionPolicyDetails deletionPolicy;
+
+        public Builder deletionPolicy(CreateDeletionPolicyDetails deletionPolicy) {
+            this.deletionPolicy = deletionPolicy;
+            this.__explicitlySet__.add("deletionPolicy");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("crashRecovery")
         private CrashRecoveryStatus crashRecovery;
 
@@ -263,6 +272,7 @@ public class CreateDbSystemDetails {
                             maintenance,
                             freeformTags,
                             definedTags,
+                            deletionPolicy,
                             crashRecovery);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -293,6 +303,7 @@ public class CreateDbSystemDetails {
                             .maintenance(o.getMaintenance())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
+                            .deletionPolicy(o.getDeletionPolicy())
                             .crashRecovery(o.getCrashRecovery());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -478,6 +489,9 @@ public class CreateDbSystemDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+    CreateDeletionPolicyDetails deletionPolicy;
 
     /**
      * Whether to run the DB System with InnoDB Redo Logs and the Double Write Buffer enabled or disabled,

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateDeletionPolicyDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateDeletionPolicyDetails.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Policy for how the DB System and related resources should be handled at the time of its deletion.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDeletionPolicyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateDeletionPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("automaticBackupRetention")
+        private AutomaticBackupRetention automaticBackupRetention;
+
+        public Builder automaticBackupRetention(AutomaticBackupRetention automaticBackupRetention) {
+            this.automaticBackupRetention = automaticBackupRetention;
+            this.__explicitlySet__.add("automaticBackupRetention");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("finalBackup")
+        private FinalBackup finalBackup;
+
+        public Builder finalBackup(FinalBackup finalBackup) {
+            this.finalBackup = finalBackup;
+            this.__explicitlySet__.add("finalBackup");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDeleteProtected")
+        private Boolean isDeleteProtected;
+
+        public Builder isDeleteProtected(Boolean isDeleteProtected) {
+            this.isDeleteProtected = isDeleteProtected;
+            this.__explicitlySet__.add("isDeleteProtected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDeletionPolicyDetails build() {
+            CreateDeletionPolicyDetails __instance__ =
+                    new CreateDeletionPolicyDetails(
+                            automaticBackupRetention, finalBackup, isDeleteProtected);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDeletionPolicyDetails o) {
+            Builder copiedBuilder =
+                    automaticBackupRetention(o.getAutomaticBackupRetention())
+                            .finalBackup(o.getFinalBackup())
+                            .isDeleteProtected(o.getIsDeleteProtected());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Specifies if any automatic backups created for a DB System should be retained or deleted when the DB System is deleted.
+     *
+     **/
+    public enum AutomaticBackupRetention {
+        Delete("DELETE"),
+        Retain("RETAIN"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, AutomaticBackupRetention> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AutomaticBackupRetention v : AutomaticBackupRetention.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        AutomaticBackupRetention(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AutomaticBackupRetention create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid AutomaticBackupRetention: " + key);
+        }
+    };
+    /**
+     * Specifies if any automatic backups created for a DB System should be retained or deleted when the DB System is deleted.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("automaticBackupRetention")
+    AutomaticBackupRetention automaticBackupRetention;
+    /**
+     * Specifies whether or not a backup is taken when the DB System is deleted.
+     *   REQUIRE_FINAL_BACKUP: a backup is taken if the DB System is deleted.
+     *   SKIP_FINAL_BACKUP: a backup is not taken if the DB System is deleted.
+     *
+     **/
+    public enum FinalBackup {
+        SkipFinalBackup("SKIP_FINAL_BACKUP"),
+        RequireFinalBackup("REQUIRE_FINAL_BACKUP"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, FinalBackup> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (FinalBackup v : FinalBackup.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        FinalBackup(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static FinalBackup create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid FinalBackup: " + key);
+        }
+    };
+    /**
+     * Specifies whether or not a backup is taken when the DB System is deleted.
+     *   REQUIRE_FINAL_BACKUP: a backup is taken if the DB System is deleted.
+     *   SKIP_FINAL_BACKUP: a backup is not taken if the DB System is deleted.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("finalBackup")
+    FinalBackup finalBackup;
+
+    /**
+     * Specifies whether the DB System can be deleted. Set to true to prevent deletion, false (default) to allow.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDeleteProtected")
+    Boolean isDeleteProtected;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystem.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystem.java
@@ -277,6 +277,15 @@ public class DbSystem {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+        private DeletionPolicyDetails deletionPolicy;
+
+        public Builder deletionPolicy(DeletionPolicyDetails deletionPolicy) {
+            this.deletionPolicy = deletionPolicy;
+            this.__explicitlySet__.add("deletionPolicy");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -357,6 +366,7 @@ public class DbSystem {
                             lifecycleState,
                             lifecycleDetails,
                             maintenance,
+                            deletionPolicy,
                             timeCreated,
                             timeUpdated,
                             freeformTags,
@@ -397,6 +407,7 @@ public class DbSystem {
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
                             .maintenance(o.getMaintenance())
+                            .deletionPolicy(o.getDeletionPolicy())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .freeformTags(o.getFreeformTags())
@@ -650,6 +661,9 @@ public class DbSystem {
 
     @com.fasterxml.jackson.annotation.JsonProperty("maintenance")
     MaintenanceDetails maintenance;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+    DeletionPolicyDetails deletionPolicy;
 
     /**
      * The date and time the DB System was created.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSnapshot.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSnapshot.java
@@ -205,6 +205,15 @@ public class DbSystemSnapshot {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+        private DeletionPolicyDetails deletionPolicy;
+
+        public Builder deletionPolicy(DeletionPolicyDetails deletionPolicy) {
+            this.deletionPolicy = deletionPolicy;
+            this.__explicitlySet__.add("deletionPolicy");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -259,6 +268,7 @@ public class DbSystemSnapshot {
                             isHighlyAvailable,
                             endpoints,
                             maintenance,
+                            deletionPolicy,
                             freeformTags,
                             definedTags,
                             crashRecovery);
@@ -289,6 +299,7 @@ public class DbSystemSnapshot {
                             .isHighlyAvailable(o.getIsHighlyAvailable())
                             .endpoints(o.getEndpoints())
                             .maintenance(o.getMaintenance())
+                            .deletionPolicy(o.getDeletionPolicy())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .crashRecovery(o.getCrashRecovery());
@@ -439,6 +450,9 @@ public class DbSystemSnapshot {
 
     @com.fasterxml.jackson.annotation.JsonProperty("maintenance")
     MaintenanceDetails maintenance;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+    DeletionPolicyDetails deletionPolicy;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSummary.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSummary.java
@@ -178,6 +178,15 @@ public class DbSystemSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+        private DeletionPolicyDetails deletionPolicy;
+
+        public Builder deletionPolicy(DeletionPolicyDetails deletionPolicy) {
+            this.deletionPolicy = deletionPolicy;
+            this.__explicitlySet__.add("deletionPolicy");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -229,6 +238,7 @@ public class DbSystemSummary {
                             mysqlVersion,
                             timeCreated,
                             timeUpdated,
+                            deletionPolicy,
                             freeformTags,
                             definedTags,
                             crashRecovery);
@@ -256,6 +266,7 @@ public class DbSystemSummary {
                             .mysqlVersion(o.getMysqlVersion())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
+                            .deletionPolicy(o.getDeletionPolicy())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .crashRecovery(o.getCrashRecovery());
@@ -384,6 +395,9 @@ public class DbSystemSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     java.util.Date timeUpdated;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+    DeletionPolicyDetails deletionPolicy;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DeletionPolicyDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DeletionPolicyDetails.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * The Deletion policy for the DB System.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DeletionPolicyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DeletionPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("automaticBackupRetention")
+        private AutomaticBackupRetention automaticBackupRetention;
+
+        public Builder automaticBackupRetention(AutomaticBackupRetention automaticBackupRetention) {
+            this.automaticBackupRetention = automaticBackupRetention;
+            this.__explicitlySet__.add("automaticBackupRetention");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("finalBackup")
+        private FinalBackup finalBackup;
+
+        public Builder finalBackup(FinalBackup finalBackup) {
+            this.finalBackup = finalBackup;
+            this.__explicitlySet__.add("finalBackup");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDeleteProtected")
+        private Boolean isDeleteProtected;
+
+        public Builder isDeleteProtected(Boolean isDeleteProtected) {
+            this.isDeleteProtected = isDeleteProtected;
+            this.__explicitlySet__.add("isDeleteProtected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DeletionPolicyDetails build() {
+            DeletionPolicyDetails __instance__ =
+                    new DeletionPolicyDetails(
+                            automaticBackupRetention, finalBackup, isDeleteProtected);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DeletionPolicyDetails o) {
+            Builder copiedBuilder =
+                    automaticBackupRetention(o.getAutomaticBackupRetention())
+                            .finalBackup(o.getFinalBackup())
+                            .isDeleteProtected(o.getIsDeleteProtected());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Specifies if any automatic backups created for a DB System should be retained or deleted when the DB System is deleted.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum AutomaticBackupRetention {
+        Delete("DELETE"),
+        Retain("RETAIN"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, AutomaticBackupRetention> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AutomaticBackupRetention v : AutomaticBackupRetention.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        AutomaticBackupRetention(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AutomaticBackupRetention create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'AutomaticBackupRetention', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Specifies if any automatic backups created for a DB System should be retained or deleted when the DB System is deleted.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("automaticBackupRetention")
+    AutomaticBackupRetention automaticBackupRetention;
+    /**
+     * Specifies whether or not a backup is taken when the DB System is deleted.
+     *   REQUIRE_FINAL_BACKUP: a backup is taken if the DB System is deleted.
+     *   SKIP_FINAL_BACKUP: a backup is not taken if the DB System is deleted.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum FinalBackup {
+        SkipFinalBackup("SKIP_FINAL_BACKUP"),
+        RequireFinalBackup("REQUIRE_FINAL_BACKUP"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, FinalBackup> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (FinalBackup v : FinalBackup.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        FinalBackup(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static FinalBackup create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'FinalBackup', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Specifies whether or not a backup is taken when the DB System is deleted.
+     *   REQUIRE_FINAL_BACKUP: a backup is taken if the DB System is deleted.
+     *   SKIP_FINAL_BACKUP: a backup is not taken if the DB System is deleted.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("finalBackup")
+    FinalBackup finalBackup;
+
+    /**
+     * Specifies whether the DB System can be deleted. Set to true to prevent deletion, false (default) to allow.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDeleteProtected")
+    Boolean isDeleteProtected;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateDbSystemDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateDbSystemDetails.java
@@ -208,6 +208,15 @@ public class UpdateDbSystemDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+        private UpdateDeletionPolicyDetails deletionPolicy;
+
+        public Builder deletionPolicy(UpdateDeletionPolicyDetails deletionPolicy) {
+            this.deletionPolicy = deletionPolicy;
+            this.__explicitlySet__.add("deletionPolicy");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("crashRecovery")
         private CrashRecoveryStatus crashRecovery;
 
@@ -243,6 +252,7 @@ public class UpdateDbSystemDetails {
                             maintenance,
                             freeformTags,
                             definedTags,
+                            deletionPolicy,
                             crashRecovery);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -271,6 +281,7 @@ public class UpdateDbSystemDetails {
                             .maintenance(o.getMaintenance())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
+                            .deletionPolicy(o.getDeletionPolicy())
                             .crashRecovery(o.getCrashRecovery());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -446,6 +457,9 @@ public class UpdateDbSystemDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deletionPolicy")
+    UpdateDeletionPolicyDetails deletionPolicy;
 
     /**
      * Whether to run the DB System with InnoDB Redo Logs and the Double Write Buffer enabled or disabled,

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateDeletionPolicyDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateDeletionPolicyDetails.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Policy for how the DB System and related resources should be handled at the time of its deletion.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateDeletionPolicyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateDeletionPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("automaticBackupRetention")
+        private AutomaticBackupRetention automaticBackupRetention;
+
+        public Builder automaticBackupRetention(AutomaticBackupRetention automaticBackupRetention) {
+            this.automaticBackupRetention = automaticBackupRetention;
+            this.__explicitlySet__.add("automaticBackupRetention");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("finalBackup")
+        private FinalBackup finalBackup;
+
+        public Builder finalBackup(FinalBackup finalBackup) {
+            this.finalBackup = finalBackup;
+            this.__explicitlySet__.add("finalBackup");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDeleteProtected")
+        private Boolean isDeleteProtected;
+
+        public Builder isDeleteProtected(Boolean isDeleteProtected) {
+            this.isDeleteProtected = isDeleteProtected;
+            this.__explicitlySet__.add("isDeleteProtected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateDeletionPolicyDetails build() {
+            UpdateDeletionPolicyDetails __instance__ =
+                    new UpdateDeletionPolicyDetails(
+                            automaticBackupRetention, finalBackup, isDeleteProtected);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateDeletionPolicyDetails o) {
+            Builder copiedBuilder =
+                    automaticBackupRetention(o.getAutomaticBackupRetention())
+                            .finalBackup(o.getFinalBackup())
+                            .isDeleteProtected(o.getIsDeleteProtected());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Specifies if any automatic backups created for a DB System should be retained or deleted when the DB System is deleted.
+     *
+     **/
+    public enum AutomaticBackupRetention {
+        Delete("DELETE"),
+        Retain("RETAIN"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, AutomaticBackupRetention> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AutomaticBackupRetention v : AutomaticBackupRetention.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        AutomaticBackupRetention(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AutomaticBackupRetention create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid AutomaticBackupRetention: " + key);
+        }
+    };
+    /**
+     * Specifies if any automatic backups created for a DB System should be retained or deleted when the DB System is deleted.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("automaticBackupRetention")
+    AutomaticBackupRetention automaticBackupRetention;
+    /**
+     * Specifies whether or not a backup is taken when the DB System is deleted.
+     *   REQUIRE_FINAL_BACKUP: a backup is taken if the DB System is deleted.
+     *   SKIP_FINAL_BACKUP: a backup is not taken if the DB System is deleted.
+     *
+     **/
+    public enum FinalBackup {
+        SkipFinalBackup("SKIP_FINAL_BACKUP"),
+        RequireFinalBackup("REQUIRE_FINAL_BACKUP"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, FinalBackup> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (FinalBackup v : FinalBackup.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        FinalBackup(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static FinalBackup create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid FinalBackup: " + key);
+        }
+    };
+    /**
+     * Specifies whether or not a backup is taken when the DB System is deleted.
+     *   REQUIRE_FINAL_BACKUP: a backup is taken if the DB System is deleted.
+     *   SKIP_FINAL_BACKUP: a backup is not taken if the DB System is deleted.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("finalBackup")
+    FinalBackup finalBackup;
+
+    /**
+     * Specifies whether the DB System can be deleted. Set to true to prevent deletion, false (default) to allow.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDeleteProtected")
+    Boolean isDeleteProtected;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsights.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsights.java
@@ -115,6 +115,33 @@ public interface OperationsInsights extends AutoCloseable {
             ChangeHostInsightCompartmentRequest request);
 
     /**
+     * Moves a private endpoint from one compartment to another. When provided, If-Match is checked against ETag values of the resource.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/ChangeOperationsInsightsPrivateEndpointCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeOperationsInsightsPrivateEndpointCompartment API.
+     */
+    ChangeOperationsInsightsPrivateEndpointCompartmentResponse
+            changeOperationsInsightsPrivateEndpointCompartment(
+                    ChangeOperationsInsightsPrivateEndpointCompartmentRequest request);
+
+    /**
+     * Change the connection details of a co-managed  database insight. When provided, If-Match is checked against ETag values of the resource.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/ChangePeComanagedDatabaseInsightExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangePeComanagedDatabaseInsight API.
+     */
+    ChangePeComanagedDatabaseInsightResponse changePeComanagedDatabaseInsight(
+            ChangePeComanagedDatabaseInsightRequest request);
+
+    /**
      * Create a AWR hub resource for the tenant in Operations Insights.
      * This resource will be created in root compartment.
      *
@@ -182,8 +209,24 @@ public interface OperationsInsights extends AutoCloseable {
     CreateHostInsightResponse createHostInsight(CreateHostInsightRequest request);
 
     /**
+     * Create a private endpoint resource for the tenant in Operations Insights.
+     * This resource will be created in customer compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/CreateOperationsInsightsPrivateEndpointExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateOperationsInsightsPrivateEndpoint API.
+     */
+    CreateOperationsInsightsPrivateEndpointResponse createOperationsInsightsPrivateEndpoint(
+            CreateOperationsInsightsPrivateEndpointRequest request);
+
+    /**
      * Create a Operations Insights Warehouse resource for the tenant in Operations Insights. New ADW will be provisioned for this tenant.
-     * There is only expected to be 1 warehouse per tenant. The warehouse is expected to be in the root compartment.
+     * There is only expected to be 1 warehouse per tenant. The warehouse is expected to be in the root compartment. If the 'opsi-warehouse-type'
+     * header is passed to the API, a warehouse resource without ADW or Schema provisioning is created.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -271,6 +314,19 @@ public interface OperationsInsights extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/DeleteHostInsightExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteHostInsight API.
      */
     DeleteHostInsightResponse deleteHostInsight(DeleteHostInsightRequest request);
+
+    /**
+     * Deletes a private endpoint.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/DeleteOperationsInsightsPrivateEndpointExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteOperationsInsightsPrivateEndpoint API.
+     */
+    DeleteOperationsInsightsPrivateEndpointResponse deleteOperationsInsightsPrivateEndpoint(
+            DeleteOperationsInsightsPrivateEndpointRequest request);
 
     /**
      * Deletes an Operations Insights Warehouse. There is only expected to be 1 warehouse per tenant.
@@ -461,6 +517,19 @@ public interface OperationsInsights extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/GetHostInsightExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetHostInsight API.
      */
     GetHostInsightResponse getHostInsight(GetHostInsightRequest request);
+
+    /**
+     * Gets the details of the specified private endpoint.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/GetOperationsInsightsPrivateEndpointExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetOperationsInsightsPrivateEndpoint API.
+     */
+    GetOperationsInsightsPrivateEndpointResponse getOperationsInsightsPrivateEndpoint(
+            GetOperationsInsightsPrivateEndpointRequest request);
 
     /**
      * Gets details of an Operations Insights Warehouse.
@@ -766,6 +835,19 @@ public interface OperationsInsights extends AutoCloseable {
      */
     ListImportableEnterpriseManagerEntitiesResponse listImportableEnterpriseManagerEntities(
             ListImportableEnterpriseManagerEntitiesRequest request);
+
+    /**
+     * Gets a list of Operation Insights private endpoints.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/ListOperationsInsightsPrivateEndpointsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListOperationsInsightsPrivateEndpoints API.
+     */
+    ListOperationsInsightsPrivateEndpointsResponse listOperationsInsightsPrivateEndpoints(
+            ListOperationsInsightsPrivateEndpointsRequest request);
 
     /**
      * Gets a list of Operations Insights Warehouse users. Either compartmentId or id must be specified. All these resources are expected to be in root compartment.
@@ -1440,6 +1522,19 @@ public interface OperationsInsights extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/UpdateHostInsightExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateHostInsight API.
      */
     UpdateHostInsightResponse updateHostInsight(UpdateHostInsightRequest request);
+
+    /**
+     * Updates one or more attributes of the specified private endpoint.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/UpdateOperationsInsightsPrivateEndpointExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateOperationsInsightsPrivateEndpoint API.
+     */
+    UpdateOperationsInsightsPrivateEndpointResponse updateOperationsInsightsPrivateEndpoint(
+            UpdateOperationsInsightsPrivateEndpointRequest request);
 
     /**
      * Updates the configuration of an Operations Insights Warehouse.

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsAsync.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsAsync.java
@@ -136,6 +136,42 @@ public interface OperationsInsightsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Moves a private endpoint from one compartment to another. When provided, If-Match is checked against ETag values of the resource.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeOperationsInsightsPrivateEndpointCompartmentResponse>
+            changeOperationsInsightsPrivateEndpointCompartment(
+                    ChangeOperationsInsightsPrivateEndpointCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeOperationsInsightsPrivateEndpointCompartmentRequest,
+                                    ChangeOperationsInsightsPrivateEndpointCompartmentResponse>
+                            handler);
+
+    /**
+     * Change the connection details of a co-managed  database insight. When provided, If-Match is checked against ETag values of the resource.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangePeComanagedDatabaseInsightResponse>
+            changePeComanagedDatabaseInsight(
+                    ChangePeComanagedDatabaseInsightRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangePeComanagedDatabaseInsightRequest,
+                                    ChangePeComanagedDatabaseInsightResponse>
+                            handler);
+
+    /**
      * Create a AWR hub resource for the tenant in Operations Insights.
      * This resource will be created in root compartment.
      *
@@ -223,8 +259,29 @@ public interface OperationsInsightsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Create a private endpoint resource for the tenant in Operations Insights.
+     * This resource will be created in customer compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateOperationsInsightsPrivateEndpointResponse>
+            createOperationsInsightsPrivateEndpoint(
+                    CreateOperationsInsightsPrivateEndpointRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    CreateOperationsInsightsPrivateEndpointRequest,
+                                    CreateOperationsInsightsPrivateEndpointResponse>
+                            handler);
+
+    /**
      * Create a Operations Insights Warehouse resource for the tenant in Operations Insights. New ADW will be provisioned for this tenant.
-     * There is only expected to be 1 warehouse per tenant. The warehouse is expected to be in the root compartment.
+     * There is only expected to be 1 warehouse per tenant. The warehouse is expected to be in the root compartment. If the 'opsi-warehouse-type'
+     * header is passed to the API, a warehouse resource without ADW or Schema provisioning is created.
      *
      *
      * @param request The request object containing the details to send
@@ -342,6 +399,24 @@ public interface OperationsInsightsAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             DeleteHostInsightRequest, DeleteHostInsightResponse>
                     handler);
+
+    /**
+     * Deletes a private endpoint.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteOperationsInsightsPrivateEndpointResponse>
+            deleteOperationsInsightsPrivateEndpoint(
+                    DeleteOperationsInsightsPrivateEndpointRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    DeleteOperationsInsightsPrivateEndpointRequest,
+                                    DeleteOperationsInsightsPrivateEndpointResponse>
+                            handler);
 
     /**
      * Deletes an Operations Insights Warehouse. There is only expected to be 1 warehouse per tenant.
@@ -590,6 +665,24 @@ public interface OperationsInsightsAsync extends AutoCloseable {
             GetHostInsightRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetHostInsightRequest, GetHostInsightResponse>
                     handler);
+
+    /**
+     * Gets the details of the specified private endpoint.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetOperationsInsightsPrivateEndpointResponse>
+            getOperationsInsightsPrivateEndpoint(
+                    GetOperationsInsightsPrivateEndpointRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetOperationsInsightsPrivateEndpointRequest,
+                                    GetOperationsInsightsPrivateEndpointResponse>
+                            handler);
 
     /**
      * Gets details of an Operations Insights Warehouse.
@@ -973,6 +1066,24 @@ public interface OperationsInsightsAsync extends AutoCloseable {
                     com.oracle.bmc.responses.AsyncHandler<
                                     ListImportableEnterpriseManagerEntitiesRequest,
                                     ListImportableEnterpriseManagerEntitiesResponse>
+                            handler);
+
+    /**
+     * Gets a list of Operation Insights private endpoints.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListOperationsInsightsPrivateEndpointsResponse>
+            listOperationsInsightsPrivateEndpoints(
+                    ListOperationsInsightsPrivateEndpointsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListOperationsInsightsPrivateEndpointsRequest,
+                                    ListOperationsInsightsPrivateEndpointsResponse>
                             handler);
 
     /**
@@ -1835,6 +1946,24 @@ public interface OperationsInsightsAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             UpdateHostInsightRequest, UpdateHostInsightResponse>
                     handler);
+
+    /**
+     * Updates one or more attributes of the specified private endpoint.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateOperationsInsightsPrivateEndpointResponse>
+            updateOperationsInsightsPrivateEndpoint(
+                    UpdateOperationsInsightsPrivateEndpointRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateOperationsInsightsPrivateEndpointRequest,
+                                    UpdateOperationsInsightsPrivateEndpointResponse>
+                            handler);
 
     /**
      * Updates the configuration of an Operations Insights Warehouse.

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsAsyncClient.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsAsyncClient.java
@@ -634,6 +634,116 @@ public class OperationsInsightsAsyncClient implements OperationsInsightsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeOperationsInsightsPrivateEndpointCompartmentResponse>
+            changeOperationsInsightsPrivateEndpointCompartment(
+                    ChangeOperationsInsightsPrivateEndpointCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeOperationsInsightsPrivateEndpointCompartmentRequest,
+                                    ChangeOperationsInsightsPrivateEndpointCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeOperationsInsightsPrivateEndpointCompartment");
+        final ChangeOperationsInsightsPrivateEndpointCompartmentRequest interceptedRequest =
+                ChangeOperationsInsightsPrivateEndpointCompartmentConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeOperationsInsightsPrivateEndpointCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ChangeOperationsInsightsPrivateEndpointCompartmentResponse>
+                transformer =
+                        ChangeOperationsInsightsPrivateEndpointCompartmentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeOperationsInsightsPrivateEndpointCompartmentRequest,
+                        ChangeOperationsInsightsPrivateEndpointCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeOperationsInsightsPrivateEndpointCompartmentRequest,
+                                ChangeOperationsInsightsPrivateEndpointCompartmentResponse>,
+                        java.util.concurrent.Future<
+                                ChangeOperationsInsightsPrivateEndpointCompartmentResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest
+                                        .getChangeOperationsInsightsPrivateEndpointCompartmentDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeOperationsInsightsPrivateEndpointCompartmentRequest,
+                    ChangeOperationsInsightsPrivateEndpointCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ChangePeComanagedDatabaseInsightResponse>
+            changePeComanagedDatabaseInsight(
+                    ChangePeComanagedDatabaseInsightRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangePeComanagedDatabaseInsightRequest,
+                                    ChangePeComanagedDatabaseInsightResponse>
+                            handler) {
+        LOG.trace("Called async changePeComanagedDatabaseInsight");
+        final ChangePeComanagedDatabaseInsightRequest interceptedRequest =
+                ChangePeComanagedDatabaseInsightConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangePeComanagedDatabaseInsightConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangePeComanagedDatabaseInsightResponse>
+                transformer = ChangePeComanagedDatabaseInsightConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangePeComanagedDatabaseInsightRequest,
+                        ChangePeComanagedDatabaseInsightResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangePeComanagedDatabaseInsightRequest,
+                                ChangePeComanagedDatabaseInsightResponse>,
+                        java.util.concurrent.Future<ChangePeComanagedDatabaseInsightResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getChangePeComanagedDatabaseInsightDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangePeComanagedDatabaseInsightRequest,
+                    ChangePeComanagedDatabaseInsightResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateAwrHubResponse> createAwrHub(
             CreateAwrHubRequest request,
             final com.oracle.bmc.responses.AsyncHandler<CreateAwrHubRequest, CreateAwrHubResponse>
@@ -854,6 +964,61 @@ public class OperationsInsightsAsyncClient implements OperationsInsightsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     CreateHostInsightRequest, CreateHostInsightResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateOperationsInsightsPrivateEndpointResponse>
+            createOperationsInsightsPrivateEndpoint(
+                    CreateOperationsInsightsPrivateEndpointRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    CreateOperationsInsightsPrivateEndpointRequest,
+                                    CreateOperationsInsightsPrivateEndpointResponse>
+                            handler) {
+        LOG.trace("Called async createOperationsInsightsPrivateEndpoint");
+        final CreateOperationsInsightsPrivateEndpointRequest interceptedRequest =
+                CreateOperationsInsightsPrivateEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateOperationsInsightsPrivateEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateOperationsInsightsPrivateEndpointResponse>
+                transformer = CreateOperationsInsightsPrivateEndpointConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateOperationsInsightsPrivateEndpointRequest,
+                        CreateOperationsInsightsPrivateEndpointResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateOperationsInsightsPrivateEndpointRequest,
+                                CreateOperationsInsightsPrivateEndpointResponse>,
+                        java.util.concurrent.Future<
+                                CreateOperationsInsightsPrivateEndpointResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest
+                                        .getCreateOperationsInsightsPrivateEndpointDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateOperationsInsightsPrivateEndpointRequest,
+                    CreateOperationsInsightsPrivateEndpointResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1163,6 +1328,54 @@ public class OperationsInsightsAsyncClient implements OperationsInsightsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     DeleteHostInsightRequest, DeleteHostInsightResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteOperationsInsightsPrivateEndpointResponse>
+            deleteOperationsInsightsPrivateEndpoint(
+                    DeleteOperationsInsightsPrivateEndpointRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DeleteOperationsInsightsPrivateEndpointRequest,
+                                    DeleteOperationsInsightsPrivateEndpointResponse>
+                            handler) {
+        LOG.trace("Called async deleteOperationsInsightsPrivateEndpoint");
+        final DeleteOperationsInsightsPrivateEndpointRequest interceptedRequest =
+                DeleteOperationsInsightsPrivateEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteOperationsInsightsPrivateEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteOperationsInsightsPrivateEndpointResponse>
+                transformer = DeleteOperationsInsightsPrivateEndpointConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteOperationsInsightsPrivateEndpointRequest,
+                        DeleteOperationsInsightsPrivateEndpointResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteOperationsInsightsPrivateEndpointRequest,
+                                DeleteOperationsInsightsPrivateEndpointResponse>,
+                        java.util.concurrent.Future<
+                                DeleteOperationsInsightsPrivateEndpointResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteOperationsInsightsPrivateEndpointRequest,
+                    DeleteOperationsInsightsPrivateEndpointResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1820,6 +2033,53 @@ public class OperationsInsightsAsyncClient implements OperationsInsightsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetHostInsightRequest, GetHostInsightResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetOperationsInsightsPrivateEndpointResponse>
+            getOperationsInsightsPrivateEndpoint(
+                    GetOperationsInsightsPrivateEndpointRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetOperationsInsightsPrivateEndpointRequest,
+                                    GetOperationsInsightsPrivateEndpointResponse>
+                            handler) {
+        LOG.trace("Called async getOperationsInsightsPrivateEndpoint");
+        final GetOperationsInsightsPrivateEndpointRequest interceptedRequest =
+                GetOperationsInsightsPrivateEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetOperationsInsightsPrivateEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetOperationsInsightsPrivateEndpointResponse>
+                transformer = GetOperationsInsightsPrivateEndpointConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetOperationsInsightsPrivateEndpointRequest,
+                        GetOperationsInsightsPrivateEndpointResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetOperationsInsightsPrivateEndpointRequest,
+                                GetOperationsInsightsPrivateEndpointResponse>,
+                        java.util.concurrent.Future<GetOperationsInsightsPrivateEndpointResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetOperationsInsightsPrivateEndpointRequest,
+                    GetOperationsInsightsPrivateEndpointResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -2771,6 +3031,53 @@ public class OperationsInsightsAsyncClient implements OperationsInsightsAsync {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListImportableEnterpriseManagerEntitiesRequest,
                     ListImportableEnterpriseManagerEntitiesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListOperationsInsightsPrivateEndpointsResponse>
+            listOperationsInsightsPrivateEndpoints(
+                    ListOperationsInsightsPrivateEndpointsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListOperationsInsightsPrivateEndpointsRequest,
+                                    ListOperationsInsightsPrivateEndpointsResponse>
+                            handler) {
+        LOG.trace("Called async listOperationsInsightsPrivateEndpoints");
+        final ListOperationsInsightsPrivateEndpointsRequest interceptedRequest =
+                ListOperationsInsightsPrivateEndpointsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListOperationsInsightsPrivateEndpointsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListOperationsInsightsPrivateEndpointsResponse>
+                transformer = ListOperationsInsightsPrivateEndpointsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListOperationsInsightsPrivateEndpointsRequest,
+                        ListOperationsInsightsPrivateEndpointsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListOperationsInsightsPrivateEndpointsRequest,
+                                ListOperationsInsightsPrivateEndpointsResponse>,
+                        java.util.concurrent.Future<ListOperationsInsightsPrivateEndpointsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListOperationsInsightsPrivateEndpointsRequest,
+                    ListOperationsInsightsPrivateEndpointsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -4807,6 +5114,60 @@ public class OperationsInsightsAsyncClient implements OperationsInsightsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     UpdateHostInsightRequest, UpdateHostInsightResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateOperationsInsightsPrivateEndpointResponse>
+            updateOperationsInsightsPrivateEndpoint(
+                    UpdateOperationsInsightsPrivateEndpointRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateOperationsInsightsPrivateEndpointRequest,
+                                    UpdateOperationsInsightsPrivateEndpointResponse>
+                            handler) {
+        LOG.trace("Called async updateOperationsInsightsPrivateEndpoint");
+        final UpdateOperationsInsightsPrivateEndpointRequest interceptedRequest =
+                UpdateOperationsInsightsPrivateEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateOperationsInsightsPrivateEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateOperationsInsightsPrivateEndpointResponse>
+                transformer = UpdateOperationsInsightsPrivateEndpointConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateOperationsInsightsPrivateEndpointRequest,
+                        UpdateOperationsInsightsPrivateEndpointResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateOperationsInsightsPrivateEndpointRequest,
+                                UpdateOperationsInsightsPrivateEndpointResponse>,
+                        java.util.concurrent.Future<
+                                UpdateOperationsInsightsPrivateEndpointResponse>>
+                futureSupplier =
+                        client.putFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest
+                                        .getUpdateOperationsInsightsPrivateEndpointDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateOperationsInsightsPrivateEndpointRequest,
+                    UpdateOperationsInsightsPrivateEndpointResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsClient.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsClient.java
@@ -646,6 +646,85 @@ public class OperationsInsightsClient implements OperationsInsights {
     }
 
     @Override
+    public ChangeOperationsInsightsPrivateEndpointCompartmentResponse
+            changeOperationsInsightsPrivateEndpointCompartment(
+                    ChangeOperationsInsightsPrivateEndpointCompartmentRequest request) {
+        LOG.trace("Called changeOperationsInsightsPrivateEndpointCompartment");
+        final ChangeOperationsInsightsPrivateEndpointCompartmentRequest interceptedRequest =
+                ChangeOperationsInsightsPrivateEndpointCompartmentConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeOperationsInsightsPrivateEndpointCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ChangeOperationsInsightsPrivateEndpointCompartmentResponse>
+                transformer =
+                        ChangeOperationsInsightsPrivateEndpointCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeOperationsInsightsPrivateEndpointCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ChangePeComanagedDatabaseInsightResponse changePeComanagedDatabaseInsight(
+            ChangePeComanagedDatabaseInsightRequest request) {
+        LOG.trace("Called changePeComanagedDatabaseInsight");
+        final ChangePeComanagedDatabaseInsightRequest interceptedRequest =
+                ChangePeComanagedDatabaseInsightConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangePeComanagedDatabaseInsightConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangePeComanagedDatabaseInsightResponse>
+                transformer = ChangePeComanagedDatabaseInsightConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangePeComanagedDatabaseInsightDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateAwrHubResponse createAwrHub(CreateAwrHubRequest request) {
         LOG.trace("Called createAwrHub");
         final CreateAwrHubRequest interceptedRequest =
@@ -813,6 +892,44 @@ public class OperationsInsightsClient implements OperationsInsights {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getCreateHostInsightDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateOperationsInsightsPrivateEndpointResponse createOperationsInsightsPrivateEndpoint(
+            CreateOperationsInsightsPrivateEndpointRequest request) {
+        LOG.trace("Called createOperationsInsightsPrivateEndpoint");
+        final CreateOperationsInsightsPrivateEndpointRequest interceptedRequest =
+                CreateOperationsInsightsPrivateEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateOperationsInsightsPrivateEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateOperationsInsightsPrivateEndpointResponse>
+                transformer = CreateOperationsInsightsPrivateEndpointConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getCreateOperationsInsightsPrivateEndpointDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -1026,6 +1143,39 @@ public class OperationsInsightsClient implements OperationsInsights {
                 DeleteHostInsightConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, DeleteHostInsightResponse>
                 transformer = DeleteHostInsightConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteOperationsInsightsPrivateEndpointResponse deleteOperationsInsightsPrivateEndpoint(
+            DeleteOperationsInsightsPrivateEndpointRequest request) {
+        LOG.trace("Called deleteOperationsInsightsPrivateEndpoint");
+        final DeleteOperationsInsightsPrivateEndpointRequest interceptedRequest =
+                DeleteOperationsInsightsPrivateEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteOperationsInsightsPrivateEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteOperationsInsightsPrivateEndpointResponse>
+                transformer = DeleteOperationsInsightsPrivateEndpointConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1515,6 +1665,38 @@ public class OperationsInsightsClient implements OperationsInsights {
                 GetHostInsightConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetHostInsightResponse>
                 transformer = GetHostInsightConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetOperationsInsightsPrivateEndpointResponse getOperationsInsightsPrivateEndpoint(
+            GetOperationsInsightsPrivateEndpointRequest request) {
+        LOG.trace("Called getOperationsInsightsPrivateEndpoint");
+        final GetOperationsInsightsPrivateEndpointRequest interceptedRequest =
+                GetOperationsInsightsPrivateEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetOperationsInsightsPrivateEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetOperationsInsightsPrivateEndpointResponse>
+                transformer = GetOperationsInsightsPrivateEndpointConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -2208,6 +2390,38 @@ public class OperationsInsightsClient implements OperationsInsights {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, ListImportableEnterpriseManagerEntitiesResponse>
                 transformer = ListImportableEnterpriseManagerEntitiesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListOperationsInsightsPrivateEndpointsResponse listOperationsInsightsPrivateEndpoints(
+            ListOperationsInsightsPrivateEndpointsRequest request) {
+        LOG.trace("Called listOperationsInsightsPrivateEndpoints");
+        final ListOperationsInsightsPrivateEndpointsRequest interceptedRequest =
+                ListOperationsInsightsPrivateEndpointsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListOperationsInsightsPrivateEndpointsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListOperationsInsightsPrivateEndpointsResponse>
+                transformer = ListOperationsInsightsPrivateEndpointsConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -3658,6 +3872,43 @@ public class OperationsInsightsClient implements OperationsInsights {
                                         client.put(
                                                 ib,
                                                 retriedRequest.getUpdateHostInsightDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateOperationsInsightsPrivateEndpointResponse updateOperationsInsightsPrivateEndpoint(
+            UpdateOperationsInsightsPrivateEndpointRequest request) {
+        LOG.trace("Called updateOperationsInsightsPrivateEndpoint");
+        final UpdateOperationsInsightsPrivateEndpointRequest interceptedRequest =
+                UpdateOperationsInsightsPrivateEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateOperationsInsightsPrivateEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateOperationsInsightsPrivateEndpointResponse>
+                transformer = UpdateOperationsInsightsPrivateEndpointConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest
+                                                        .getUpdateOperationsInsightsPrivateEndpointDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsPaginators.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsPaginators.java
@@ -1424,6 +1424,138 @@ public class OperationsInsightsPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listOperationsInsightsPrivateEndpoints operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListOperationsInsightsPrivateEndpointsResponse>
+            listOperationsInsightsPrivateEndpointsResponseIterator(
+                    final ListOperationsInsightsPrivateEndpointsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListOperationsInsightsPrivateEndpointsRequest.Builder,
+                ListOperationsInsightsPrivateEndpointsRequest,
+                ListOperationsInsightsPrivateEndpointsResponse>(
+                new com.google.common.base.Supplier<
+                        ListOperationsInsightsPrivateEndpointsRequest.Builder>() {
+                    @Override
+                    public ListOperationsInsightsPrivateEndpointsRequest.Builder get() {
+                        return ListOperationsInsightsPrivateEndpointsRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListOperationsInsightsPrivateEndpointsResponse, String>() {
+                    @Override
+                    public String apply(ListOperationsInsightsPrivateEndpointsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListOperationsInsightsPrivateEndpointsRequest.Builder>,
+                        ListOperationsInsightsPrivateEndpointsRequest>() {
+                    @Override
+                    public ListOperationsInsightsPrivateEndpointsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListOperationsInsightsPrivateEndpointsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListOperationsInsightsPrivateEndpointsRequest,
+                        ListOperationsInsightsPrivateEndpointsResponse>() {
+                    @Override
+                    public ListOperationsInsightsPrivateEndpointsResponse apply(
+                            ListOperationsInsightsPrivateEndpointsRequest request) {
+                        return client.listOperationsInsightsPrivateEndpoints(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointSummary} objects
+     * contained in responses from the listOperationsInsightsPrivateEndpoints operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointSummary>
+            listOperationsInsightsPrivateEndpointsRecordIterator(
+                    final ListOperationsInsightsPrivateEndpointsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListOperationsInsightsPrivateEndpointsRequest.Builder,
+                ListOperationsInsightsPrivateEndpointsRequest,
+                ListOperationsInsightsPrivateEndpointsResponse,
+                com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointSummary>(
+                new com.google.common.base.Supplier<
+                        ListOperationsInsightsPrivateEndpointsRequest.Builder>() {
+                    @Override
+                    public ListOperationsInsightsPrivateEndpointsRequest.Builder get() {
+                        return ListOperationsInsightsPrivateEndpointsRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListOperationsInsightsPrivateEndpointsResponse, String>() {
+                    @Override
+                    public String apply(ListOperationsInsightsPrivateEndpointsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListOperationsInsightsPrivateEndpointsRequest.Builder>,
+                        ListOperationsInsightsPrivateEndpointsRequest>() {
+                    @Override
+                    public ListOperationsInsightsPrivateEndpointsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListOperationsInsightsPrivateEndpointsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListOperationsInsightsPrivateEndpointsRequest,
+                        ListOperationsInsightsPrivateEndpointsResponse>() {
+                    @Override
+                    public ListOperationsInsightsPrivateEndpointsResponse apply(
+                            ListOperationsInsightsPrivateEndpointsRequest request) {
+                        return client.listOperationsInsightsPrivateEndpoints(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListOperationsInsightsPrivateEndpointsResponse,
+                        java.util.List<
+                                com.oracle.bmc.opsi.model
+                                        .OperationsInsightsPrivateEndpointSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.opsi.model
+                                            .OperationsInsightsPrivateEndpointSummary>
+                            apply(ListOperationsInsightsPrivateEndpointsResponse response) {
+                        return response.getOperationsInsightsPrivateEndpointCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listOperationsInsightsWarehouseUsers operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsWaiters.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsWaiters.java
@@ -532,6 +532,127 @@ public class OperationsInsightsWaiters {
      * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
+                    GetOperationsInsightsPrivateEndpointRequest,
+                    GetOperationsInsightsPrivateEndpointResponse>
+            forOperationsInsightsPrivateEndpoint(
+                    GetOperationsInsightsPrivateEndpointRequest request,
+                    com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointLifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forOperationsInsightsPrivateEndpoint(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetOperationsInsightsPrivateEndpointRequest,
+                    GetOperationsInsightsPrivateEndpointResponse>
+            forOperationsInsightsPrivateEndpoint(
+                    GetOperationsInsightsPrivateEndpointRequest request,
+                    com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointLifecycleState
+                            targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forOperationsInsightsPrivateEndpoint(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetOperationsInsightsPrivateEndpointRequest,
+                    GetOperationsInsightsPrivateEndpointResponse>
+            forOperationsInsightsPrivateEndpoint(
+                    GetOperationsInsightsPrivateEndpointRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointLifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forOperationsInsightsPrivateEndpoint(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for OperationsInsightsPrivateEndpoint.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetOperationsInsightsPrivateEndpointRequest,
+                    GetOperationsInsightsPrivateEndpointResponse>
+            forOperationsInsightsPrivateEndpoint(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetOperationsInsightsPrivateEndpointRequest request,
+                    final com.oracle.bmc.opsi.model
+                                    .OperationsInsightsPrivateEndpointLifecycleState...
+                            targetStates) {
+        final java.util.Set<
+                        com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointLifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetOperationsInsightsPrivateEndpointRequest,
+                                GetOperationsInsightsPrivateEndpointResponse>() {
+                            @Override
+                            public GetOperationsInsightsPrivateEndpointResponse apply(
+                                    GetOperationsInsightsPrivateEndpointRequest request) {
+                                return client.getOperationsInsightsPrivateEndpoint(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<
+                                GetOperationsInsightsPrivateEndpointResponse>() {
+                            @Override
+                            public boolean apply(
+                                    GetOperationsInsightsPrivateEndpointResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getOperationsInsightsPrivateEndpoint()
+                                                .getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.opsi.model
+                                        .OperationsInsightsPrivateEndpointLifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
                     GetOperationsInsightsWarehouseRequest, GetOperationsInsightsWarehouseResponse>
             forOperationsInsightsWarehouse(
                     GetOperationsInsightsWarehouseRequest request,

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/ChangeOperationsInsightsPrivateEndpointCompartmentConverter.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/ChangeOperationsInsightsPrivateEndpointCompartmentConverter.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.opsi.model.*;
+import com.oracle.bmc.opsi.requests.*;
+import com.oracle.bmc.opsi.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class ChangeOperationsInsightsPrivateEndpointCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.opsi.requests
+                    .ChangeOperationsInsightsPrivateEndpointCompartmentRequest
+            interceptRequest(
+                    com.oracle.bmc.opsi.requests
+                                    .ChangeOperationsInsightsPrivateEndpointCompartmentRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.opsi.requests.ChangeOperationsInsightsPrivateEndpointCompartmentRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getOperationsInsightsPrivateEndpointId(),
+                "operationsInsightsPrivateEndpointId must not be blank");
+        Validate.notNull(
+                request.getChangeOperationsInsightsPrivateEndpointCompartmentDetails(),
+                "changeOperationsInsightsPrivateEndpointCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200630")
+                        .path("operationsInsightsPrivateEndpoints")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOperationsInsightsPrivateEndpointId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.opsi.responses
+                            .ChangeOperationsInsightsPrivateEndpointCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.opsi.responses
+                                .ChangeOperationsInsightsPrivateEndpointCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.opsi.responses
+                                        .ChangeOperationsInsightsPrivateEndpointCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.opsi.responses
+                                            .ChangeOperationsInsightsPrivateEndpointCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.opsi.responses.ChangeOperationsInsightsPrivateEndpointCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.opsi.responses
+                                                .ChangeOperationsInsightsPrivateEndpointCompartmentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.opsi.responses
+                                                        .ChangeOperationsInsightsPrivateEndpointCompartmentResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.opsi.responses
+                                                .ChangeOperationsInsightsPrivateEndpointCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/ChangePeComanagedDatabaseInsightConverter.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/ChangePeComanagedDatabaseInsightConverter.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.opsi.model.*;
+import com.oracle.bmc.opsi.requests.*;
+import com.oracle.bmc.opsi.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class ChangePeComanagedDatabaseInsightConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.opsi.requests.ChangePeComanagedDatabaseInsightRequest
+            interceptRequest(
+                    com.oracle.bmc.opsi.requests.ChangePeComanagedDatabaseInsightRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.opsi.requests.ChangePeComanagedDatabaseInsightRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDatabaseInsightId(), "databaseInsightId must not be blank");
+        Validate.notNull(
+                request.getChangePeComanagedDatabaseInsightDetails(),
+                "changePeComanagedDatabaseInsightDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200630")
+                        .path("databaseInsights")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDatabaseInsightId()))
+                        .path("actions")
+                        .path("changePeComanagedDatabaseInsightDetails");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.opsi.responses.ChangePeComanagedDatabaseInsightResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.opsi.responses.ChangePeComanagedDatabaseInsightResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.opsi.responses
+                                        .ChangePeComanagedDatabaseInsightResponse>() {
+                            @Override
+                            public com.oracle.bmc.opsi.responses
+                                            .ChangePeComanagedDatabaseInsightResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.opsi.responses.ChangePeComanagedDatabaseInsightResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.opsi.responses
+                                                .ChangePeComanagedDatabaseInsightResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.opsi.responses
+                                                        .ChangePeComanagedDatabaseInsightResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.opsi.responses
+                                                .ChangePeComanagedDatabaseInsightResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/CreateOperationsInsightsPrivateEndpointConverter.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/CreateOperationsInsightsPrivateEndpointConverter.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.opsi.model.*;
+import com.oracle.bmc.opsi.requests.*;
+import com.oracle.bmc.opsi.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class CreateOperationsInsightsPrivateEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.opsi.requests.CreateOperationsInsightsPrivateEndpointRequest
+            interceptRequest(
+                    com.oracle.bmc.opsi.requests.CreateOperationsInsightsPrivateEndpointRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.opsi.requests.CreateOperationsInsightsPrivateEndpointRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateOperationsInsightsPrivateEndpointDetails(),
+                "createOperationsInsightsPrivateEndpointDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20200630").path("operationsInsightsPrivateEndpoints");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.opsi.responses.CreateOperationsInsightsPrivateEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.opsi.responses
+                                .CreateOperationsInsightsPrivateEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.opsi.responses
+                                        .CreateOperationsInsightsPrivateEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.opsi.responses
+                                            .CreateOperationsInsightsPrivateEndpointResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.opsi.responses.CreateOperationsInsightsPrivateEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.opsi.model
+                                                                .OperationsInsightsPrivateEndpoint>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.opsi.model
+                                                                        .OperationsInsightsPrivateEndpoint
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.opsi.model
+                                                        .OperationsInsightsPrivateEndpoint>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.opsi.responses
+                                                .CreateOperationsInsightsPrivateEndpointResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.opsi.responses
+                                                        .CreateOperationsInsightsPrivateEndpointResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.operationsInsightsPrivateEndpoint(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        contentLocationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "content-location");
+                                if (contentLocationHeader.isPresent()) {
+                                    builder.contentLocation(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "content-location",
+                                                    contentLocationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.oracle.bmc.opsi.responses
+                                                .CreateOperationsInsightsPrivateEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/DeleteOperationsInsightsPrivateEndpointConverter.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/DeleteOperationsInsightsPrivateEndpointConverter.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.opsi.model.*;
+import com.oracle.bmc.opsi.requests.*;
+import com.oracle.bmc.opsi.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class DeleteOperationsInsightsPrivateEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.opsi.requests.DeleteOperationsInsightsPrivateEndpointRequest
+            interceptRequest(
+                    com.oracle.bmc.opsi.requests.DeleteOperationsInsightsPrivateEndpointRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.opsi.requests.DeleteOperationsInsightsPrivateEndpointRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getOperationsInsightsPrivateEndpointId(),
+                "operationsInsightsPrivateEndpointId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200630")
+                        .path("operationsInsightsPrivateEndpoints")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOperationsInsightsPrivateEndpointId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.opsi.responses.DeleteOperationsInsightsPrivateEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.opsi.responses
+                                .DeleteOperationsInsightsPrivateEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.opsi.responses
+                                        .DeleteOperationsInsightsPrivateEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.opsi.responses
+                                            .DeleteOperationsInsightsPrivateEndpointResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.opsi.responses.DeleteOperationsInsightsPrivateEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.opsi.responses
+                                                .DeleteOperationsInsightsPrivateEndpointResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.opsi.responses
+                                                        .DeleteOperationsInsightsPrivateEndpointResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.opsi.responses
+                                                .DeleteOperationsInsightsPrivateEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/GetOperationsInsightsPrivateEndpointConverter.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/GetOperationsInsightsPrivateEndpointConverter.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.opsi.model.*;
+import com.oracle.bmc.opsi.requests.*;
+import com.oracle.bmc.opsi.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class GetOperationsInsightsPrivateEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.opsi.requests.GetOperationsInsightsPrivateEndpointRequest
+            interceptRequest(
+                    com.oracle.bmc.opsi.requests.GetOperationsInsightsPrivateEndpointRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.opsi.requests.GetOperationsInsightsPrivateEndpointRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getOperationsInsightsPrivateEndpointId(),
+                "operationsInsightsPrivateEndpointId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200630")
+                        .path("operationsInsightsPrivateEndpoints")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOperationsInsightsPrivateEndpointId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.opsi.responses.GetOperationsInsightsPrivateEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.opsi.responses.GetOperationsInsightsPrivateEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.opsi.responses
+                                        .GetOperationsInsightsPrivateEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.opsi.responses
+                                            .GetOperationsInsightsPrivateEndpointResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.opsi.responses.GetOperationsInsightsPrivateEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.opsi.model
+                                                                .OperationsInsightsPrivateEndpoint>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.opsi.model
+                                                                        .OperationsInsightsPrivateEndpoint
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.opsi.model
+                                                        .OperationsInsightsPrivateEndpoint>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.opsi.responses
+                                                .GetOperationsInsightsPrivateEndpointResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.opsi.responses
+                                                        .GetOperationsInsightsPrivateEndpointResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.operationsInsightsPrivateEndpoint(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.opsi.responses
+                                                .GetOperationsInsightsPrivateEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/ListDatabaseInsightsConverter.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/ListDatabaseInsightsConverter.java
@@ -149,6 +149,14 @@ public class ListDatabaseInsightsConverter {
                                     request.getCompartmentIdInSubtree()));
         }
 
+        if (request.getOpsiPrivateEndpointId() != null) {
+            target =
+                    target.queryParam(
+                            "opsiPrivateEndpointId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getOpsiPrivateEndpointId()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/ListOperationsInsightsPrivateEndpointsConverter.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/ListOperationsInsightsPrivateEndpointsConverter.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.opsi.model.*;
+import com.oracle.bmc.opsi.requests.*;
+import com.oracle.bmc.opsi.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class ListOperationsInsightsPrivateEndpointsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.opsi.requests.ListOperationsInsightsPrivateEndpointsRequest
+            interceptRequest(
+                    com.oracle.bmc.opsi.requests.ListOperationsInsightsPrivateEndpointsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.opsi.requests.ListOperationsInsightsPrivateEndpointsRequest request) {
+        Validate.notNull(request, "request instance is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20200630").path("operationsInsightsPrivateEndpoints");
+
+        if (request.getCompartmentId() != null) {
+            target =
+                    target.queryParam(
+                            "compartmentId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCompartmentId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getOpsiPrivateEndpointId() != null) {
+            target =
+                    target.queryParam(
+                            "opsiPrivateEndpointId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getOpsiPrivateEndpointId()));
+        }
+
+        if (request.getIsUsedForRacDbs() != null) {
+            target =
+                    target.queryParam(
+                            "isUsedForRacDbs",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsUsedForRacDbs()));
+        }
+
+        if (request.getVcnId() != null) {
+            target =
+                    target.queryParam(
+                            "vcnId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getVcnId()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "lifecycleState",
+                            request.getLifecycleState(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getCompartmentIdInSubtree() != null) {
+            target =
+                    target.queryParam(
+                            "compartmentIdInSubtree",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCompartmentIdInSubtree()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.opsi.responses.ListOperationsInsightsPrivateEndpointsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.opsi.responses
+                                .ListOperationsInsightsPrivateEndpointsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.opsi.responses
+                                        .ListOperationsInsightsPrivateEndpointsResponse>() {
+                            @Override
+                            public com.oracle.bmc.opsi.responses
+                                            .ListOperationsInsightsPrivateEndpointsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.opsi.responses.ListOperationsInsightsPrivateEndpointsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.opsi.model
+                                                                .OperationsInsightsPrivateEndpointCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.opsi.model
+                                                                        .OperationsInsightsPrivateEndpointCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.opsi.model
+                                                        .OperationsInsightsPrivateEndpointCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.opsi.responses
+                                                .ListOperationsInsightsPrivateEndpointsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.opsi.responses
+                                                        .ListOperationsInsightsPrivateEndpointsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.operationsInsightsPrivateEndpointCollection(
+                                        response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.opsi.responses
+                                                .ListOperationsInsightsPrivateEndpointsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/UpdateOperationsInsightsPrivateEndpointConverter.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/UpdateOperationsInsightsPrivateEndpointConverter.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.opsi.model.*;
+import com.oracle.bmc.opsi.requests.*;
+import com.oracle.bmc.opsi.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class UpdateOperationsInsightsPrivateEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.opsi.requests.UpdateOperationsInsightsPrivateEndpointRequest
+            interceptRequest(
+                    com.oracle.bmc.opsi.requests.UpdateOperationsInsightsPrivateEndpointRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.opsi.requests.UpdateOperationsInsightsPrivateEndpointRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getOperationsInsightsPrivateEndpointId(),
+                "operationsInsightsPrivateEndpointId must not be blank");
+        Validate.notNull(
+                request.getUpdateOperationsInsightsPrivateEndpointDetails(),
+                "updateOperationsInsightsPrivateEndpointDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200630")
+                        .path("operationsInsightsPrivateEndpoints")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOperationsInsightsPrivateEndpointId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.opsi.responses.UpdateOperationsInsightsPrivateEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.opsi.responses
+                                .UpdateOperationsInsightsPrivateEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.opsi.responses
+                                        .UpdateOperationsInsightsPrivateEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.opsi.responses
+                                            .UpdateOperationsInsightsPrivateEndpointResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.opsi.responses.UpdateOperationsInsightsPrivateEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.opsi.responses
+                                                .UpdateOperationsInsightsPrivateEndpointResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.opsi.responses
+                                                        .UpdateOperationsInsightsPrivateEndpointResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.opsi.responses
+                                                .UpdateOperationsInsightsPrivateEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/AutonomousDatabaseInsight.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/AutonomousDatabaseInsight.java
@@ -150,6 +150,15 @@ public class AutonomousDatabaseInsight extends DatabaseInsight {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+        private String databaseConnectionStatusDetails;
+
+        public Builder databaseConnectionStatusDetails(String databaseConnectionStatusDetails) {
+            this.databaseConnectionStatusDetails = databaseConnectionStatusDetails;
+            this.__explicitlySet__.add("databaseConnectionStatusDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
         private String databaseId;
 
@@ -214,6 +223,7 @@ public class AutonomousDatabaseInsight extends DatabaseInsight {
                             timeUpdated,
                             lifecycleState,
                             lifecycleDetails,
+                            databaseConnectionStatusDetails,
                             databaseId,
                             databaseName,
                             databaseDisplayName,
@@ -239,6 +249,7 @@ public class AutonomousDatabaseInsight extends DatabaseInsight {
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
+                            .databaseConnectionStatusDetails(o.getDatabaseConnectionStatusDetails())
                             .databaseId(o.getDatabaseId())
                             .databaseName(o.getDatabaseName())
                             .databaseDisplayName(o.getDatabaseDisplayName())
@@ -272,6 +283,7 @@ public class AutonomousDatabaseInsight extends DatabaseInsight {
             java.util.Date timeUpdated,
             LifecycleState lifecycleState,
             String lifecycleDetails,
+            String databaseConnectionStatusDetails,
             String databaseId,
             String databaseName,
             String databaseDisplayName,
@@ -290,7 +302,8 @@ public class AutonomousDatabaseInsight extends DatabaseInsight {
                 timeCreated,
                 timeUpdated,
                 lifecycleState,
-                lifecycleDetails);
+                lifecycleDetails,
+                databaseConnectionStatusDetails);
         this.databaseId = databaseId;
         this.databaseName = databaseName;
         this.databaseDisplayName = databaseDisplayName;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/AutonomousDatabaseInsightSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/AutonomousDatabaseInsightSummary.java
@@ -186,6 +186,15 @@ public class AutonomousDatabaseInsightSummary extends DatabaseInsightSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+        private String databaseConnectionStatusDetails;
+
+        public Builder databaseConnectionStatusDetails(String databaseConnectionStatusDetails) {
+            this.databaseConnectionStatusDetails = databaseConnectionStatusDetails;
+            this.__explicitlySet__.add("databaseConnectionStatusDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseResourceType")
         private String databaseResourceType;
 
@@ -218,6 +227,7 @@ public class AutonomousDatabaseInsightSummary extends DatabaseInsightSummary {
                             timeUpdated,
                             lifecycleState,
                             lifecycleDetails,
+                            databaseConnectionStatusDetails,
                             databaseResourceType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -243,6 +253,7 @@ public class AutonomousDatabaseInsightSummary extends DatabaseInsightSummary {
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
+                            .databaseConnectionStatusDetails(o.getDatabaseConnectionStatusDetails())
                             .databaseResourceType(o.getDatabaseResourceType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -276,6 +287,7 @@ public class AutonomousDatabaseInsightSummary extends DatabaseInsightSummary {
             java.util.Date timeUpdated,
             LifecycleState lifecycleState,
             String lifecycleDetails,
+            String databaseConnectionStatusDetails,
             String databaseResourceType) {
         super(
                 id,
@@ -294,7 +306,8 @@ public class AutonomousDatabaseInsightSummary extends DatabaseInsightSummary {
                 timeCreated,
                 timeUpdated,
                 lifecycleState,
-                lifecycleDetails);
+                lifecycleDetails,
+                databaseConnectionStatusDetails);
         this.databaseResourceType = databaseResourceType;
     }
 

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/ChangeOperationsInsightsPrivateEndpointCompartmentDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/ChangeOperationsInsightsPrivateEndpointCompartmentDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * The details used to change the compartment of a Operation Insights private endpoint.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeOperationsInsightsPrivateEndpointCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeOperationsInsightsPrivateEndpointCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeOperationsInsightsPrivateEndpointCompartmentDetails build() {
+            ChangeOperationsInsightsPrivateEndpointCompartmentDetails __instance__ =
+                    new ChangeOperationsInsightsPrivateEndpointCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeOperationsInsightsPrivateEndpointCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The new compartment [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the Private service accessed database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/ChangePeComanagedDatabaseInsightDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/ChangePeComanagedDatabaseInsightDetails.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Details of a Private Endpoint co-managed database insight.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangePeComanagedDatabaseInsightDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangePeComanagedDatabaseInsightDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("serviceName")
+        private String serviceName;
+
+        public Builder serviceName(String serviceName) {
+            this.serviceName = serviceName;
+            this.__explicitlySet__.add("serviceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("credentialDetails")
+        private CredentialDetails credentialDetails;
+
+        public Builder credentialDetails(CredentialDetails credentialDetails) {
+            this.credentialDetails = credentialDetails;
+            this.__explicitlySet__.add("credentialDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+        private String opsiPrivateEndpointId;
+
+        public Builder opsiPrivateEndpointId(String opsiPrivateEndpointId) {
+            this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+            this.__explicitlySet__.add("opsiPrivateEndpointId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangePeComanagedDatabaseInsightDetails build() {
+            ChangePeComanagedDatabaseInsightDetails __instance__ =
+                    new ChangePeComanagedDatabaseInsightDetails(
+                            serviceName, credentialDetails, opsiPrivateEndpointId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangePeComanagedDatabaseInsightDetails o) {
+            Builder copiedBuilder =
+                    serviceName(o.getServiceName())
+                            .credentialDetails(o.getCredentialDetails())
+                            .opsiPrivateEndpointId(o.getOpsiPrivateEndpointId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Database service name used for connection requests.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("serviceName")
+    String serviceName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("credentialDetails")
+    CredentialDetails credentialDetails;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the OPSI private endpoint
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+    String opsiPrivateEndpointId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/ConnectionDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/ConnectionDetails.java
@@ -156,7 +156,7 @@ public class ConnectionDetails {
     Integer port;
 
     /**
-     * Service name used for connection requests.
+     * Database service name used for connection requests.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceName")
     String serviceName;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CreateDatabaseInsightDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CreateDatabaseInsightDetails.java
@@ -31,6 +31,10 @@ package com.oracle.bmc.opsi.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateEmManagedExternalDatabaseInsightDetails.class,
         name = "EM_MANAGED_EXTERNAL_DATABASE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreatePeComanagedDatabaseInsightDetails.class,
+        name = "PE_COMANAGED_DATABASE"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CreateOperationsInsightsPrivateEndpointDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CreateOperationsInsightsPrivateEndpointDetails.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * The details used to create a new Operation Insights private endpoint.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateOperationsInsightsPrivateEndpointDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateOperationsInsightsPrivateEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+        private String vcnId;
+
+        public Builder vcnId(String vcnId) {
+            this.vcnId = vcnId;
+            this.__explicitlySet__.add("vcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isUsedForRacDbs")
+        private Boolean isUsedForRacDbs;
+
+        public Builder isUsedForRacDbs(Boolean isUsedForRacDbs) {
+            this.isUsedForRacDbs = isUsedForRacDbs;
+            this.__explicitlySet__.add("isUsedForRacDbs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateOperationsInsightsPrivateEndpointDetails build() {
+            CreateOperationsInsightsPrivateEndpointDetails __instance__ =
+                    new CreateOperationsInsightsPrivateEndpointDetails(
+                            displayName,
+                            compartmentId,
+                            vcnId,
+                            subnetId,
+                            isUsedForRacDbs,
+                            description,
+                            nsgIds,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateOperationsInsightsPrivateEndpointDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .vcnId(o.getVcnId())
+                            .subnetId(o.getSubnetId())
+                            .isUsedForRacDbs(o.getIsUsedForRacDbs())
+                            .description(o.getDescription())
+                            .nsgIds(o.getNsgIds())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The display name for the private endpoint. It is changeable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The compartment [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the Private service accessed database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The VCN [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the Private service accessed database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+    String vcnId;
+
+    /**
+     * The Subnet [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the Private service accessed database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * The flag to identify if private endpoint is used for rac database or not
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isUsedForRacDbs")
+    Boolean isUsedForRacDbs;
+
+    /**
+     * The description of the private endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security groups that the private endpoint belongs to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CreatePeComanagedDatabaseInsightDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CreatePeComanagedDatabaseInsightDetails.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * The information about database to be analyzed.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreatePeComanagedDatabaseInsightDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "entitySource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreatePeComanagedDatabaseInsightDetails extends CreateDatabaseInsightDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
+        private String databaseId;
+
+        public Builder databaseId(String databaseId) {
+            this.databaseId = databaseId;
+            this.__explicitlySet__.add("databaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseResourceType")
+        private String databaseResourceType;
+
+        public Builder databaseResourceType(String databaseResourceType) {
+            this.databaseResourceType = databaseResourceType;
+            this.__explicitlySet__.add("databaseResourceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+        private String opsiPrivateEndpointId;
+
+        public Builder opsiPrivateEndpointId(String opsiPrivateEndpointId) {
+            this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+            this.__explicitlySet__.add("opsiPrivateEndpointId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("serviceName")
+        private String serviceName;
+
+        public Builder serviceName(String serviceName) {
+            this.serviceName = serviceName;
+            this.__explicitlySet__.add("serviceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("credentialDetails")
+        private CredentialDetails credentialDetails;
+
+        public Builder credentialDetails(CredentialDetails credentialDetails) {
+            this.credentialDetails = credentialDetails;
+            this.__explicitlySet__.add("credentialDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentType")
+        private DeploymentType deploymentType;
+
+        public Builder deploymentType(DeploymentType deploymentType) {
+            this.deploymentType = deploymentType;
+            this.__explicitlySet__.add("deploymentType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreatePeComanagedDatabaseInsightDetails build() {
+            CreatePeComanagedDatabaseInsightDetails __instance__ =
+                    new CreatePeComanagedDatabaseInsightDetails(
+                            compartmentId,
+                            freeformTags,
+                            definedTags,
+                            databaseId,
+                            databaseResourceType,
+                            opsiPrivateEndpointId,
+                            serviceName,
+                            credentialDetails,
+                            deploymentType,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreatePeComanagedDatabaseInsightDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .databaseId(o.getDatabaseId())
+                            .databaseResourceType(o.getDatabaseResourceType())
+                            .opsiPrivateEndpointId(o.getOpsiPrivateEndpointId())
+                            .serviceName(o.getServiceName())
+                            .credentialDetails(o.getCredentialDetails())
+                            .deploymentType(o.getDeploymentType())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreatePeComanagedDatabaseInsightDetails(
+            String compartmentId,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String databaseId,
+            String databaseResourceType,
+            String opsiPrivateEndpointId,
+            String serviceName,
+            CredentialDetails credentialDetails,
+            DeploymentType deploymentType,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+        super(compartmentId, freeformTags, definedTags);
+        this.databaseId = databaseId;
+        this.databaseResourceType = databaseResourceType;
+        this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+        this.serviceName = serviceName;
+        this.credentialDetails = credentialDetails;
+        this.deploymentType = deploymentType;
+        this.systemTags = systemTags;
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
+    String databaseId;
+
+    /**
+     * OCI database resource type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseResourceType")
+    String databaseResourceType;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the OPSI private endpoint
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+    String opsiPrivateEndpointId;
+
+    /**
+     * Database service name used for connection requests.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("serviceName")
+    String serviceName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("credentialDetails")
+    CredentialDetails credentialDetails;
+    /**
+     * Database Deployment Type
+     **/
+    public enum DeploymentType {
+        VirtualMachine("VIRTUAL_MACHINE"),
+        BareMetal("BARE_METAL"),
+        Exacs("EXACS"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, DeploymentType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DeploymentType v : DeploymentType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        DeploymentType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DeploymentType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid DeploymentType: " + key);
+        }
+    };
+    /**
+     * Database Deployment Type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentType")
+    DeploymentType deploymentType;
+
+    /**
+     * System tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CredentialByVault.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CredentialByVault.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Vault Credential Details to connect to the database.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CredentialByVault.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "credentialType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CredentialByVault extends CredentialDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("credentialSourceName")
+        private String credentialSourceName;
+
+        public Builder credentialSourceName(String credentialSourceName) {
+            this.credentialSourceName = credentialSourceName;
+            this.__explicitlySet__.add("credentialSourceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("userName")
+        private String userName;
+
+        public Builder userName(String userName) {
+            this.userName = userName;
+            this.__explicitlySet__.add("userName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecretId")
+        private String passwordSecretId;
+
+        public Builder passwordSecretId(String passwordSecretId) {
+            this.passwordSecretId = passwordSecretId;
+            this.__explicitlySet__.add("passwordSecretId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("role")
+        private Role role;
+
+        public Builder role(Role role) {
+            this.role = role;
+            this.__explicitlySet__.add("role");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CredentialByVault build() {
+            CredentialByVault __instance__ =
+                    new CredentialByVault(credentialSourceName, userName, passwordSecretId, role);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CredentialByVault o) {
+            Builder copiedBuilder =
+                    credentialSourceName(o.getCredentialSourceName())
+                            .userName(o.getUserName())
+                            .passwordSecretId(o.getPasswordSecretId())
+                            .role(o.getRole());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CredentialByVault(
+            String credentialSourceName, String userName, String passwordSecretId, Role role) {
+        super(credentialSourceName);
+        this.userName = userName;
+        this.passwordSecretId = passwordSecretId;
+        this.role = role;
+    }
+
+    /**
+     * database user name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("userName")
+    String userName;
+
+    /**
+     * The secret [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) mapping to the database credentials.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecretId")
+    String passwordSecretId;
+    /**
+     * database user role.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Role {
+        Normal("NORMAL"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Role> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Role v : Role.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Role(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Role create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Role', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * database user role.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("role")
+    Role role;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CredentialDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/CredentialDetails.java
@@ -32,6 +32,10 @@ package com.oracle.bmc.opsi.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CredentialsBySource.class,
         name = "CREDENTIALS_BY_SOURCE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CredentialByVault.class,
+        name = "CREDENTIALS_BY_VAULT"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
@@ -49,6 +53,7 @@ public class CredentialDetails {
     @lombok.extern.slf4j.Slf4j
     public enum CredentialType {
         CredentialsBySource("CREDENTIALS_BY_SOURCE"),
+        CredentialsByVault("CREDENTIALS_BY_VAULT"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseConfigurationSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseConfigurationSummary.java
@@ -39,6 +39,10 @@ package com.oracle.bmc.opsi.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = MacsManagedExternalDatabaseConfigurationSummary.class,
         name = "MACS_MANAGED_EXTERNAL_DATABASE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PeComanagedManagedExternalDatabaseConfigurationSummary.class,
+        name = "PE_COMANAGED_DATABASE"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseEntitySource.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseEntitySource.java
@@ -10,6 +10,7 @@ package com.oracle.bmc.opsi.model;
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
 public enum DatabaseEntitySource {
     EmManagedExternalDatabase("EM_MANAGED_EXTERNAL_DATABASE"),
+    PeComanagedDatabase("PE_COMANAGED_DATABASE"),
     ;
 
     private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseEntitySourceAll.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseEntitySourceAll.java
@@ -13,6 +13,7 @@ public enum DatabaseEntitySourceAll {
     AutonomousDatabase("AUTONOMOUS_DATABASE"),
     EmManagedExternalDatabase("EM_MANAGED_EXTERNAL_DATABASE"),
     MacsManagedExternalDatabase("MACS_MANAGED_EXTERNAL_DATABASE"),
+    PeComanagedDatabase("PE_COMANAGED_DATABASE"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseInsight.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseInsight.java
@@ -37,6 +37,10 @@ package com.oracle.bmc.opsi.model;
         name = "MACS_MANAGED_EXTERNAL_DATABASE"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PeComanagedDatabaseInsight.class,
+        name = "PE_COMANAGED_DATABASE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = AutonomousDatabaseInsight.class,
         name = "AUTONOMOUS_DATABASE"
     )
@@ -127,4 +131,10 @@ public class DatabaseInsight {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
     String lifecycleDetails;
+
+    /**
+     * A message describing the status of the database connection of this resource. For example, it can be used to provide actionable information about the permission and content validity of the database connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+    String databaseConnectionStatusDetails;
 }

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseInsightSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/DatabaseInsightSummary.java
@@ -37,6 +37,10 @@ package com.oracle.bmc.opsi.model;
         name = "AUTONOMOUS_DATABASE"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PeComanagedDatabaseInsightSummary.class,
+        name = "PE_COMANAGED_DATABASE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = EmManagedExternalDatabaseInsightSummary.class,
         name = "EM_MANAGED_EXTERNAL_DATABASE"
     )
@@ -151,4 +155,10 @@ public class DatabaseInsightSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
     String lifecycleDetails;
+
+    /**
+     * A message describing the status of the database connection of this resource. For example, it can be used to provide actionable information about the permission and content validity of the database connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+    String databaseConnectionStatusDetails;
 }

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EmManagedExternalDatabaseInsight.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EmManagedExternalDatabaseInsight.java
@@ -150,6 +150,15 @@ public class EmManagedExternalDatabaseInsight extends DatabaseInsight {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+        private String databaseConnectionStatusDetails;
+
+        public Builder databaseConnectionStatusDetails(String databaseConnectionStatusDetails) {
+            this.databaseConnectionStatusDetails = databaseConnectionStatusDetails;
+            this.__explicitlySet__.add("databaseConnectionStatusDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("enterpriseManagerIdentifier")
         private String enterpriseManagerIdentifier;
 
@@ -233,6 +242,7 @@ public class EmManagedExternalDatabaseInsight extends DatabaseInsight {
                             timeUpdated,
                             lifecycleState,
                             lifecycleDetails,
+                            databaseConnectionStatusDetails,
                             enterpriseManagerIdentifier,
                             enterpriseManagerEntityName,
                             enterpriseManagerEntityType,
@@ -260,6 +270,7 @@ public class EmManagedExternalDatabaseInsight extends DatabaseInsight {
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
+                            .databaseConnectionStatusDetails(o.getDatabaseConnectionStatusDetails())
                             .enterpriseManagerIdentifier(o.getEnterpriseManagerIdentifier())
                             .enterpriseManagerEntityName(o.getEnterpriseManagerEntityName())
                             .enterpriseManagerEntityType(o.getEnterpriseManagerEntityType())
@@ -297,6 +308,7 @@ public class EmManagedExternalDatabaseInsight extends DatabaseInsight {
             java.util.Date timeUpdated,
             LifecycleState lifecycleState,
             String lifecycleDetails,
+            String databaseConnectionStatusDetails,
             String enterpriseManagerIdentifier,
             String enterpriseManagerEntityName,
             String enterpriseManagerEntityType,
@@ -317,7 +329,8 @@ public class EmManagedExternalDatabaseInsight extends DatabaseInsight {
                 timeCreated,
                 timeUpdated,
                 lifecycleState,
-                lifecycleDetails);
+                lifecycleDetails,
+                databaseConnectionStatusDetails);
         this.enterpriseManagerIdentifier = enterpriseManagerIdentifier;
         this.enterpriseManagerEntityName = enterpriseManagerEntityName;
         this.enterpriseManagerEntityType = enterpriseManagerEntityType;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EmManagedExternalDatabaseInsightSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EmManagedExternalDatabaseInsightSummary.java
@@ -186,6 +186,15 @@ public class EmManagedExternalDatabaseInsightSummary extends DatabaseInsightSumm
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+        private String databaseConnectionStatusDetails;
+
+        public Builder databaseConnectionStatusDetails(String databaseConnectionStatusDetails) {
+            this.databaseConnectionStatusDetails = databaseConnectionStatusDetails;
+            this.__explicitlySet__.add("databaseConnectionStatusDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("enterpriseManagerIdentifier")
         private String enterpriseManagerIdentifier;
 
@@ -273,6 +282,7 @@ public class EmManagedExternalDatabaseInsightSummary extends DatabaseInsightSumm
                             timeUpdated,
                             lifecycleState,
                             lifecycleDetails,
+                            databaseConnectionStatusDetails,
                             enterpriseManagerIdentifier,
                             enterpriseManagerEntityName,
                             enterpriseManagerEntityType,
@@ -304,6 +314,7 @@ public class EmManagedExternalDatabaseInsightSummary extends DatabaseInsightSumm
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
+                            .databaseConnectionStatusDetails(o.getDatabaseConnectionStatusDetails())
                             .enterpriseManagerIdentifier(o.getEnterpriseManagerIdentifier())
                             .enterpriseManagerEntityName(o.getEnterpriseManagerEntityName())
                             .enterpriseManagerEntityType(o.getEnterpriseManagerEntityType())
@@ -345,6 +356,7 @@ public class EmManagedExternalDatabaseInsightSummary extends DatabaseInsightSumm
             java.util.Date timeUpdated,
             LifecycleState lifecycleState,
             String lifecycleDetails,
+            String databaseConnectionStatusDetails,
             String enterpriseManagerIdentifier,
             String enterpriseManagerEntityName,
             String enterpriseManagerEntityType,
@@ -369,7 +381,8 @@ public class EmManagedExternalDatabaseInsightSummary extends DatabaseInsightSumm
                 timeCreated,
                 timeUpdated,
                 lifecycleState,
-                lifecycleDetails);
+                lifecycleDetails,
+                databaseConnectionStatusDetails);
         this.enterpriseManagerIdentifier = enterpriseManagerIdentifier;
         this.enterpriseManagerEntityName = enterpriseManagerEntityName;
         this.enterpriseManagerEntityType = enterpriseManagerEntityType;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EnableDatabaseInsightDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EnableDatabaseInsightDetails.java
@@ -31,6 +31,10 @@ package com.oracle.bmc.opsi.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = EnableEmManagedExternalDatabaseInsightDetails.class,
         name = "EM_MANAGED_EXTERNAL_DATABASE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = EnablePeComanagedDatabaseInsightDetails.class,
+        name = "PE_COMANAGED_DATABASE"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EnablePeComanagedDatabaseInsightDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EnablePeComanagedDatabaseInsightDetails.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * The information about database to be analyzed.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EnablePeComanagedDatabaseInsightDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "entitySource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EnablePeComanagedDatabaseInsightDetails extends EnableDatabaseInsightDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+        private String opsiPrivateEndpointId;
+
+        public Builder opsiPrivateEndpointId(String opsiPrivateEndpointId) {
+            this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+            this.__explicitlySet__.add("opsiPrivateEndpointId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("serviceName")
+        private String serviceName;
+
+        public Builder serviceName(String serviceName) {
+            this.serviceName = serviceName;
+            this.__explicitlySet__.add("serviceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("credentialDetails")
+        private CredentialDetails credentialDetails;
+
+        public Builder credentialDetails(CredentialDetails credentialDetails) {
+            this.credentialDetails = credentialDetails;
+            this.__explicitlySet__.add("credentialDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EnablePeComanagedDatabaseInsightDetails build() {
+            EnablePeComanagedDatabaseInsightDetails __instance__ =
+                    new EnablePeComanagedDatabaseInsightDetails(
+                            compartmentId,
+                            opsiPrivateEndpointId,
+                            serviceName,
+                            credentialDetails,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EnablePeComanagedDatabaseInsightDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .opsiPrivateEndpointId(o.getOpsiPrivateEndpointId())
+                            .serviceName(o.getServiceName())
+                            .credentialDetails(o.getCredentialDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public EnablePeComanagedDatabaseInsightDetails(
+            String compartmentId,
+            String opsiPrivateEndpointId,
+            String serviceName,
+            CredentialDetails credentialDetails,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+        super();
+        this.compartmentId = compartmentId;
+        this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+        this.serviceName = serviceName;
+        this.credentialDetails = credentialDetails;
+        this.freeformTags = freeformTags;
+        this.definedTags = definedTags;
+        this.systemTags = systemTags;
+    }
+
+    /**
+     * The compartment [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the Private service accessed database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the OPSI private endpoint
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+    String opsiPrivateEndpointId;
+
+    /**
+     * Database service name used for connection requests.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("serviceName")
+    String serviceName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("credentialDetails")
+    CredentialDetails credentialDetails;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * System tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/ExadataMemberSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/ExadataMemberSummary.java
@@ -103,6 +103,7 @@ public class ExadataMemberSummary {
         ClusterAsm("CLUSTER_ASM"),
         InfinibandSwitch("INFINIBAND_SWITCH"),
         EthernetSwitch("ETHERNET_SWITCH"),
+        Host("HOST"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/MacsManagedExternalDatabaseInsight.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/MacsManagedExternalDatabaseInsight.java
@@ -150,6 +150,15 @@ public class MacsManagedExternalDatabaseInsight extends DatabaseInsight {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+        private String databaseConnectionStatusDetails;
+
+        public Builder databaseConnectionStatusDetails(String databaseConnectionStatusDetails) {
+            this.databaseConnectionStatusDetails = databaseConnectionStatusDetails;
+            this.__explicitlySet__.add("databaseConnectionStatusDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("managementAgentId")
         private String managementAgentId;
 
@@ -250,6 +259,7 @@ public class MacsManagedExternalDatabaseInsight extends DatabaseInsight {
                             timeUpdated,
                             lifecycleState,
                             lifecycleDetails,
+                            databaseConnectionStatusDetails,
                             managementAgentId,
                             connectorId,
                             connectionDetails,
@@ -279,6 +289,7 @@ public class MacsManagedExternalDatabaseInsight extends DatabaseInsight {
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
+                            .databaseConnectionStatusDetails(o.getDatabaseConnectionStatusDetails())
                             .managementAgentId(o.getManagementAgentId())
                             .connectorId(o.getConnectorId())
                             .connectionDetails(o.getConnectionDetails())
@@ -316,6 +327,7 @@ public class MacsManagedExternalDatabaseInsight extends DatabaseInsight {
             java.util.Date timeUpdated,
             LifecycleState lifecycleState,
             String lifecycleDetails,
+            String databaseConnectionStatusDetails,
             String managementAgentId,
             String connectorId,
             ConnectionDetails connectionDetails,
@@ -338,7 +350,8 @@ public class MacsManagedExternalDatabaseInsight extends DatabaseInsight {
                 timeCreated,
                 timeUpdated,
                 lifecycleState,
-                lifecycleDetails);
+                lifecycleDetails,
+                databaseConnectionStatusDetails);
         this.managementAgentId = managementAgentId;
         this.connectorId = connectorId;
         this.connectionDetails = connectionDetails;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/MacsManagedExternalDatabaseInsightSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/MacsManagedExternalDatabaseInsightSummary.java
@@ -186,6 +186,15 @@ public class MacsManagedExternalDatabaseInsightSummary extends DatabaseInsightSu
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+        private String databaseConnectionStatusDetails;
+
+        public Builder databaseConnectionStatusDetails(String databaseConnectionStatusDetails) {
+            this.databaseConnectionStatusDetails = databaseConnectionStatusDetails;
+            this.__explicitlySet__.add("databaseConnectionStatusDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseResourceType")
         private String databaseResourceType;
 
@@ -236,6 +245,7 @@ public class MacsManagedExternalDatabaseInsightSummary extends DatabaseInsightSu
                             timeUpdated,
                             lifecycleState,
                             lifecycleDetails,
+                            databaseConnectionStatusDetails,
                             databaseResourceType,
                             managementAgentId,
                             connectorId);
@@ -263,6 +273,7 @@ public class MacsManagedExternalDatabaseInsightSummary extends DatabaseInsightSu
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
+                            .databaseConnectionStatusDetails(o.getDatabaseConnectionStatusDetails())
                             .databaseResourceType(o.getDatabaseResourceType())
                             .managementAgentId(o.getManagementAgentId())
                             .connectorId(o.getConnectorId());
@@ -298,6 +309,7 @@ public class MacsManagedExternalDatabaseInsightSummary extends DatabaseInsightSu
             java.util.Date timeUpdated,
             LifecycleState lifecycleState,
             String lifecycleDetails,
+            String databaseConnectionStatusDetails,
             String databaseResourceType,
             String managementAgentId,
             String connectorId) {
@@ -318,7 +330,8 @@ public class MacsManagedExternalDatabaseInsightSummary extends DatabaseInsightSu
                 timeCreated,
                 timeUpdated,
                 lifecycleState,
-                lifecycleDetails);
+                lifecycleDetails,
+                databaseConnectionStatusDetails);
         this.databaseResourceType = databaseResourceType;
         this.managementAgentId = managementAgentId;
         this.connectorId = connectorId;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationType.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationType.java
@@ -47,6 +47,10 @@ public enum OperationType {
     CreateAwrhub("CREATE_AWRHUB"),
     MoveAwrhub("MOVE_AWRHUB"),
     DeleteAwrhub("DELETE_AWRHUB"),
+    UpdatePrivateEndpoint("UPDATE_PRIVATE_ENDPOINT"),
+    CreatePrivateEndpoint("CREATE_PRIVATE_ENDPOINT"),
+    MovePrivateEndpoint("MOVE_PRIVATE_ENDPOINT"),
+    DeletePrivateEndpoint("DELETE_PRIVATE_ENDPOINT"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationsInsightsPrivateEndpoint.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationsInsightsPrivateEndpoint.java
@@ -1,0 +1,339 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * A private endpoint that allows Operation Insights services to connect to databases in a customer's virtual cloud network (VCN).
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OperationsInsightsPrivateEndpoint.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OperationsInsightsPrivateEndpoint {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+        private String vcnId;
+
+        public Builder vcnId(String vcnId) {
+            this.vcnId = vcnId;
+            this.__explicitlySet__.add("vcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("privateIp")
+        private String privateIp;
+
+        public Builder privateIp(String privateIp) {
+            this.privateIp = privateIp;
+            this.__explicitlySet__.add("privateIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private OperationsInsightsPrivateEndpointLifecycleState lifecycleState;
+
+        public Builder lifecycleState(
+                OperationsInsightsPrivateEndpointLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointStatusDetails")
+        private String privateEndpointStatusDetails;
+
+        public Builder privateEndpointStatusDetails(String privateEndpointStatusDetails) {
+            this.privateEndpointStatusDetails = privateEndpointStatusDetails;
+            this.__explicitlySet__.add("privateEndpointStatusDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isUsedForRacDbs")
+        private Boolean isUsedForRacDbs;
+
+        public Builder isUsedForRacDbs(Boolean isUsedForRacDbs) {
+            this.isUsedForRacDbs = isUsedForRacDbs;
+            this.__explicitlySet__.add("isUsedForRacDbs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OperationsInsightsPrivateEndpoint build() {
+            OperationsInsightsPrivateEndpoint __instance__ =
+                    new OperationsInsightsPrivateEndpoint(
+                            id,
+                            displayName,
+                            compartmentId,
+                            vcnId,
+                            subnetId,
+                            privateIp,
+                            description,
+                            timeCreated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            privateEndpointStatusDetails,
+                            isUsedForRacDbs,
+                            nsgIds,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OperationsInsightsPrivateEndpoint o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .vcnId(o.getVcnId())
+                            .subnetId(o.getSubnetId())
+                            .privateIp(o.getPrivateIp())
+                            .description(o.getDescription())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .privateEndpointStatusDetails(o.getPrivateEndpointStatusDetails())
+                            .isUsedForRacDbs(o.getIsUsedForRacDbs())
+                            .nsgIds(o.getNsgIds())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the Private service accessed database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The display name of the private endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The compartment OCID of the Private service accessed database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The OCID of the VCN.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+    String vcnId;
+
+    /**
+     * The OCID of the subnet.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * The private IP addresses assigned to the private endpoint. All IP addresses will be concatenated if it is RAC DBs.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("privateIp")
+    String privateIp;
+
+    /**
+     * The description of the private endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The date and time the private endpoint was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The current state of the private endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    OperationsInsightsPrivateEndpointLifecycleState lifecycleState;
+
+    /**
+     * A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * A message describing the status of the private endpoint connection of this resource. For example, it can be used to provide actionable information about the validity of the private endpoint connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointStatusDetails")
+    String privateEndpointStatusDetails;
+
+    /**
+     * The flag is to identify if private endpoint is used for rac database or not
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isUsedForRacDbs")
+    Boolean isUsedForRacDbs;
+
+    /**
+     * The OCIDs of the network security groups that the private endpoint belongs to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * System tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationsInsightsPrivateEndpointCollection.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationsInsightsPrivateEndpointCollection.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * A collection of Operation Insights private endpoint objects.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OperationsInsightsPrivateEndpointCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OperationsInsightsPrivateEndpointCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<OperationsInsightsPrivateEndpointSummary> items;
+
+        public Builder items(java.util.List<OperationsInsightsPrivateEndpointSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OperationsInsightsPrivateEndpointCollection build() {
+            OperationsInsightsPrivateEndpointCollection __instance__ =
+                    new OperationsInsightsPrivateEndpointCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OperationsInsightsPrivateEndpointCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A list of OperationsInsightsPrivateEndpointSummary objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<OperationsInsightsPrivateEndpointSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationsInsightsPrivateEndpointLifecycleState.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationsInsightsPrivateEndpointLifecycleState.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Private endpoint lifecycle states.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public enum OperationsInsightsPrivateEndpointLifecycleState {
+    Creating("CREATING"),
+    Updating("UPDATING"),
+    Active("ACTIVE"),
+    Deleting("DELETING"),
+    Deleted("DELETED"),
+    Failed("FAILED"),
+    NeedsAttention("NEEDS_ATTENTION"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, OperationsInsightsPrivateEndpointLifecycleState> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (OperationsInsightsPrivateEndpointLifecycleState v :
+                OperationsInsightsPrivateEndpointLifecycleState.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    OperationsInsightsPrivateEndpointLifecycleState(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static OperationsInsightsPrivateEndpointLifecycleState create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'OperationsInsightsPrivateEndpointLifecycleState', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationsInsightsPrivateEndpointSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/OperationsInsightsPrivateEndpointSummary.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Summary of a Operation Insights private endpoint.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OperationsInsightsPrivateEndpointSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OperationsInsightsPrivateEndpointSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+        private String vcnId;
+
+        public Builder vcnId(String vcnId) {
+            this.vcnId = vcnId;
+            this.__explicitlySet__.add("vcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isUsedForRacDbs")
+        private Boolean isUsedForRacDbs;
+
+        public Builder isUsedForRacDbs(Boolean isUsedForRacDbs) {
+            this.isUsedForRacDbs = isUsedForRacDbs;
+            this.__explicitlySet__.add("isUsedForRacDbs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private OperationsInsightsPrivateEndpointLifecycleState lifecycleState;
+
+        public Builder lifecycleState(
+                OperationsInsightsPrivateEndpointLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointStatusDetails")
+        private String privateEndpointStatusDetails;
+
+        public Builder privateEndpointStatusDetails(String privateEndpointStatusDetails) {
+            this.privateEndpointStatusDetails = privateEndpointStatusDetails;
+            this.__explicitlySet__.add("privateEndpointStatusDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OperationsInsightsPrivateEndpointSummary build() {
+            OperationsInsightsPrivateEndpointSummary __instance__ =
+                    new OperationsInsightsPrivateEndpointSummary(
+                            id,
+                            displayName,
+                            compartmentId,
+                            vcnId,
+                            subnetId,
+                            isUsedForRacDbs,
+                            description,
+                            timeCreated,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            lifecycleState,
+                            lifecycleDetails,
+                            privateEndpointStatusDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OperationsInsightsPrivateEndpointSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .vcnId(o.getVcnId())
+                            .subnetId(o.getSubnetId())
+                            .isUsedForRacDbs(o.getIsUsedForRacDbs())
+                            .description(o.getDescription())
+                            .timeCreated(o.getTimeCreated())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .privateEndpointStatusDetails(o.getPrivateEndpointStatusDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the Private service accessed database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The display name of the private endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The compartment OCID of the Private service accessed database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The OCID of the VCN.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+    String vcnId;
+
+    /**
+     * The OCID of the subnet.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * The flag to identify if private endpoint is used for rac database or not
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isUsedForRacDbs")
+    Boolean isUsedForRacDbs;
+
+    /**
+     * The description of the private endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The date and time the private endpoint was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * System tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    /**
+     * Private endpoint lifecycle states
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    OperationsInsightsPrivateEndpointLifecycleState lifecycleState;
+
+    /**
+     * A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * A message describing the status of the private endpoint connection of this resource. For example, it can be used to provide actionable information about the validity of the private endpoint connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointStatusDetails")
+    String privateEndpointStatusDetails;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedDatabaseConnectionDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedDatabaseConnectionDetails.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Connection details of the private endpoints.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PeComanagedDatabaseConnectionDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PeComanagedDatabaseConnectionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hosts")
+        private java.util.List<PeComanagedDatabaseHostDetails> hosts;
+
+        public Builder hosts(java.util.List<PeComanagedDatabaseHostDetails> hosts) {
+            this.hosts = hosts;
+            this.__explicitlySet__.add("hosts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("protocol")
+        private Protocol protocol;
+
+        public Builder protocol(Protocol protocol) {
+            this.protocol = protocol;
+            this.__explicitlySet__.add("protocol");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("serviceName")
+        private String serviceName;
+
+        public Builder serviceName(String serviceName) {
+            this.serviceName = serviceName;
+            this.__explicitlySet__.add("serviceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PeComanagedDatabaseConnectionDetails build() {
+            PeComanagedDatabaseConnectionDetails __instance__ =
+                    new PeComanagedDatabaseConnectionDetails(hosts, protocol, serviceName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PeComanagedDatabaseConnectionDetails o) {
+            Builder copiedBuilder =
+                    hosts(o.getHosts()).protocol(o.getProtocol()).serviceName(o.getServiceName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of hosts and port for private endpoint accessed database resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hosts")
+    java.util.List<PeComanagedDatabaseHostDetails> hosts;
+    /**
+     * Protocol used for connection requests for private endpoint accssed database resource.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Protocol {
+        Tcp("TCP"),
+        Tcps("TCPS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Protocol> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Protocol v : Protocol.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Protocol(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Protocol create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Protocol', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Protocol used for connection requests for private endpoint accssed database resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("protocol")
+    Protocol protocol;
+
+    /**
+     * Database service name used for connection requests.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("serviceName")
+    String serviceName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedDatabaseHostDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedDatabaseHostDetails.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Input Host Details used for connection requests for private endpoint accessed db resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PeComanagedDatabaseHostDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PeComanagedDatabaseHostDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hostIp")
+        private String hostIp;
+
+        public Builder hostIp(String hostIp) {
+            this.hostIp = hostIp;
+            this.__explicitlySet__.add("hostIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("port")
+        private Integer port;
+
+        public Builder port(Integer port) {
+            this.port = port;
+            this.__explicitlySet__.add("port");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PeComanagedDatabaseHostDetails build() {
+            PeComanagedDatabaseHostDetails __instance__ =
+                    new PeComanagedDatabaseHostDetails(hostIp, port);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PeComanagedDatabaseHostDetails o) {
+            Builder copiedBuilder = hostIp(o.getHostIp()).port(o.getPort());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Host IP used for connection requests for Cloud DB resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostIp")
+    String hostIp;
+
+    /**
+     * Listener port number used for connection requests for rivate endpoint accessed db resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("port")
+    Integer port;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedDatabaseInsight.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedDatabaseInsight.java
@@ -1,0 +1,378 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Database insight resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PeComanagedDatabaseInsight.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "entitySource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PeComanagedDatabaseInsight extends DatabaseInsight {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private ResourceStatus status;
+
+        public Builder status(ResourceStatus status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseType")
+        private String databaseType;
+
+        public Builder databaseType(String databaseType) {
+            this.databaseType = databaseType;
+            this.__explicitlySet__.add("databaseType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseVersion")
+        private String databaseVersion;
+
+        public Builder databaseVersion(String databaseVersion) {
+            this.databaseVersion = databaseVersion;
+            this.__explicitlySet__.add("databaseVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("processorCount")
+        private Integer processorCount;
+
+        public Builder processorCount(Integer processorCount) {
+            this.processorCount = processorCount;
+            this.__explicitlySet__.add("processorCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+        private String databaseConnectionStatusDetails;
+
+        public Builder databaseConnectionStatusDetails(String databaseConnectionStatusDetails) {
+            this.databaseConnectionStatusDetails = databaseConnectionStatusDetails;
+            this.__explicitlySet__.add("databaseConnectionStatusDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+        private String opsiPrivateEndpointId;
+
+        public Builder opsiPrivateEndpointId(String opsiPrivateEndpointId) {
+            this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+            this.__explicitlySet__.add("opsiPrivateEndpointId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionDetails")
+        private PeComanagedDatabaseConnectionDetails connectionDetails;
+
+        public Builder connectionDetails(PeComanagedDatabaseConnectionDetails connectionDetails) {
+            this.connectionDetails = connectionDetails;
+            this.__explicitlySet__.add("connectionDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("credentialDetails")
+        private CredentialDetails credentialDetails;
+
+        public Builder credentialDetails(CredentialDetails credentialDetails) {
+            this.credentialDetails = credentialDetails;
+            this.__explicitlySet__.add("credentialDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
+        private String databaseId;
+
+        public Builder databaseId(String databaseId) {
+            this.databaseId = databaseId;
+            this.__explicitlySet__.add("databaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseName")
+        private String databaseName;
+
+        public Builder databaseName(String databaseName) {
+            this.databaseName = databaseName;
+            this.__explicitlySet__.add("databaseName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseDisplayName")
+        private String databaseDisplayName;
+
+        public Builder databaseDisplayName(String databaseDisplayName) {
+            this.databaseDisplayName = databaseDisplayName;
+            this.__explicitlySet__.add("databaseDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseResourceType")
+        private String databaseResourceType;
+
+        public Builder databaseResourceType(String databaseResourceType) {
+            this.databaseResourceType = databaseResourceType;
+            this.__explicitlySet__.add("databaseResourceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PeComanagedDatabaseInsight build() {
+            PeComanagedDatabaseInsight __instance__ =
+                    new PeComanagedDatabaseInsight(
+                            id,
+                            compartmentId,
+                            status,
+                            databaseType,
+                            databaseVersion,
+                            processorCount,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            databaseConnectionStatusDetails,
+                            opsiPrivateEndpointId,
+                            connectionDetails,
+                            credentialDetails,
+                            databaseId,
+                            databaseName,
+                            databaseDisplayName,
+                            databaseResourceType);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PeComanagedDatabaseInsight o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .status(o.getStatus())
+                            .databaseType(o.getDatabaseType())
+                            .databaseVersion(o.getDatabaseVersion())
+                            .processorCount(o.getProcessorCount())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .databaseConnectionStatusDetails(o.getDatabaseConnectionStatusDetails())
+                            .opsiPrivateEndpointId(o.getOpsiPrivateEndpointId())
+                            .connectionDetails(o.getConnectionDetails())
+                            .credentialDetails(o.getCredentialDetails())
+                            .databaseId(o.getDatabaseId())
+                            .databaseName(o.getDatabaseName())
+                            .databaseDisplayName(o.getDatabaseDisplayName())
+                            .databaseResourceType(o.getDatabaseResourceType());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PeComanagedDatabaseInsight(
+            String id,
+            String compartmentId,
+            ResourceStatus status,
+            String databaseType,
+            String databaseVersion,
+            Integer processorCount,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            String databaseConnectionStatusDetails,
+            String opsiPrivateEndpointId,
+            PeComanagedDatabaseConnectionDetails connectionDetails,
+            CredentialDetails credentialDetails,
+            String databaseId,
+            String databaseName,
+            String databaseDisplayName,
+            String databaseResourceType) {
+        super(
+                id,
+                compartmentId,
+                status,
+                databaseType,
+                databaseVersion,
+                processorCount,
+                freeformTags,
+                definedTags,
+                systemTags,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                databaseConnectionStatusDetails);
+        this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+        this.connectionDetails = connectionDetails;
+        this.credentialDetails = credentialDetails;
+        this.databaseId = databaseId;
+        this.databaseName = databaseName;
+        this.databaseDisplayName = databaseDisplayName;
+        this.databaseResourceType = databaseResourceType;
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the OPSI private endpoint
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+    String opsiPrivateEndpointId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("connectionDetails")
+    PeComanagedDatabaseConnectionDetails connectionDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("credentialDetails")
+    CredentialDetails credentialDetails;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
+    String databaseId;
+
+    /**
+     * Name of database
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseName")
+    String databaseName;
+
+    /**
+     * Display name of database
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseDisplayName")
+    String databaseDisplayName;
+
+    /**
+     * OCI database resource type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseResourceType")
+    String databaseResourceType;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedDatabaseInsightSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedDatabaseInsightSummary.java
@@ -1,0 +1,341 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Summary of a database insight resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PeComanagedDatabaseInsightSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "entitySource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PeComanagedDatabaseInsightSummary extends DatabaseInsightSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
+        private String databaseId;
+
+        public Builder databaseId(String databaseId) {
+            this.databaseId = databaseId;
+            this.__explicitlySet__.add("databaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseName")
+        private String databaseName;
+
+        public Builder databaseName(String databaseName) {
+            this.databaseName = databaseName;
+            this.__explicitlySet__.add("databaseName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseDisplayName")
+        private String databaseDisplayName;
+
+        public Builder databaseDisplayName(String databaseDisplayName) {
+            this.databaseDisplayName = databaseDisplayName;
+            this.__explicitlySet__.add("databaseDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseType")
+        private String databaseType;
+
+        public Builder databaseType(String databaseType) {
+            this.databaseType = databaseType;
+            this.__explicitlySet__.add("databaseType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseVersion")
+        private String databaseVersion;
+
+        public Builder databaseVersion(String databaseVersion) {
+            this.databaseVersion = databaseVersion;
+            this.__explicitlySet__.add("databaseVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseHostNames")
+        private java.util.List<String> databaseHostNames;
+
+        public Builder databaseHostNames(java.util.List<String> databaseHostNames) {
+            this.databaseHostNames = databaseHostNames;
+            this.__explicitlySet__.add("databaseHostNames");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("processorCount")
+        private Integer processorCount;
+
+        public Builder processorCount(Integer processorCount) {
+            this.processorCount = processorCount;
+            this.__explicitlySet__.add("processorCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private ResourceStatus status;
+
+        public Builder status(ResourceStatus status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConnectionStatusDetails")
+        private String databaseConnectionStatusDetails;
+
+        public Builder databaseConnectionStatusDetails(String databaseConnectionStatusDetails) {
+            this.databaseConnectionStatusDetails = databaseConnectionStatusDetails;
+            this.__explicitlySet__.add("databaseConnectionStatusDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseResourceType")
+        private String databaseResourceType;
+
+        public Builder databaseResourceType(String databaseResourceType) {
+            this.databaseResourceType = databaseResourceType;
+            this.__explicitlySet__.add("databaseResourceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+        private String opsiPrivateEndpointId;
+
+        public Builder opsiPrivateEndpointId(String opsiPrivateEndpointId) {
+            this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+            this.__explicitlySet__.add("opsiPrivateEndpointId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PeComanagedDatabaseInsightSummary build() {
+            PeComanagedDatabaseInsightSummary __instance__ =
+                    new PeComanagedDatabaseInsightSummary(
+                            id,
+                            databaseId,
+                            compartmentId,
+                            databaseName,
+                            databaseDisplayName,
+                            databaseType,
+                            databaseVersion,
+                            databaseHostNames,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            processorCount,
+                            status,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            databaseConnectionStatusDetails,
+                            databaseResourceType,
+                            opsiPrivateEndpointId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PeComanagedDatabaseInsightSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .databaseId(o.getDatabaseId())
+                            .compartmentId(o.getCompartmentId())
+                            .databaseName(o.getDatabaseName())
+                            .databaseDisplayName(o.getDatabaseDisplayName())
+                            .databaseType(o.getDatabaseType())
+                            .databaseVersion(o.getDatabaseVersion())
+                            .databaseHostNames(o.getDatabaseHostNames())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .processorCount(o.getProcessorCount())
+                            .status(o.getStatus())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .databaseConnectionStatusDetails(o.getDatabaseConnectionStatusDetails())
+                            .databaseResourceType(o.getDatabaseResourceType())
+                            .opsiPrivateEndpointId(o.getOpsiPrivateEndpointId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PeComanagedDatabaseInsightSummary(
+            String id,
+            String databaseId,
+            String compartmentId,
+            String databaseName,
+            String databaseDisplayName,
+            String databaseType,
+            String databaseVersion,
+            java.util.List<String> databaseHostNames,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            Integer processorCount,
+            ResourceStatus status,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            String databaseConnectionStatusDetails,
+            String databaseResourceType,
+            String opsiPrivateEndpointId) {
+        super(
+                id,
+                databaseId,
+                compartmentId,
+                databaseName,
+                databaseDisplayName,
+                databaseType,
+                databaseVersion,
+                databaseHostNames,
+                freeformTags,
+                definedTags,
+                systemTags,
+                processorCount,
+                status,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                databaseConnectionStatusDetails);
+        this.databaseResourceType = databaseResourceType;
+        this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+    }
+
+    /**
+     * OCI database resource type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseResourceType")
+    String databaseResourceType;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the OPSI private endpoint
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+    String opsiPrivateEndpointId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedManagedExternalDatabaseConfigurationSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/PeComanagedManagedExternalDatabaseConfigurationSummary.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Configuration Summary of a Private Endpoint Co-managed External database.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PeComanagedManagedExternalDatabaseConfigurationSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "entitySource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PeComanagedManagedExternalDatabaseConfigurationSummary
+        extends DatabaseConfigurationSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseInsightId")
+        private String databaseInsightId;
+
+        public Builder databaseInsightId(String databaseInsightId) {
+            this.databaseInsightId = databaseInsightId;
+            this.__explicitlySet__.add("databaseInsightId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseName")
+        private String databaseName;
+
+        public Builder databaseName(String databaseName) {
+            this.databaseName = databaseName;
+            this.__explicitlySet__.add("databaseName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseDisplayName")
+        private String databaseDisplayName;
+
+        public Builder databaseDisplayName(String databaseDisplayName) {
+            this.databaseDisplayName = databaseDisplayName;
+            this.__explicitlySet__.add("databaseDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseType")
+        private String databaseType;
+
+        public Builder databaseType(String databaseType) {
+            this.databaseType = databaseType;
+            this.__explicitlySet__.add("databaseType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseVersion")
+        private String databaseVersion;
+
+        public Builder databaseVersion(String databaseVersion) {
+            this.databaseVersion = databaseVersion;
+            this.__explicitlySet__.add("databaseVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cdbName")
+        private String cdbName;
+
+        public Builder cdbName(String cdbName) {
+            this.cdbName = cdbName;
+            this.__explicitlySet__.add("cdbName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("processorCount")
+        private Integer processorCount;
+
+        public Builder processorCount(Integer processorCount) {
+            this.processorCount = processorCount;
+            this.__explicitlySet__.add("processorCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
+        private String databaseId;
+
+        public Builder databaseId(String databaseId) {
+            this.databaseId = databaseId;
+            this.__explicitlySet__.add("databaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+        private String opsiPrivateEndpointId;
+
+        public Builder opsiPrivateEndpointId(String opsiPrivateEndpointId) {
+            this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+            this.__explicitlySet__.add("opsiPrivateEndpointId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PeComanagedManagedExternalDatabaseConfigurationSummary build() {
+            PeComanagedManagedExternalDatabaseConfigurationSummary __instance__ =
+                    new PeComanagedManagedExternalDatabaseConfigurationSummary(
+                            databaseInsightId,
+                            compartmentId,
+                            databaseName,
+                            databaseDisplayName,
+                            databaseType,
+                            databaseVersion,
+                            cdbName,
+                            definedTags,
+                            freeformTags,
+                            processorCount,
+                            databaseId,
+                            opsiPrivateEndpointId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PeComanagedManagedExternalDatabaseConfigurationSummary o) {
+            Builder copiedBuilder =
+                    databaseInsightId(o.getDatabaseInsightId())
+                            .compartmentId(o.getCompartmentId())
+                            .databaseName(o.getDatabaseName())
+                            .databaseDisplayName(o.getDatabaseDisplayName())
+                            .databaseType(o.getDatabaseType())
+                            .databaseVersion(o.getDatabaseVersion())
+                            .cdbName(o.getCdbName())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags())
+                            .processorCount(o.getProcessorCount())
+                            .databaseId(o.getDatabaseId())
+                            .opsiPrivateEndpointId(o.getOpsiPrivateEndpointId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PeComanagedManagedExternalDatabaseConfigurationSummary(
+            String databaseInsightId,
+            String compartmentId,
+            String databaseName,
+            String databaseDisplayName,
+            String databaseType,
+            String databaseVersion,
+            String cdbName,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, String> freeformTags,
+            Integer processorCount,
+            String databaseId,
+            String opsiPrivateEndpointId) {
+        super(
+                databaseInsightId,
+                compartmentId,
+                databaseName,
+                databaseDisplayName,
+                databaseType,
+                databaseVersion,
+                cdbName,
+                definedTags,
+                freeformTags,
+                processorCount);
+        this.databaseId = databaseId;
+        this.opsiPrivateEndpointId = opsiPrivateEndpointId;
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
+    String databaseId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the OPSI private endpoint
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("opsiPrivateEndpointId")
+    String opsiPrivateEndpointId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/UpdateDatabaseInsightDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/UpdateDatabaseInsightDetails.java
@@ -37,6 +37,10 @@ package com.oracle.bmc.opsi.model;
         name = "EM_MANAGED_EXTERNAL_DATABASE"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdatePeComanagedDatabaseInsightDetails.class,
+        name = "PE_COMANAGED_DATABASE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateAutonomousDatabaseInsightDetails.class,
         name = "AUTONOMOUS_DATABASE"
     )

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/UpdateOperationsInsightsPrivateEndpointDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/UpdateOperationsInsightsPrivateEndpointDetails.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * The details used to update a Operation Insights private endpoint.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOperationsInsightsPrivateEndpointDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOperationsInsightsPrivateEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOperationsInsightsPrivateEndpointDetails build() {
+            UpdateOperationsInsightsPrivateEndpointDetails __instance__ =
+                    new UpdateOperationsInsightsPrivateEndpointDetails(
+                            displayName, description, nsgIds, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOperationsInsightsPrivateEndpointDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .nsgIds(o.getNsgIds())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The display name of the private endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The description of the private endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security groups that the Private service accessed the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/UpdatePeComanagedDatabaseInsightDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/UpdatePeComanagedDatabaseInsightDetails.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * The information to be updated.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdatePeComanagedDatabaseInsightDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "entitySource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdatePeComanagedDatabaseInsightDetails extends UpdateDatabaseInsightDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdatePeComanagedDatabaseInsightDetails build() {
+            UpdatePeComanagedDatabaseInsightDetails __instance__ =
+                    new UpdatePeComanagedDatabaseInsightDetails(freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdatePeComanagedDatabaseInsightDetails o) {
+            Builder copiedBuilder =
+                    freeformTags(o.getFreeformTags()).definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdatePeComanagedDatabaseInsightDetails(
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+        super(freeformTags, definedTags);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ChangeOperationsInsightsPrivateEndpointCompartmentRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ChangeOperationsInsightsPrivateEndpointCompartmentRequest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.requests;
+
+import com.oracle.bmc.opsi.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/ChangeOperationsInsightsPrivateEndpointCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeOperationsInsightsPrivateEndpointCompartmentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ChangeOperationsInsightsPrivateEndpointCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.opsi.model
+                        .ChangeOperationsInsightsPrivateEndpointCompartmentDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Operation Insights private endpoint.
+     */
+    private String operationsInsightsPrivateEndpointId;
+
+    /**
+     * The details used to change the compartment of a private endpoint
+     */
+    private com.oracle.bmc.opsi.model.ChangeOperationsInsightsPrivateEndpointCompartmentDetails
+            changeOperationsInsightsPrivateEndpointCompartmentDetails;
+
+    /**
+     * Used for optimistic concurrency control. In the update or delete call for a resource, set the {@code if-match}
+     * parameter to the value of the etag from a previous get, create, or update response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request that can be retried in case of a timeout or
+     * server error without risk of executing the same action again. Retry tokens expire after 24
+     * hours.
+     * <p>
+     *Note:* Retry tokens can be invalidated before the 24 hour time limit due to conflicting
+     * operations, such as a resource being deleted or purged from the system.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.opsi.model.ChangeOperationsInsightsPrivateEndpointCompartmentDetails
+            getBody$() {
+        return changeOperationsInsightsPrivateEndpointCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeOperationsInsightsPrivateEndpointCompartmentRequest,
+                    com.oracle.bmc.opsi.model
+                            .ChangeOperationsInsightsPrivateEndpointCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeOperationsInsightsPrivateEndpointCompartmentRequest o) {
+            operationsInsightsPrivateEndpointId(o.getOperationsInsightsPrivateEndpointId());
+            changeOperationsInsightsPrivateEndpointCompartmentDetails(
+                    o.getChangeOperationsInsightsPrivateEndpointCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeOperationsInsightsPrivateEndpointCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeOperationsInsightsPrivateEndpointCompartmentRequest
+         */
+        public ChangeOperationsInsightsPrivateEndpointCompartmentRequest build() {
+            ChangeOperationsInsightsPrivateEndpointCompartmentRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.opsi.model.ChangeOperationsInsightsPrivateEndpointCompartmentDetails
+                        body) {
+            changeOperationsInsightsPrivateEndpointCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ChangePeComanagedDatabaseInsightRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ChangePeComanagedDatabaseInsightRequest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.requests;
+
+import com.oracle.bmc.opsi.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/ChangePeComanagedDatabaseInsightExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangePeComanagedDatabaseInsightRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ChangePeComanagedDatabaseInsightRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.opsi.model.ChangePeComanagedDatabaseInsightDetails> {
+
+    /**
+     * Unique database insight identifier
+     */
+    private String databaseInsightId;
+
+    /**
+     * The information to be updated.
+     */
+    private com.oracle.bmc.opsi.model.ChangePeComanagedDatabaseInsightDetails
+            changePeComanagedDatabaseInsightDetails;
+
+    /**
+     * Used for optimistic concurrency control. In the update or delete call for a resource, set the {@code if-match}
+     * parameter to the value of the etag from a previous get, create, or update response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request that can be retried in case of a timeout or
+     * server error without risk of executing the same action again. Retry tokens expire after 24
+     * hours.
+     * <p>
+     *Note:* Retry tokens can be invalidated before the 24 hour time limit due to conflicting
+     * operations, such as a resource being deleted or purged from the system.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.opsi.model.ChangePeComanagedDatabaseInsightDetails getBody$() {
+        return changePeComanagedDatabaseInsightDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangePeComanagedDatabaseInsightRequest,
+                    com.oracle.bmc.opsi.model.ChangePeComanagedDatabaseInsightDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangePeComanagedDatabaseInsightRequest o) {
+            databaseInsightId(o.getDatabaseInsightId());
+            changePeComanagedDatabaseInsightDetails(o.getChangePeComanagedDatabaseInsightDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangePeComanagedDatabaseInsightRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangePeComanagedDatabaseInsightRequest
+         */
+        public ChangePeComanagedDatabaseInsightRequest build() {
+            ChangePeComanagedDatabaseInsightRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.opsi.model.ChangePeComanagedDatabaseInsightDetails body) {
+            changePeComanagedDatabaseInsightDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/CreateOperationsInsightsPrivateEndpointRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/CreateOperationsInsightsPrivateEndpointRequest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.requests;
+
+import com.oracle.bmc.opsi.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/CreateOperationsInsightsPrivateEndpointExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateOperationsInsightsPrivateEndpointRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateOperationsInsightsPrivateEndpointRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.opsi.model.CreateOperationsInsightsPrivateEndpointDetails> {
+
+    /**
+     * Details to create a new private endpoint.
+     */
+    private com.oracle.bmc.opsi.model.CreateOperationsInsightsPrivateEndpointDetails
+            createOperationsInsightsPrivateEndpointDetails;
+
+    /**
+     * A token that uniquely identifies a request that can be retried in case of a timeout or
+     * server error without risk of executing the same action again. Retry tokens expire after 24
+     * hours.
+     * <p>
+     *Note:* Retry tokens can be invalidated before the 24 hour time limit due to conflicting
+     * operations, such as a resource being deleted or purged from the system.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.opsi.model.CreateOperationsInsightsPrivateEndpointDetails getBody$() {
+        return createOperationsInsightsPrivateEndpointDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateOperationsInsightsPrivateEndpointRequest,
+                    com.oracle.bmc.opsi.model.CreateOperationsInsightsPrivateEndpointDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateOperationsInsightsPrivateEndpointRequest o) {
+            createOperationsInsightsPrivateEndpointDetails(
+                    o.getCreateOperationsInsightsPrivateEndpointDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateOperationsInsightsPrivateEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateOperationsInsightsPrivateEndpointRequest
+         */
+        public CreateOperationsInsightsPrivateEndpointRequest build() {
+            CreateOperationsInsightsPrivateEndpointRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.opsi.model.CreateOperationsInsightsPrivateEndpointDetails body) {
+            createOperationsInsightsPrivateEndpointDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/DeleteOperationsInsightsPrivateEndpointRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/DeleteOperationsInsightsPrivateEndpointRequest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.requests;
+
+import com.oracle.bmc.opsi.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/DeleteOperationsInsightsPrivateEndpointExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteOperationsInsightsPrivateEndpointRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteOperationsInsightsPrivateEndpointRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Operation Insights private endpoint.
+     */
+    private String operationsInsightsPrivateEndpointId;
+
+    /**
+     * Used for optimistic concurrency control. In the update or delete call for a resource, set the {@code if-match}
+     * parameter to the value of the etag from a previous get, create, or update response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteOperationsInsightsPrivateEndpointRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteOperationsInsightsPrivateEndpointRequest o) {
+            operationsInsightsPrivateEndpointId(o.getOperationsInsightsPrivateEndpointId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteOperationsInsightsPrivateEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteOperationsInsightsPrivateEndpointRequest
+         */
+        public DeleteOperationsInsightsPrivateEndpointRequest build() {
+            DeleteOperationsInsightsPrivateEndpointRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/GetOperationsInsightsPrivateEndpointRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/GetOperationsInsightsPrivateEndpointRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.requests;
+
+import com.oracle.bmc.opsi.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/GetOperationsInsightsPrivateEndpointExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetOperationsInsightsPrivateEndpointRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetOperationsInsightsPrivateEndpointRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Operation Insights private endpoint.
+     */
+    private String operationsInsightsPrivateEndpointId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetOperationsInsightsPrivateEndpointRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetOperationsInsightsPrivateEndpointRequest o) {
+            operationsInsightsPrivateEndpointId(o.getOperationsInsightsPrivateEndpointId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetOperationsInsightsPrivateEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetOperationsInsightsPrivateEndpointRequest
+         */
+        public GetOperationsInsightsPrivateEndpointRequest build() {
+            GetOperationsInsightsPrivateEndpointRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListDatabaseConfigurationsRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListDatabaseConfigurationsRequest.java
@@ -73,6 +73,15 @@ public class ListDatabaseConfigurationsRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListDatabaseInsightsRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListDatabaseInsightsRequest.java
@@ -65,6 +65,15 @@ public class ListDatabaseInsightsRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;
@@ -226,6 +235,11 @@ public class ListDatabaseInsightsRequest
      *
      */
     private Boolean compartmentIdInSubtree;
+
+    /**
+     * Unique Operations Insights PrivateEndpoint identifier
+     */
+    private String opsiPrivateEndpointId;
 
     /**
      * Unique Oracle-assigned identifier for the request. If you need to contact
@@ -408,6 +422,7 @@ public class ListDatabaseInsightsRequest
             sortBy(o.getSortBy());
             exadataInsightId(o.getExadataInsightId());
             compartmentIdInSubtree(o.getCompartmentIdInSubtree());
+            opsiPrivateEndpointId(o.getOpsiPrivateEndpointId());
             opcRequestId(o.getOpcRequestId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListOperationsInsightsPrivateEndpointsRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListOperationsInsightsPrivateEndpointsRequest.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.requests;
+
+import com.oracle.bmc.opsi.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/ListOperationsInsightsPrivateEndpointsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListOperationsInsightsPrivateEndpointsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListOperationsInsightsPrivateEndpointsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * A filter to return only resources that match the entire display name.
+     */
+    private String displayName;
+
+    /**
+     * Unique Operations Insights PrivateEndpoint identifier
+     */
+    private String opsiPrivateEndpointId;
+
+    /**
+     * The option to filter OPSI private endpoints that can used for RAC. Should be used along with vcnId query parameter.
+     */
+    private Boolean isUsedForRacDbs;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     */
+    private String vcnId;
+
+    /**
+     * Lifecycle states
+     */
+    private java.util.List<
+                    com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointLifecycleState>
+            lifecycleState;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to
+     * return in a paginated "List" call.
+     * For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     * Example: {@code 50}
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the {@code opc-next-page} response header from
+     * the previous "List" call. For important details about how pagination works,
+     * see [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either ascending ({@code ASC}) or descending ({@code DESC}).
+     *
+     */
+    private com.oracle.bmc.opsi.model.SortOrder sortOrder;
+
+    /**
+     * The field to sort private endpoints.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort private endpoints.
+     *
+     **/
+    public enum SortBy {
+        TimeCreated("timeCreated"),
+        Id("id"),
+        DisplayName("displayName"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * A flag to search all resources within a given compartment and all sub-compartments.
+     *
+     */
+    private Boolean compartmentIdInSubtree;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListOperationsInsightsPrivateEndpointsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        private java.util.List<
+                        com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointLifecycleState>
+                lifecycleState = null;
+
+        /**
+         * Lifecycle states
+         * @return this builder instance
+         */
+        public Builder lifecycleState(
+                java.util.List<
+                                com.oracle.bmc.opsi.model
+                                        .OperationsInsightsPrivateEndpointLifecycleState>
+                        lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            return this;
+        }
+
+        /**
+         * Singular setter. Lifecycle states
+         * @return this builder instance
+         */
+        public Builder lifecycleState(
+                OperationsInsightsPrivateEndpointLifecycleState singularValue) {
+            return this.lifecycleState(java.util.Arrays.asList(singularValue));
+        }
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListOperationsInsightsPrivateEndpointsRequest o) {
+            compartmentId(o.getCompartmentId());
+            displayName(o.getDisplayName());
+            opsiPrivateEndpointId(o.getOpsiPrivateEndpointId());
+            isUsedForRacDbs(o.getIsUsedForRacDbs());
+            vcnId(o.getVcnId());
+            lifecycleState(o.getLifecycleState());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            compartmentIdInSubtree(o.getCompartmentIdInSubtree());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListOperationsInsightsPrivateEndpointsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListOperationsInsightsPrivateEndpointsRequest
+         */
+        public ListOperationsInsightsPrivateEndpointsRequest build() {
+            ListOperationsInsightsPrivateEndpointsRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceCapacityTrendRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceCapacityTrendRequest.java
@@ -79,6 +79,15 @@ public class SummarizeDatabaseInsightResourceCapacityTrendRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceForecastTrendRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceForecastTrendRequest.java
@@ -79,6 +79,15 @@ public class SummarizeDatabaseInsightResourceForecastTrendRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceStatisticsRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceStatisticsRequest.java
@@ -79,6 +79,15 @@ public class SummarizeDatabaseInsightResourceStatisticsRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceUsageRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceUsageRequest.java
@@ -79,6 +79,15 @@ public class SummarizeDatabaseInsightResourceUsageRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceUsageTrendRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceUsageTrendRequest.java
@@ -79,6 +79,15 @@ public class SummarizeDatabaseInsightResourceUsageTrendRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceUtilizationInsightRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeDatabaseInsightResourceUtilizationInsightRequest.java
@@ -79,6 +79,15 @@ public class SummarizeDatabaseInsightResourceUtilizationInsightRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeSqlInsightsRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeSqlInsightsRequest.java
@@ -44,6 +44,15 @@ public class SummarizeSqlInsightsRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeSqlStatisticsRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeSqlStatisticsRequest.java
@@ -44,6 +44,15 @@ public class SummarizeSqlStatisticsRequest
         AtpD("ATP-D"),
         ExternalPdb("EXTERNAL-PDB"),
         ExternalNoncdb("EXTERNAL-NONCDB"),
+        ComanagedVmCdb("COMANAGED-VM-CDB"),
+        ComanagedVmPdb("COMANAGED-VM-PDB"),
+        ComanagedVmNoncdb("COMANAGED-VM-NONCDB"),
+        ComanagedBmCdb("COMANAGED-BM-CDB"),
+        ComanagedBmPdb("COMANAGED-BM-PDB"),
+        ComanagedBmNoncdb("COMANAGED-BM-NONCDB"),
+        ComanagedExacsCdb("COMANAGED-EXACS-CDB"),
+        ComanagedExacsPdb("COMANAGED-EXACS-PDB"),
+        ComanagedExacsNoncdb("COMANAGED-EXACS-NONCDB"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/UpdateOperationsInsightsPrivateEndpointRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/UpdateOperationsInsightsPrivateEndpointRequest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.requests;
+
+import com.oracle.bmc.opsi.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/UpdateOperationsInsightsPrivateEndpointExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateOperationsInsightsPrivateEndpointRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateOperationsInsightsPrivateEndpointRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.opsi.model.UpdateOperationsInsightsPrivateEndpointDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Operation Insights private endpoint.
+     */
+    private String operationsInsightsPrivateEndpointId;
+
+    /**
+     * The details used to update a private endpoint.
+     */
+    private com.oracle.bmc.opsi.model.UpdateOperationsInsightsPrivateEndpointDetails
+            updateOperationsInsightsPrivateEndpointDetails;
+
+    /**
+     * Used for optimistic concurrency control. In the update or delete call for a resource, set the {@code if-match}
+     * parameter to the value of the etag from a previous get, create, or update response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.opsi.model.UpdateOperationsInsightsPrivateEndpointDetails getBody$() {
+        return updateOperationsInsightsPrivateEndpointDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateOperationsInsightsPrivateEndpointRequest,
+                    com.oracle.bmc.opsi.model.UpdateOperationsInsightsPrivateEndpointDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateOperationsInsightsPrivateEndpointRequest o) {
+            operationsInsightsPrivateEndpointId(o.getOperationsInsightsPrivateEndpointId());
+            updateOperationsInsightsPrivateEndpointDetails(
+                    o.getUpdateOperationsInsightsPrivateEndpointDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateOperationsInsightsPrivateEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateOperationsInsightsPrivateEndpointRequest
+         */
+        public UpdateOperationsInsightsPrivateEndpointRequest build() {
+            UpdateOperationsInsightsPrivateEndpointRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.opsi.model.UpdateOperationsInsightsPrivateEndpointDetails body) {
+            updateOperationsInsightsPrivateEndpointDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/ChangeOperationsInsightsPrivateEndpointCompartmentResponse.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/ChangeOperationsInsightsPrivateEndpointCompartmentResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.responses;
+
+import com.oracle.bmc.opsi.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ChangeOperationsInsightsPrivateEndpointCompartmentResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private ChangeOperationsInsightsPrivateEndpointCompartmentResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeOperationsInsightsPrivateEndpointCompartmentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public ChangeOperationsInsightsPrivateEndpointCompartmentResponse build() {
+            return new ChangeOperationsInsightsPrivateEndpointCompartmentResponse(
+                    __httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/ChangePeComanagedDatabaseInsightResponse.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/ChangePeComanagedDatabaseInsightResponse.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.responses;
+
+import com.oracle.bmc.opsi.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ChangePeComanagedDatabaseInsightResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private ChangePeComanagedDatabaseInsightResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangePeComanagedDatabaseInsightResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public ChangePeComanagedDatabaseInsightResponse build() {
+            return new ChangePeComanagedDatabaseInsightResponse(
+                    __httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/CreateOperationsInsightsPrivateEndpointResponse.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/CreateOperationsInsightsPrivateEndpointResponse.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.responses;
+
+import com.oracle.bmc.opsi.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateOperationsInsightsPrivateEndpointResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * URI of the resource
+     */
+    private String location;
+
+    /**
+     * URI of the resource
+     */
+    private String contentLocation;
+
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned OperationsInsightsPrivateEndpoint instance.
+     */
+    private com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpoint
+            operationsInsightsPrivateEndpoint;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcWorkRequestId",
+        "opcRequestId",
+        "location",
+        "contentLocation",
+        "etag",
+        "operationsInsightsPrivateEndpoint"
+    })
+    private CreateOperationsInsightsPrivateEndpointResponse(
+            int __httpStatusCode__,
+            String opcWorkRequestId,
+            String opcRequestId,
+            String location,
+            String contentLocation,
+            String etag,
+            com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpoint
+                    operationsInsightsPrivateEndpoint) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+        this.location = location;
+        this.contentLocation = contentLocation;
+        this.etag = etag;
+        this.operationsInsightsPrivateEndpoint = operationsInsightsPrivateEndpoint;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateOperationsInsightsPrivateEndpointResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            location(o.getLocation());
+            contentLocation(o.getContentLocation());
+            etag(o.getEtag());
+            operationsInsightsPrivateEndpoint(o.getOperationsInsightsPrivateEndpoint());
+
+            return this;
+        }
+
+        public CreateOperationsInsightsPrivateEndpointResponse build() {
+            return new CreateOperationsInsightsPrivateEndpointResponse(
+                    __httpStatusCode__,
+                    opcWorkRequestId,
+                    opcRequestId,
+                    location,
+                    contentLocation,
+                    etag,
+                    operationsInsightsPrivateEndpoint);
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/DeleteOperationsInsightsPrivateEndpointResponse.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/DeleteOperationsInsightsPrivateEndpointResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.responses;
+
+import com.oracle.bmc.opsi.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteOperationsInsightsPrivateEndpointResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private DeleteOperationsInsightsPrivateEndpointResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteOperationsInsightsPrivateEndpointResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public DeleteOperationsInsightsPrivateEndpointResponse build() {
+            return new DeleteOperationsInsightsPrivateEndpointResponse(
+                    __httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/GetOperationsInsightsPrivateEndpointResponse.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/GetOperationsInsightsPrivateEndpointResponse.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.responses;
+
+import com.oracle.bmc.opsi.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetOperationsInsightsPrivateEndpointResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned OperationsInsightsPrivateEndpoint instance.
+     */
+    private com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpoint
+            operationsInsightsPrivateEndpoint;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "etag",
+        "opcRequestId",
+        "operationsInsightsPrivateEndpoint"
+    })
+    private GetOperationsInsightsPrivateEndpointResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpoint
+                    operationsInsightsPrivateEndpoint) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.operationsInsightsPrivateEndpoint = operationsInsightsPrivateEndpoint;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetOperationsInsightsPrivateEndpointResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            operationsInsightsPrivateEndpoint(o.getOperationsInsightsPrivateEndpoint());
+
+            return this;
+        }
+
+        public GetOperationsInsightsPrivateEndpointResponse build() {
+            return new GetOperationsInsightsPrivateEndpointResponse(
+                    __httpStatusCode__, etag, opcRequestId, operationsInsightsPrivateEndpoint);
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/ListOperationsInsightsPrivateEndpointsResponse.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/ListOperationsInsightsPrivateEndpointsResponse.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.responses;
+
+import com.oracle.bmc.opsi.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListOperationsInsightsPrivateEndpointsResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the {@code page} parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned OperationsInsightsPrivateEndpointCollection instance.
+     */
+    private com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointCollection
+            operationsInsightsPrivateEndpointCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "operationsInsightsPrivateEndpointCollection"
+    })
+    private ListOperationsInsightsPrivateEndpointsResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            com.oracle.bmc.opsi.model.OperationsInsightsPrivateEndpointCollection
+                    operationsInsightsPrivateEndpointCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.operationsInsightsPrivateEndpointCollection =
+                operationsInsightsPrivateEndpointCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListOperationsInsightsPrivateEndpointsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            operationsInsightsPrivateEndpointCollection(
+                    o.getOperationsInsightsPrivateEndpointCollection());
+
+            return this;
+        }
+
+        public ListOperationsInsightsPrivateEndpointsResponse build() {
+            return new ListOperationsInsightsPrivateEndpointsResponse(
+                    __httpStatusCode__,
+                    opcRequestId,
+                    opcNextPage,
+                    operationsInsightsPrivateEndpointCollection);
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/UpdateOperationsInsightsPrivateEndpointResponse.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/UpdateOperationsInsightsPrivateEndpointResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.responses;
+
+import com.oracle.bmc.opsi.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateOperationsInsightsPrivateEndpointResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private UpdateOperationsInsightsPrivateEndpointResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateOperationsInsightsPrivateEndpointResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public UpdateOperationsInsightsPrivateEndpointResponse build() {
+            return new UpdateOperationsInsightsPrivateEndpointResponse(
+                    __httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ospgateway/pom.xml
+++ b/bmc-ospgateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ospgateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubbillingschedule/pom.xml
+++ b/bmc-osubbillingschedule/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osuborganizationsubscription/pom.xml
+++ b/bmc-osuborganizationsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubsubscription/pom.xml
+++ b/bmc-osubsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubusage/pom.xml
+++ b/bmc-osubusage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubusage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemanagerproxy/pom.xml
+++ b/bmc-servicemanagerproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-threatintelligence/pom.xml
+++ b/bmc-threatintelligence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-threatintelligence</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usage/pom.xml
+++ b/bmc-usage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-visualbuilder/pom.xml
+++ b/bmc-visualbuilder/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-visualbuilder</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.19.1</version>
+    <version>2.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.19.1</version>
+      <version>2.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.19.1</version>
+  <version>2.20.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for getting the storage utilization of a deployment on deployment list and get operations in the GoldenGate service

- Support for virtual machines, bare metal machines, and Exadata databases with private endpoints in the Operations Insights service

- Support for setting deletion policies on database systems in the MySQL Database service



### Breaking Changes

- Support for retries by default on operations in the Data Labeling service (data plane and control plane)
