### PR TITLE
Could com.oracle.oci.sdk:oci-java-sdk-circuitbreaker:2.19.0 drop off redundant dependencies?

### DIFF
--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -36,22 +36,62 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>listenablefuture</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.github.resilience4j</groupId>
       <artifactId>resilience4j-circuitbreaker</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.vavr</groupId>
+          <artifactId>vavr-match</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.glassfish.hk2.external</groupId>
+          <artifactId>jakarta.inject</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jakarta.ws.rs</groupId>
+          <artifactId>jakarta.ws.rs-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
+      <exclusions>
+        <exclusion>
+           <groupId>org.glassfish.hk2.external</groupId>
+           <artifactId>jakarta.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Test Time Dependencies -->
     <dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_com.oracle.oci.sdk:oci-java-sdk-circuitbreaker:2.19.0_** introduced **_38_** dependencies. However, among them, **_7_** libraries (**_18%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.google.code.findbugs:jsr305:jar:3.0.2:compile
org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile
io.vavr:vavr-match:jar:0.10.2:compile
com.google.errorprone:error_prone_annotations:jar:2.7.1:compile
## Outdated dependencies
org.glassfish.hk2.external:jakarta.inject:2.6.1 (**_1436_** days without maintenance)
com.google.j2objc:j2objc-annotations:1.3 (**_2383_** days without maintenance)

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, 2 of the redundant dependencies **_com.google.code.findbugs:jsr305:jar:3.0.2:compile, org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_com.oracle.oci.sdk:oci-java-sdk-circuitbreaker:2.19.0_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.oracle.oci.sdk:oci-java-sdk-circuitbreaker:2.19.0_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/160566923-f5906836-9ac3-4a3c-a78d-f7498c64b469.png)