### PR TITLE
Releasing version 2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.21.0 - 2022-03-29
+### Added
+- Support for returning the number of network ports as part of listing shapes in the Compute service
+- Support for Java runtime removal and custom logs in the Java Management service
+- Support for new parameters for BGP admin state and enabling/disabling BFD in the Networking service
+- Support for private OKE clusters and blue-green deployments in the DevOps service
+- Support for international customers to consume and launch third-party paid listings in the Marketplace service
+- Support for additional fields on entities, attributes, and folders in the Data Catalog service
+
+### Breaking Changes
+- Support for retries by default on operations in the Marketplace service
+
 ## 2.20.0 - 2022-03-22
 ### Added
 - Support for getting the storage utilization of a deployment on deployment list and get operations in the GoldenGate service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aispeech/pom.xml
+++ b/bmc-aispeech/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aispeech</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aivision/pom.xml
+++ b/bmc-aivision/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aivision</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-appmgmtcontrol/pom.xml
+++ b/bmc-appmgmtcontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,636 +19,636 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificates</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usage</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasetools</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ospgateway</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identitydataplane</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-visualbuilder</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubusage</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubsubscription</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dashboardservice</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-threatintelligence</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aivision</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aispeech</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataconnectivity</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificates/pom.xml
+++ b/bmc-certificates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificates</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificatesmanagement/pom.xml
+++ b/bmc-certificatesmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolume.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolume.java
@@ -355,15 +355,17 @@ public class BootVolume {
     /**
      * The number of volume performance units (VPUs) that will be applied to this boot volume per GB,
      * representing the Block Volume service's elastic performance options.
-     * See [Block Volume Elastic Performance](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
+     * See [Block Volume Performance Levels](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
      * <p>
      * Allowed values:
      * <p>
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
+     *
+     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
-     * For performance autotune enabled volumes, It would be the Default(Minimum) VPUs/GB.
+     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateBootVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateBootVolumeDetails.java
@@ -254,15 +254,17 @@ public class CreateBootVolumeDetails {
     /**
      * The number of volume performance units (VPUs) that will be applied to this volume per GB,
      * representing the Block Volume service's elastic performance options.
-     * See [Block Volume Elastic Performance](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
+     * See [Block Volume Performance Levels](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
      * <p>
      * Allowed values:
      * <p>
-     * {@code 10}: Represents Balanced option.
+     * {@code 10}: Represents the Balanced option.
      * <p>
-     * {@code 20}: Represents Higher Performance option.
-     * <p>
-     * For performance autotune enabled volumes, It would be the Default(Minimum) VPUs/GB.
+     * {@code 20}: Represents the Higher Performance option.
+     *
+     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
+     *
+     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVirtualCircuitDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVirtualCircuitDetails.java
@@ -63,6 +63,24 @@ public class CreateVirtualCircuitDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("bgpAdminState")
+        private BgpAdminState bgpAdminState;
+
+        public Builder bgpAdminState(BgpAdminState bgpAdminState) {
+            this.bgpAdminState = bgpAdminState;
+            this.__explicitlySet__.add("bgpAdminState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBfdEnabled")
+        private Boolean isBfdEnabled;
+
+        public Builder isBfdEnabled(Boolean isBfdEnabled) {
+            this.isBfdEnabled = isBfdEnabled;
+            this.__explicitlySet__.add("isBfdEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("customerBgpAsn")
         private Integer customerBgpAsn;
 
@@ -201,6 +219,8 @@ public class CreateVirtualCircuitDetails {
                             compartmentId,
                             crossConnectMappings,
                             routingPolicy,
+                            bgpAdminState,
+                            isBfdEnabled,
                             customerBgpAsn,
                             customerAsn,
                             definedTags,
@@ -226,6 +246,8 @@ public class CreateVirtualCircuitDetails {
                             .compartmentId(o.getCompartmentId())
                             .crossConnectMappings(o.getCrossConnectMappings())
                             .routingPolicy(o.getRoutingPolicy())
+                            .bgpAdminState(o.getBgpAdminState())
+                            .isBfdEnabled(o.getIsBfdEnabled())
                             .customerBgpAsn(o.getCustomerBgpAsn())
                             .customerAsn(o.getCustomerAsn())
                             .definedTags(o.getDefinedTags())
@@ -323,6 +345,55 @@ public class CreateVirtualCircuitDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routingPolicy")
     java.util.List<RoutingPolicy> routingPolicy;
+    /**
+     * Set to ENABLED to activate the bgp session of virtual circuit, DISABLED to deactivate.
+     *
+     **/
+    public enum BgpAdminState {
+        Enabled("ENABLED"),
+        Disabled("DISABLED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, BgpAdminState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (BgpAdminState v : BgpAdminState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        BgpAdminState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static BgpAdminState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid BgpAdminState: " + key);
+        }
+    };
+    /**
+     * Set to ENABLED to activate the bgp session of virtual circuit, DISABLED to deactivate.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bgpAdminState")
+    BgpAdminState bgpAdminState;
+
+    /**
+     * Set to true to enable BFD for ipv4 Bgp Peering, false to disable. If not set, default is false
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBfdEnabled")
+    Boolean isBfdEnabled;
 
     /**
      * Deprecated. Instead use {@code customerAsn}.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeDetails.java
@@ -272,7 +272,7 @@ public class CreateVolumeDetails {
     /**
      * The number of volume performance units (VPUs) that will be applied to this volume per GB,
      * representing the Block Volume service's elastic performance options.
-     * See [Block Volume Elastic Performance](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
+     * See [Block Volume Performance Levels](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
      * <p>
      * Allowed values:
      * <p>
@@ -281,8 +281,10 @@ public class CreateVolumeDetails {
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
+     *
+     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
-     * For performance autotune enabled volumes, It would be the Default(Minimum) VPUs/GB.
+     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Shape.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Shape.java
@@ -83,6 +83,15 @@ public class Shape {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkPorts")
+        private Integer networkPorts;
+
+        public Builder networkPorts(Integer networkPorts) {
+            this.networkPorts = networkPorts;
+            this.__explicitlySet__.add("networkPorts");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("networkingBandwidthInGbps")
         private Float networkingBandwidthInGbps;
 
@@ -143,6 +152,24 @@ public class Shape {
         public Builder localDiskDescription(String localDiskDescription) {
             this.localDiskDescription = localDiskDescription;
             this.__explicitlySet__.add("localDiskDescription");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rdmaPorts")
+        private Integer rdmaPorts;
+
+        public Builder rdmaPorts(Integer rdmaPorts) {
+            this.rdmaPorts = rdmaPorts;
+            this.__explicitlySet__.add("rdmaPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rdmaBandwidthInGbps")
+        private Integer rdmaBandwidthInGbps;
+
+        public Builder rdmaBandwidthInGbps(Integer rdmaBandwidthInGbps) {
+            this.rdmaBandwidthInGbps = rdmaBandwidthInGbps;
+            this.__explicitlySet__.add("rdmaBandwidthInGbps");
             return this;
         }
 
@@ -278,6 +305,7 @@ public class Shape {
                             processorDescription,
                             ocpus,
                             memoryInGBs,
+                            networkPorts,
                             networkingBandwidthInGbps,
                             maxVnicAttachments,
                             gpus,
@@ -285,6 +313,8 @@ public class Shape {
                             localDisks,
                             localDisksTotalSizeInGBs,
                             localDiskDescription,
+                            rdmaPorts,
+                            rdmaBandwidthInGbps,
                             isLiveMigrationSupported,
                             ocpuOptions,
                             memoryOptions,
@@ -311,6 +341,7 @@ public class Shape {
                             .processorDescription(o.getProcessorDescription())
                             .ocpus(o.getOcpus())
                             .memoryInGBs(o.getMemoryInGBs())
+                            .networkPorts(o.getNetworkPorts())
                             .networkingBandwidthInGbps(o.getNetworkingBandwidthInGbps())
                             .maxVnicAttachments(o.getMaxVnicAttachments())
                             .gpus(o.getGpus())
@@ -318,6 +349,8 @@ public class Shape {
                             .localDisks(o.getLocalDisks())
                             .localDisksTotalSizeInGBs(o.getLocalDisksTotalSizeInGBs())
                             .localDiskDescription(o.getLocalDiskDescription())
+                            .rdmaPorts(o.getRdmaPorts())
+                            .rdmaBandwidthInGbps(o.getRdmaBandwidthInGbps())
                             .isLiveMigrationSupported(o.getIsLiveMigrationSupported())
                             .ocpuOptions(o.getOcpuOptions())
                             .memoryOptions(o.getMemoryOptions())
@@ -435,6 +468,13 @@ public class Shape {
     Float memoryInGBs;
 
     /**
+     * The number of physical network interface card (NIC) ports available for this shape.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("networkPorts")
+    Integer networkPorts;
+
+    /**
      * The networking bandwidth available for this shape, in gigabits per second.
      *
      **/
@@ -488,6 +528,23 @@ public class Shape {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("localDiskDescription")
     String localDiskDescription;
+
+    /**
+     * The number of networking ports available for the remote direct memory access (RDMA) network between nodes in
+     * a high performance computing (HPC) cluster network. If the shape does not support cluster networks, this
+     * value is {@code 0}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rdmaPorts")
+    Integer rdmaPorts;
+
+    /**
+     * The networking bandwidth available for the remote direct memory access (RDMA) network for this shape, in
+     * gigabits per second.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rdmaBandwidthInGbps")
+    Integer rdmaBandwidthInGbps;
 
     /**
      * Whether live migration is supported for this shape.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeDetails.java
@@ -168,13 +168,15 @@ public class UpdateBootVolumeDetails {
     /**
      * The number of volume performance units (VPUs) that will be applied to this volume per GB,
      * representing the Block Volume service's elastic performance options.
-     * See [Block Volume Elastic Performance](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
+     * See [Block Volume Performance Levels](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
      * <p>
      * Allowed values:
      * <p>
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
+     *
+     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
      * For performance autotune enabled volumes, It would be the Default(Minimum) VPUs/GB.
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVirtualCircuitDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVirtualCircuitDetails.java
@@ -54,6 +54,24 @@ public class UpdateVirtualCircuitDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("bgpAdminState")
+        private BgpAdminState bgpAdminState;
+
+        public Builder bgpAdminState(BgpAdminState bgpAdminState) {
+            this.bgpAdminState = bgpAdminState;
+            this.__explicitlySet__.add("bgpAdminState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBfdEnabled")
+        private Boolean isBfdEnabled;
+
+        public Builder isBfdEnabled(Boolean isBfdEnabled) {
+            this.isBfdEnabled = isBfdEnabled;
+            this.__explicitlySet__.add("isBfdEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("customerBgpAsn")
         private Integer customerBgpAsn;
 
@@ -154,6 +172,8 @@ public class UpdateVirtualCircuitDetails {
                             bandwidthShapeName,
                             crossConnectMappings,
                             routingPolicy,
+                            bgpAdminState,
+                            isBfdEnabled,
                             customerBgpAsn,
                             customerAsn,
                             definedTags,
@@ -174,6 +194,8 @@ public class UpdateVirtualCircuitDetails {
                     bandwidthShapeName(o.getBandwidthShapeName())
                             .crossConnectMappings(o.getCrossConnectMappings())
                             .routingPolicy(o.getRoutingPolicy())
+                            .bgpAdminState(o.getBgpAdminState())
+                            .isBfdEnabled(o.getIsBfdEnabled())
                             .customerBgpAsn(o.getCustomerBgpAsn())
                             .customerAsn(o.getCustomerAsn())
                             .definedTags(o.getDefinedTags())
@@ -263,6 +285,55 @@ public class UpdateVirtualCircuitDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routingPolicy")
     java.util.List<RoutingPolicy> routingPolicy;
+    /**
+     * Set to ENABLED to activate the bgp session of virtual circuit, DISABLED to deactivate.
+     *
+     **/
+    public enum BgpAdminState {
+        Enabled("ENABLED"),
+        Disabled("DISABLED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, BgpAdminState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (BgpAdminState v : BgpAdminState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        BgpAdminState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static BgpAdminState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid BgpAdminState: " + key);
+        }
+    };
+    /**
+     * Set to ENABLED to activate the bgp session of virtual circuit, DISABLED to deactivate.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bgpAdminState")
+    BgpAdminState bgpAdminState;
+
+    /**
+     * Set to true to enable BFD for ipv4 Bgp Peering, false to disable. If not set, default is false
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBfdEnabled")
+    Boolean isBfdEnabled;
 
     /**
      * Deprecated. Instead use {@code customerAsn}.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeDetails.java
@@ -162,7 +162,7 @@ public class UpdateVolumeDetails {
     /**
      * The number of volume performance units (VPUs) that will be applied to this volume per GB,
      * representing the Block Volume service's elastic performance options.
-     * See [Block Volume Elastic Performance](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
+     * See [Block Volume Performance Levels](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
      * <p>
      * Allowed values:
      * <p>
@@ -171,8 +171,10 @@ public class UpdateVolumeDetails {
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
+     *
+     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
-     * For performance autotune enabled volumes, It would be the Default(Minimum) VPUs/GB.
+     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuit.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuit.java
@@ -107,6 +107,24 @@ public class VirtualCircuit {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("bgpAdminState")
+        private BgpAdminState bgpAdminState;
+
+        public Builder bgpAdminState(BgpAdminState bgpAdminState) {
+            this.bgpAdminState = bgpAdminState;
+            this.__explicitlySet__.add("bgpAdminState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBfdEnabled")
+        private Boolean isBfdEnabled;
+
+        public Builder isBfdEnabled(Boolean isBfdEnabled) {
+            this.isBfdEnabled = isBfdEnabled;
+            this.__explicitlySet__.add("isBfdEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("customerBgpAsn")
         private Integer customerBgpAsn;
 
@@ -310,6 +328,8 @@ public class VirtualCircuit {
                             compartmentId,
                             crossConnectMappings,
                             routingPolicy,
+                            bgpAdminState,
+                            isBfdEnabled,
                             customerBgpAsn,
                             customerAsn,
                             definedTags,
@@ -345,6 +365,8 @@ public class VirtualCircuit {
                             .compartmentId(o.getCompartmentId())
                             .crossConnectMappings(o.getCrossConnectMappings())
                             .routingPolicy(o.getRoutingPolicy())
+                            .bgpAdminState(o.getBgpAdminState())
+                            .isBfdEnabled(o.getIsBfdEnabled())
                             .customerBgpAsn(o.getCustomerBgpAsn())
                             .customerAsn(o.getCustomerAsn())
                             .definedTags(o.getDefinedTags())
@@ -618,6 +640,66 @@ public class VirtualCircuit {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routingPolicy")
     java.util.List<RoutingPolicy> routingPolicy;
+    /**
+     * Set to ENABLED to activate the  bgp session of virtual circuit, DISABLED to deactivate.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum BgpAdminState {
+        Enabled("ENABLED"),
+        Disabled("DISABLED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, BgpAdminState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (BgpAdminState v : BgpAdminState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        BgpAdminState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static BgpAdminState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'BgpAdminState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Set to ENABLED to activate the  bgp session of virtual circuit, DISABLED to deactivate.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bgpAdminState")
+    BgpAdminState bgpAdminState;
+
+    /**
+     * Set to true to enable BFD for ipv4 Bgp Peering, false to disable. If not set, default is false
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBfdEnabled")
+    Boolean isBfdEnabled;
 
     /**
      * Deprecated. Instead use {@code customerAsn}.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Volume.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Volume.java
@@ -400,7 +400,7 @@ public class Volume {
     /**
      * The number of volume performance units (VPUs) that will be applied to this volume per GB,
      * representing the Block Volume service's elastic performance options.
-     * See [Block Volume Elastic Performance](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
+     * See [Block Volume Performance Levels](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
      * <p>
      * Allowed values:
      * <p>
@@ -409,8 +409,10 @@ public class Volume {
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
+     *
+     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
-     * For performance autotune enabled volumes, It would be the Default(Minimum) VPUs/GB.
+     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeletePrivateIpRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeletePrivateIpRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.core.model.*;
 public class DeletePrivateIpRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the private IP.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the private IP or IPv6.
      */
     private String privateIpId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetPrivateIpRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetPrivateIpRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.core.model.*;
 public class GetPrivateIpRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the private IP.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the private IP or IPv6.
      */
     private String privateIpId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdatePrivateIpRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdatePrivateIpRequest.java
@@ -22,7 +22,7 @@ public class UpdatePrivateIpRequest
                 com.oracle.bmc.core.model.UpdatePrivateIpDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the private IP.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the private IP or IPv6.
      */
     private String privateIpId;
 

--- a/bmc-dashboardservice/pom.xml
+++ b/bmc-dashboardservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dashboardservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasetools/pom.xml
+++ b/bmc-databasetools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasetools</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateAttributeDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateAttributeDetails.java
@@ -171,6 +171,15 @@ public class CreateAttributeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("typeKey")
+        private String typeKey;
+
+        public Builder typeKey(String typeKey) {
+            this.typeKey = typeKey;
+            this.__explicitlySet__.add("typeKey");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -202,6 +211,7 @@ public class CreateAttributeDetails {
                             externalDatatypeEntityKey,
                             externalParentAttributeKey,
                             customPropertyMembers,
+                            typeKey,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -226,6 +236,7 @@ public class CreateAttributeDetails {
                             .externalDatatypeEntityKey(o.getExternalDatatypeEntityKey())
                             .externalParentAttributeKey(o.getExternalParentAttributeKey())
                             .customPropertyMembers(o.getCustomPropertyMembers())
+                            .typeKey(o.getTypeKey())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -340,6 +351,12 @@ public class CreateAttributeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
     java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+    /**
+     * Type key of the object. Type keys can be found via the '/types' endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("typeKey")
+    String typeKey;
 
     /**
      * A map of maps that contains the properties which are specific to the attribute type. Each attribute type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateFolderDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateFolderDetails.java
@@ -108,6 +108,15 @@ public class CreateFolderDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("typeKey")
+        private String typeKey;
+
+        public Builder typeKey(String typeKey) {
+            this.typeKey = typeKey;
+            this.__explicitlySet__.add("typeKey");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -122,7 +131,8 @@ public class CreateFolderDetails {
                             parentFolderKey,
                             timeExternal,
                             lastJobKey,
-                            harvestStatus);
+                            harvestStatus,
+                            typeKey);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -138,7 +148,8 @@ public class CreateFolderDetails {
                             .parentFolderKey(o.getParentFolderKey())
                             .timeExternal(o.getTimeExternal())
                             .lastJobKey(o.getLastJobKey())
-                            .harvestStatus(o.getHarvestStatus());
+                            .harvestStatus(o.getHarvestStatus())
+                            .typeKey(o.getTypeKey());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -215,6 +226,12 @@ public class CreateFolderDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("harvestStatus")
     HarvestStatus harvestStatus;
+
+    /**
+     * Type key of the object. Type keys can be found via the '/types' endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("typeKey")
+    String typeKey;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateJobDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateJobDetails.java
@@ -142,9 +142,8 @@ public class CreateJobDetails {
     String description;
 
     /**
-     * Schedule specified in the cron expression format that has seven fields for second, minute, hour, day-of-month, month, day-of-week, year.
-     * It can also include special characters like * for all and ? for any. There are also pre-defined schedules that can be specified using
-     * special strings. For example, @hourly will run the job every hour.
+     * Interval on which the job will be run. Value is specified as a cron-supported time specification "nickname".
+     * The following subset of those is supported: @monthly, @weekly, @daily, @hourly.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scheduleCronExpression")

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Entity.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Entity.java
@@ -261,6 +261,15 @@ public class Entity {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStorageUrl")
+        private String objectStorageUrl;
+
+        public Builder objectStorageUrl(String objectStorageUrl) {
+            this.objectStorageUrl = objectStorageUrl;
+            this.__explicitlySet__.add("objectStorageUrl");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
         private java.util.List<CustomPropertyGetUsage> customPropertyMembers;
 
@@ -312,6 +321,7 @@ public class Entity {
                             lastJobKey,
                             typeKey,
                             uri,
+                            objectStorageUrl,
                             customPropertyMembers,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -347,6 +357,7 @@ public class Entity {
                             .lastJobKey(o.getLastJobKey())
                             .typeKey(o.getTypeKey())
                             .uri(o.getUri())
+                            .objectStorageUrl(o.getObjectStorageUrl())
                             .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties());
 
@@ -525,6 +536,12 @@ public class Entity {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
     String uri;
+
+    /**
+     * URL of the data entity in the object store.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStorageUrl")
+    String objectStorageUrl;
 
     /**
      * The list of customized properties along with the values for this object

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntitySummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntitySummary.java
@@ -189,6 +189,15 @@ public class EntitySummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStorageUrl")
+        private String objectStorageUrl;
+
+        public Builder objectStorageUrl(String objectStorageUrl) {
+            this.objectStorageUrl = objectStorageUrl;
+            this.__explicitlySet__.add("objectStorageUrl");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleState lifecycleState;
 
@@ -231,6 +240,7 @@ public class EntitySummary {
                             timeUpdated,
                             updatedById,
                             uri,
+                            objectStorageUrl,
                             lifecycleState,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -258,6 +268,7 @@ public class EntitySummary {
                             .timeUpdated(o.getTimeUpdated())
                             .updatedById(o.getUpdatedById())
                             .uri(o.getUri())
+                            .objectStorageUrl(o.getObjectStorageUrl())
                             .lifecycleState(o.getLifecycleState())
                             .properties(o.getProperties());
 
@@ -387,6 +398,12 @@ public class EntitySummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
     String uri;
+
+    /**
+     * URL of the data entity in the object store.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStorageUrl")
+    String objectStorageUrl;
 
     /**
      * State of the data entity.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Folder.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Folder.java
@@ -227,6 +227,15 @@ public class Folder {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStorageUrl")
+        private String objectStorageUrl;
+
+        public Builder objectStorageUrl(String objectStorageUrl) {
+            this.objectStorageUrl = objectStorageUrl;
+            this.__explicitlySet__.add("objectStorageUrl");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -254,7 +263,8 @@ public class Folder {
                             lifecycleState,
                             harvestStatus,
                             lastJobKey,
-                            uri);
+                            uri,
+                            objectStorageUrl);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -283,7 +293,8 @@ public class Folder {
                             .lifecycleState(o.getLifecycleState())
                             .harvestStatus(o.getHarvestStatus())
                             .lastJobKey(o.getLastJobKey())
-                            .uri(o.getUri());
+                            .uri(o.getUri())
+                            .objectStorageUrl(o.getObjectStorageUrl());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -439,6 +450,12 @@ public class Folder {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
     String uri;
+
+    /**
+     * URL of the folder in the object store.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStorageUrl")
+    String objectStorageUrl;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FolderSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FolderSummary.java
@@ -128,12 +128,30 @@ public class FolderSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("uri")
         private String uri;
 
         public Builder uri(String uri) {
             this.uri = uri;
             this.__explicitlySet__.add("uri");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStorageUrl")
+        private String objectStorageUrl;
+
+        public Builder objectStorageUrl(String objectStorageUrl) {
+            this.objectStorageUrl = objectStorageUrl;
+            this.__explicitlySet__.add("objectStorageUrl");
             return this;
         }
 
@@ -163,7 +181,9 @@ public class FolderSummary {
                             externalKey,
                             timeExternal,
                             timeCreated,
+                            timeUpdated,
                             uri,
+                            objectStorageUrl,
                             lifecycleState);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -183,7 +203,9 @@ public class FolderSummary {
                             .externalKey(o.getExternalKey())
                             .timeExternal(o.getTimeExternal())
                             .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
                             .uri(o.getUri())
+                            .objectStorageUrl(o.getObjectStorageUrl())
                             .lifecycleState(o.getLifecycleState());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -269,10 +291,23 @@ public class FolderSummary {
     java.util.Date timeCreated;
 
     /**
+     * The date and time the folder was last updated, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339). Example: 2019-03-25T21:10:29.600Z
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
      * URI of the folder resource within the data catalog API.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
     String uri;
+
+    /**
+     * URL of the folder in the object store.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStorageUrl")
+    String objectStorageUrl;
 
     /**
      * State of the folder.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Job.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Job.java
@@ -367,9 +367,8 @@ public class Job {
     JobType jobType;
 
     /**
-     * Schedule specified in the cron expression format that has seven fields for second, minute, hour, day-of-month, month, day-of-week, year.
-     * It can also include special characters like * for all and ? for any. There are also pre-defined schedules that can be specified using
-     * special strings. For example, @hourly will run the job every hour.
+     * Interval on which the job will be run. Value is specified as a cron-supported time specification "nickname".
+     * The following subset of those is supported: @monthly, @weekly, @daily, @hourly.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scheduleCronExpression")

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobSummary.java
@@ -376,9 +376,8 @@ public class JobSummary {
     String updatedById;
 
     /**
-     * Schedule specified in the cron expression format that has seven fields for second, minute, hour, day-of-month, month, day-of-week, year.
-     * It can also include special characters like * for all and ? for any. There are also pre-defined schedules that can be specified using
-     * special strings. For example, @hourly will run the job every hour.
+     * Interval on which the job will be run. Value is specified as a cron-supported time specification "nickname".
+     * The following subset of those is supported: @monthly, @weekly, @daily, @hourly.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scheduleCronExpression")

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateJobDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateJobDetails.java
@@ -131,9 +131,8 @@ public class UpdateJobDetails {
     String description;
 
     /**
-     * Schedule specified in the cron expression format that has seven fields for second, minute, hour, day-of-month, month, day-of-week, year.
-     * It can also include special characters like * for all and ? for any. There are also pre-defined schedules that can be specified using
-     * special strings. For example, @hourly will run the job every hour.
+     * Interval on which the job will be run. Value is specified as a cron-supported time specification "nickname".
+     * The following subset of those is supported: @monthly, @weekly, @daily, @hourly.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scheduleCronExpression")

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/WorkRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/WorkRequest.java
@@ -164,6 +164,10 @@ public class WorkRequest {
         MoveCatalogPrivateEndpoint("MOVE_CATALOG_PRIVATE_ENDPOINT"),
         AttachCatalogPrivateEndpoint("ATTACH_CATALOG_PRIVATE_ENDPOINT"),
         DetachCatalogPrivateEndpoint("DETACH_CATALOG_PRIVATE_ENDPOINT"),
+        CreateMetastore("CREATE_METASTORE"),
+        UpdateMetastore("UPDATE_METASTORE"),
+        DeleteMetastore("DELETE_METASTORE"),
+        MoveMetastore("MOVE_METASTORE"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobsRequest.java
@@ -78,9 +78,8 @@ public class ListJobsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
     private String dataAssetKey;
 
     /**
-     * Schedule specified in the cron expression format that has seven fields for second, minute, hour, day-of-month, month, day-of-week, year.
-     * It can also include special characters like * for all and ? for any. There are also pre-defined schedules that can be specified using
-     * special strings. For example, @hourly will run the job every hour.
+     * Interval on which the job will be run. Value is specified as a cron-supported time specification "nickname".
+     * The following subset of those is supported: @monthly, @weekly, @daily, @hourly.
      *
      */
     private String scheduleCronExpression;

--- a/bmc-dataconnectivity/pom.xml
+++ b/bmc-dataconnectivity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataconnectivity</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/Devops.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/Devops.java
@@ -514,7 +514,7 @@ public interface Devops extends AutoCloseable {
     GetDeploymentResponse getDeployment(GetDeploymentRequest request);
 
     /**
-     * Gets the line-by-line difference between files on different commits.
+     * Gets the line-by-line difference between file on different commits. This API will be deprecated on Wed, 29 Mar 2023 01:00:00 GMT as it does not get recognized when filePath has '/'. This will be replaced by \"/repositories/{repositoryId}/file/diffs\"
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -590,6 +590,32 @@ public interface Devops extends AutoCloseable {
     GetRefResponse getRef(GetRefRequest request);
 
     /**
+     * Gets the line-by-line difference between file on different commits.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/devops/GetRepoFileDiffExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetRepoFileDiff API.
+     */
+    GetRepoFileDiffResponse getRepoFileDiff(GetRepoFileDiffRequest request);
+
+    /**
+     * Retrieve lines of a specified file. Supports starting line number and limit.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/devops/GetRepoFileLinesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetRepoFileLines API.
+     */
+    GetRepoFileLinesResponse getRepoFileLines(GetRepoFileLinesRequest request);
+
+    /**
      * Retrieves a repository by identifier.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -616,7 +642,7 @@ public interface Devops extends AutoCloseable {
             GetRepositoryArchiveContentRequest request);
 
     /**
-     * Retrieve lines of a specified file. Supports starting line number and limit.
+     * Retrieve lines of a specified file. Supports starting line number and limit. This API will be deprecated on Wed, 29 Mar 2023 01:00:00 GMT as it does not get recognized when filePath has '/'. This will be replaced by \"/repositories/{repositoryId}/file/lines\"
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/DevopsAsync.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/DevopsAsync.java
@@ -639,7 +639,7 @@ public interface DevopsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets the line-by-line difference between files on different commits.
+     * Gets the line-by-line difference between file on different commits. This API will be deprecated on Wed, 29 Mar 2023 01:00:00 GMT as it does not get recognized when filePath has '/'. This will be replaced by \"/repositories/{repositoryId}/file/diffs\"
      *
      *
      * @param request The request object containing the details to send
@@ -729,6 +729,38 @@ public interface DevopsAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetRefRequest, GetRefResponse> handler);
 
     /**
+     * Gets the line-by-line difference between file on different commits.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetRepoFileDiffResponse> getRepoFileDiff(
+            GetRepoFileDiffRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetRepoFileDiffRequest, GetRepoFileDiffResponse>
+                    handler);
+
+    /**
+     * Retrieve lines of a specified file. Supports starting line number and limit.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetRepoFileLinesResponse> getRepoFileLines(
+            GetRepoFileLinesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetRepoFileLinesRequest, GetRepoFileLinesResponse>
+                    handler);
+
+    /**
      * Retrieves a repository by identifier.
      *
      * @param request The request object containing the details to send
@@ -761,7 +793,7 @@ public interface DevopsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Retrieve lines of a specified file. Supports starting line number and limit.
+     * Retrieve lines of a specified file. Supports starting line number and limit. This API will be deprecated on Wed, 29 Mar 2023 01:00:00 GMT as it does not get recognized when filePath has '/'. This will be replaced by \"/repositories/{repositoryId}/file/lines\"
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/DevopsAsyncClient.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/DevopsAsyncClient.java
@@ -2201,6 +2201,84 @@ public class DevopsAsyncClient implements DevopsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetRepoFileDiffResponse> getRepoFileDiff(
+            GetRepoFileDiffRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetRepoFileDiffRequest, GetRepoFileDiffResponse>
+                    handler) {
+        LOG.trace("Called async getRepoFileDiff");
+        final GetRepoFileDiffRequest interceptedRequest =
+                GetRepoFileDiffConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetRepoFileDiffConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetRepoFileDiffResponse>
+                transformer = GetRepoFileDiffConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetRepoFileDiffRequest, GetRepoFileDiffResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetRepoFileDiffRequest, GetRepoFileDiffResponse>,
+                        java.util.concurrent.Future<GetRepoFileDiffResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetRepoFileDiffRequest, GetRepoFileDiffResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetRepoFileLinesResponse> getRepoFileLines(
+            GetRepoFileLinesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetRepoFileLinesRequest, GetRepoFileLinesResponse>
+                    handler) {
+        LOG.trace("Called async getRepoFileLines");
+        final GetRepoFileLinesRequest interceptedRequest =
+                GetRepoFileLinesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetRepoFileLinesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetRepoFileLinesResponse>
+                transformer = GetRepoFileLinesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetRepoFileLinesRequest, GetRepoFileLinesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetRepoFileLinesRequest, GetRepoFileLinesResponse>,
+                        java.util.concurrent.Future<GetRepoFileLinesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetRepoFileLinesRequest, GetRepoFileLinesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetRepositoryResponse> getRepository(
             GetRepositoryRequest request,
             final com.oracle.bmc.responses.AsyncHandler<GetRepositoryRequest, GetRepositoryResponse>

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/DevopsClient.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/DevopsClient.java
@@ -1840,6 +1840,64 @@ public class DevopsClient implements Devops {
     }
 
     @Override
+    public GetRepoFileDiffResponse getRepoFileDiff(GetRepoFileDiffRequest request) {
+        LOG.trace("Called getRepoFileDiff");
+        final GetRepoFileDiffRequest interceptedRequest =
+                GetRepoFileDiffConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetRepoFileDiffConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetRepoFileDiffResponse>
+                transformer = GetRepoFileDiffConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetRepoFileLinesResponse getRepoFileLines(GetRepoFileLinesRequest request) {
+        LOG.trace("Called getRepoFileLines");
+        final GetRepoFileLinesRequest interceptedRequest =
+                GetRepoFileLinesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetRepoFileLinesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetRepoFileLinesResponse>
+                transformer = GetRepoFileLinesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetRepositoryResponse getRepository(GetRepositoryRequest request) {
         LOG.trace("Called getRepository");
         final GetRepositoryRequest interceptedRequest =

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/internal/http/GetFileDiffConverter.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/internal/http/GetFileDiffConverter.java
@@ -139,6 +139,18 @@ public class GetFileDiffConverter {
                                                     String.class));
                                 }
 
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        sunsetHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Sunset");
+                                if (sunsetHeader.isPresent()) {
+                                    builder.sunset(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Sunset",
+                                                    sunsetHeader.get().get(0),
+                                                    String.class));
+                                }
+
                                 com.oracle.bmc.devops.responses.GetFileDiffResponse
                                         responseWrapper = builder.build();
 

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/internal/http/GetRepoFileDiffConverter.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/internal/http/GetRepoFileDiffConverter.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.devops.model.*;
+import com.oracle.bmc.devops.requests.*;
+import com.oracle.bmc.devops.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.extern.slf4j.Slf4j
+public class GetRepoFileDiffConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.devops.requests.GetRepoFileDiffRequest interceptRequest(
+            com.oracle.bmc.devops.requests.GetRepoFileDiffRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.devops.requests.GetRepoFileDiffRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notNull(request.getBaseVersion(), "baseVersion is required");
+        Validate.notNull(request.getTargetVersion(), "targetVersion is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210630")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()))
+                        .path("file")
+                        .path("diffs");
+
+        if (request.getFilePath() != null) {
+            target =
+                    target.queryParam(
+                            "filePath",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getFilePath()));
+        }
+
+        target =
+                target.queryParam(
+                        "baseVersion",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getBaseVersion()));
+
+        target =
+                target.queryParam(
+                        "targetVersion",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getTargetVersion()));
+
+        if (request.getIsComparisonFromMergeBase() != null) {
+            target =
+                    target.queryParam(
+                            "isComparisonFromMergeBase",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsComparisonFromMergeBase()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.devops.responses.GetRepoFileDiffResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.devops.responses.GetRepoFileDiffResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.devops.responses.GetRepoFileDiffResponse>() {
+                            @Override
+                            public com.oracle.bmc.devops.responses.GetRepoFileDiffResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.devops.responses.GetRepoFileDiffResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.devops.model
+                                                                .FileDiffResponse>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.devops.model.FileDiffResponse
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.devops.model.FileDiffResponse>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.devops.responses.GetRepoFileDiffResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.devops.responses
+                                                        .GetRepoFileDiffResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.fileDiffResponse(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.devops.responses.GetRepoFileDiffResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/internal/http/GetRepoFileLinesConverter.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/internal/http/GetRepoFileLinesConverter.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.devops.model.*;
+import com.oracle.bmc.devops.requests.*;
+import com.oracle.bmc.devops.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.extern.slf4j.Slf4j
+public class GetRepoFileLinesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.devops.requests.GetRepoFileLinesRequest interceptRequest(
+            com.oracle.bmc.devops.requests.GetRepoFileLinesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.devops.requests.GetRepoFileLinesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notNull(request.getRevision(), "revision is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210630")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()))
+                        .path("file")
+                        .path("lines");
+
+        if (request.getFilePath() != null) {
+            target =
+                    target.queryParam(
+                            "filePath",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getFilePath()));
+        }
+
+        target =
+                target.queryParam(
+                        "revision",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getRevision()));
+
+        if (request.getStartLineNumber() != null) {
+            target =
+                    target.queryParam(
+                            "startLineNumber",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getStartLineNumber()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.devops.responses.GetRepoFileLinesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.devops.responses.GetRepoFileLinesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.devops.responses.GetRepoFileLinesResponse>() {
+                            @Override
+                            public com.oracle.bmc.devops.responses.GetRepoFileLinesResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.devops.responses.GetRepoFileLinesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.devops.model
+                                                                .RepositoryFileLines>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.devops.model
+                                                                        .RepositoryFileLines
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.devops.model.RepositoryFileLines>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.devops.responses.GetRepoFileLinesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.devops.responses
+                                                        .GetRepoFileLinesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.repositoryFileLines(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.oracle.bmc.devops.responses.GetRepoFileLinesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/internal/http/GetRepositoryFileLinesConverter.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/internal/http/GetRepositoryFileLinesConverter.java
@@ -144,6 +144,18 @@ public class GetRepositoryFileLinesConverter {
                                                     "etag", etagHeader.get().get(0), String.class));
                                 }
 
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        sunsetHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Sunset");
+                                if (sunsetHeader.isPresent()) {
+                                    builder.sunset(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Sunset",
+                                                    sunsetHeader.get().get(0),
+                                                    String.class));
+                                }
+
                                 com.oracle.bmc.devops.responses.GetRepositoryFileLinesResponse
                                         responseWrapper = builder.build();
 

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ApprovalAction.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ApprovalAction.java
@@ -42,18 +42,28 @@ public class ApprovalAction {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("reason")
+        private String reason;
+
+        public Builder reason(String reason) {
+            this.reason = reason;
+            this.__explicitlySet__.add("reason");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ApprovalAction build() {
-            ApprovalAction __instance__ = new ApprovalAction(subjectId, action);
+            ApprovalAction __instance__ = new ApprovalAction(subjectId, action, reason);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ApprovalAction o) {
-            Builder copiedBuilder = subjectId(o.getSubjectId()).action(o.getAction());
+            Builder copiedBuilder =
+                    subjectId(o.getSubjectId()).action(o.getAction()).reason(o.getReason());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -123,6 +133,12 @@ public class ApprovalAction {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("action")
     Action action;
+
+    /**
+     * The reason for approving or rejecting the deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reason")
+    String reason;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildPipelineStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildPipelineStage.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.devops.model;
 
 /**
  * A single node in a build pipeline. A stage takes a specific designated action.
- * There are many types of stages such as 'Build' and 'Deliver Artifacts'.
+ * There are many types of stages such as 'BUILD' and 'DELIVER_ARTIFACT'.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -177,7 +177,7 @@ public class BuildPipelineStage {
     java.util.Map<String, java.util.Map<String, Object>> systemTags;
 
     /**
-     * Defines the stage type, which is one of the following: Build, Deliver Artifacts, Wait, and Trigger Deployment.
+     * Defines the stage type, which is one of the following: BUILD, DELIVER_ARTIFACT, WAIT, and TRIGGER_DEPLOYMENT_PIPELINE.
      *
      **/
     @lombok.extern.slf4j.Slf4j

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildPipelineStagePredecessor.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildPipelineStagePredecessor.java
@@ -61,7 +61,9 @@ public class BuildPipelineStagePredecessor {
     }
 
     /**
-     * The ID of the predecessor stage. If a stage is the first stage in the pipeline, then the ID is the pipeline's ID.
+     * The OCID of the predecessor stage. If a stage is the first stage in the pipeline, then
+     * the ID is the pipeline's OCID.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildStageRunStep.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildStageRunStep.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * The details about each step in a Build stage.
+ * The details about each step in a build stage.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenDeployStage.java
@@ -1,0 +1,394 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupBlueGreenDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupBlueGreenDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdA")
+        private String deployEnvironmentIdA;
+
+        public Builder deployEnvironmentIdA(String deployEnvironmentIdA) {
+            this.deployEnvironmentIdA = deployEnvironmentIdA;
+            this.__explicitlySet__.add("deployEnvironmentIdA");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdB")
+        private String deployEnvironmentIdB;
+
+        public Builder deployEnvironmentIdB(String deployEnvironmentIdB) {
+            this.deployEnvironmentIdB = deployEnvironmentIdB;
+            this.__explicitlySet__.add("deployEnvironmentIdB");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+        private String deploymentSpecDeployArtifactId;
+
+        public Builder deploymentSpecDeployArtifactId(String deploymentSpecDeployArtifactId) {
+            this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+            this.__explicitlySet__.add("deploymentSpecDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+        private java.util.List<String> deployArtifactIds;
+
+        public Builder deployArtifactIds(java.util.List<String> deployArtifactIds) {
+            this.deployArtifactIds = deployArtifactIds;
+            this.__explicitlySet__.add("deployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(ComputeInstanceGroupRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("failurePolicy")
+        private ComputeInstanceGroupFailurePolicy failurePolicy;
+
+        public Builder failurePolicy(ComputeInstanceGroupFailurePolicy failurePolicy) {
+            this.failurePolicy = failurePolicy;
+            this.__explicitlySet__.add("failurePolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+        private LoadBalancerConfig testLoadBalancerConfig;
+
+        public Builder testLoadBalancerConfig(LoadBalancerConfig testLoadBalancerConfig) {
+            this.testLoadBalancerConfig = testLoadBalancerConfig;
+            this.__explicitlySet__.add("testLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+        private LoadBalancerConfig productionLoadBalancerConfig;
+
+        public Builder productionLoadBalancerConfig(
+                LoadBalancerConfig productionLoadBalancerConfig) {
+            this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+            this.__explicitlySet__.add("productionLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupBlueGreenDeployStage build() {
+            ComputeInstanceGroupBlueGreenDeployStage __instance__ =
+                    new ComputeInstanceGroupBlueGreenDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            deployEnvironmentIdA,
+                            deployEnvironmentIdB,
+                            deploymentSpecDeployArtifactId,
+                            deployArtifactIds,
+                            rolloutPolicy,
+                            failurePolicy,
+                            testLoadBalancerConfig,
+                            productionLoadBalancerConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupBlueGreenDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .deployEnvironmentIdA(o.getDeployEnvironmentIdA())
+                            .deployEnvironmentIdB(o.getDeployEnvironmentIdB())
+                            .deploymentSpecDeployArtifactId(o.getDeploymentSpecDeployArtifactId())
+                            .deployArtifactIds(o.getDeployArtifactIds())
+                            .rolloutPolicy(o.getRolloutPolicy())
+                            .failurePolicy(o.getFailurePolicy())
+                            .testLoadBalancerConfig(o.getTestLoadBalancerConfig())
+                            .productionLoadBalancerConfig(o.getProductionLoadBalancerConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupBlueGreenDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String deployEnvironmentIdA,
+            String deployEnvironmentIdB,
+            String deploymentSpecDeployArtifactId,
+            java.util.List<String> deployArtifactIds,
+            ComputeInstanceGroupRolloutPolicy rolloutPolicy,
+            ComputeInstanceGroupFailurePolicy failurePolicy,
+            LoadBalancerConfig testLoadBalancerConfig,
+            LoadBalancerConfig productionLoadBalancerConfig) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.deployEnvironmentIdA = deployEnvironmentIdA;
+        this.deployEnvironmentIdB = deployEnvironmentIdB;
+        this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+        this.deployArtifactIds = deployArtifactIds;
+        this.rolloutPolicy = rolloutPolicy;
+        this.failurePolicy = failurePolicy;
+        this.testLoadBalancerConfig = testLoadBalancerConfig;
+        this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+    }
+
+    /**
+     * First compute instance group environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdA")
+    String deployEnvironmentIdA;
+
+    /**
+     * Second compute instance group environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdB")
+    String deployEnvironmentIdB;
+
+    /**
+     * The OCID of the artifact that contains the deployment specification.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+    String deploymentSpecDeployArtifactId;
+
+    /**
+     * The list of file artifact OCIDs to deploy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+    java.util.List<String> deployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("failurePolicy")
+    ComputeInstanceGroupFailurePolicy failurePolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+    LoadBalancerConfig testLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+    LoadBalancerConfig productionLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenDeployStageExecutionProgress.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupBlueGreenDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupBlueGreenDeployStageExecutionProgress
+        extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("environmentId")
+        private String environmentId;
+
+        public Builder environmentId(String environmentId) {
+            this.environmentId = environmentId;
+            this.__explicitlySet__.add("environmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupBlueGreenDeployStageExecutionProgress build() {
+            ComputeInstanceGroupBlueGreenDeployStageExecutionProgress __instance__ =
+                    new ComputeInstanceGroupBlueGreenDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails,
+                            environmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupBlueGreenDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails())
+                            .environmentId(o.getEnvironmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupBlueGreenDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails> deployStageExecutionProgressDetails,
+            String environmentId) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+        this.environmentId = environmentId;
+    }
+
+    /**
+     * The OCID of the environment where the artifacts were deployed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("environmentId")
+    String environmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenDeployStageSummary.java
@@ -1,0 +1,394 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupBlueGreenDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupBlueGreenDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdA")
+        private String deployEnvironmentIdA;
+
+        public Builder deployEnvironmentIdA(String deployEnvironmentIdA) {
+            this.deployEnvironmentIdA = deployEnvironmentIdA;
+            this.__explicitlySet__.add("deployEnvironmentIdA");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdB")
+        private String deployEnvironmentIdB;
+
+        public Builder deployEnvironmentIdB(String deployEnvironmentIdB) {
+            this.deployEnvironmentIdB = deployEnvironmentIdB;
+            this.__explicitlySet__.add("deployEnvironmentIdB");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+        private String deploymentSpecDeployArtifactId;
+
+        public Builder deploymentSpecDeployArtifactId(String deploymentSpecDeployArtifactId) {
+            this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+            this.__explicitlySet__.add("deploymentSpecDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+        private java.util.List<String> deployArtifactIds;
+
+        public Builder deployArtifactIds(java.util.List<String> deployArtifactIds) {
+            this.deployArtifactIds = deployArtifactIds;
+            this.__explicitlySet__.add("deployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(ComputeInstanceGroupRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("failurePolicy")
+        private ComputeInstanceGroupFailurePolicy failurePolicy;
+
+        public Builder failurePolicy(ComputeInstanceGroupFailurePolicy failurePolicy) {
+            this.failurePolicy = failurePolicy;
+            this.__explicitlySet__.add("failurePolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+        private LoadBalancerConfig testLoadBalancerConfig;
+
+        public Builder testLoadBalancerConfig(LoadBalancerConfig testLoadBalancerConfig) {
+            this.testLoadBalancerConfig = testLoadBalancerConfig;
+            this.__explicitlySet__.add("testLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+        private LoadBalancerConfig productionLoadBalancerConfig;
+
+        public Builder productionLoadBalancerConfig(
+                LoadBalancerConfig productionLoadBalancerConfig) {
+            this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+            this.__explicitlySet__.add("productionLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupBlueGreenDeployStageSummary build() {
+            ComputeInstanceGroupBlueGreenDeployStageSummary __instance__ =
+                    new ComputeInstanceGroupBlueGreenDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            deployEnvironmentIdA,
+                            deployEnvironmentIdB,
+                            deploymentSpecDeployArtifactId,
+                            deployArtifactIds,
+                            rolloutPolicy,
+                            failurePolicy,
+                            testLoadBalancerConfig,
+                            productionLoadBalancerConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupBlueGreenDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .deployEnvironmentIdA(o.getDeployEnvironmentIdA())
+                            .deployEnvironmentIdB(o.getDeployEnvironmentIdB())
+                            .deploymentSpecDeployArtifactId(o.getDeploymentSpecDeployArtifactId())
+                            .deployArtifactIds(o.getDeployArtifactIds())
+                            .rolloutPolicy(o.getRolloutPolicy())
+                            .failurePolicy(o.getFailurePolicy())
+                            .testLoadBalancerConfig(o.getTestLoadBalancerConfig())
+                            .productionLoadBalancerConfig(o.getProductionLoadBalancerConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupBlueGreenDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String deployEnvironmentIdA,
+            String deployEnvironmentIdB,
+            String deploymentSpecDeployArtifactId,
+            java.util.List<String> deployArtifactIds,
+            ComputeInstanceGroupRolloutPolicy rolloutPolicy,
+            ComputeInstanceGroupFailurePolicy failurePolicy,
+            LoadBalancerConfig testLoadBalancerConfig,
+            LoadBalancerConfig productionLoadBalancerConfig) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.deployEnvironmentIdA = deployEnvironmentIdA;
+        this.deployEnvironmentIdB = deployEnvironmentIdB;
+        this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+        this.deployArtifactIds = deployArtifactIds;
+        this.rolloutPolicy = rolloutPolicy;
+        this.failurePolicy = failurePolicy;
+        this.testLoadBalancerConfig = testLoadBalancerConfig;
+        this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+    }
+
+    /**
+     * First compute instance group environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdA")
+    String deployEnvironmentIdA;
+
+    /**
+     * Second compute instance group environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdB")
+    String deployEnvironmentIdB;
+
+    /**
+     * The OCID of the artifact that contains the deployment specification.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+    String deploymentSpecDeployArtifactId;
+
+    /**
+     * The list of file artifact OCIDs to deploy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+    java.util.List<String> deployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("failurePolicy")
+    ComputeInstanceGroupFailurePolicy failurePolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+    LoadBalancerConfig testLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+    LoadBalancerConfig productionLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenTrafficShiftDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenTrafficShiftDeployStage.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the instance group blue-green deployment load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupBlueGreenTrafficShiftDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupBlueGreenTrafficShiftDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "computeInstanceGroupBlueGreenDeploymentDeployStageId")
+        private String computeInstanceGroupBlueGreenDeploymentDeployStageId;
+
+        public Builder computeInstanceGroupBlueGreenDeploymentDeployStageId(
+                String computeInstanceGroupBlueGreenDeploymentDeployStageId) {
+            this.computeInstanceGroupBlueGreenDeploymentDeployStageId =
+                    computeInstanceGroupBlueGreenDeploymentDeployStageId;
+            this.__explicitlySet__.add("computeInstanceGroupBlueGreenDeploymentDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupBlueGreenTrafficShiftDeployStage build() {
+            ComputeInstanceGroupBlueGreenTrafficShiftDeployStage __instance__ =
+                    new ComputeInstanceGroupBlueGreenTrafficShiftDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            computeInstanceGroupBlueGreenDeploymentDeployStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupBlueGreenTrafficShiftDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .computeInstanceGroupBlueGreenDeploymentDeployStageId(
+                                    o.getComputeInstanceGroupBlueGreenDeploymentDeployStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupBlueGreenTrafficShiftDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String computeInstanceGroupBlueGreenDeploymentDeployStageId) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.computeInstanceGroupBlueGreenDeploymentDeployStageId =
+                computeInstanceGroupBlueGreenDeploymentDeployStageId;
+    }
+
+    /**
+     * The OCID of the upstream compute instance group blue-green deployment stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty(
+            "computeInstanceGroupBlueGreenDeploymentDeployStageId")
+    String computeInstanceGroupBlueGreenDeploymentDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Blue-Green deployment load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress
+        extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("environmentId")
+        private String environmentId;
+
+        public Builder environmentId(String environmentId) {
+            this.environmentId = environmentId;
+            this.__explicitlySet__.add("environmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress build() {
+            ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress __instance__ =
+                    new ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails,
+                            environmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(
+                ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails())
+                            .environmentId(o.getEnvironmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails> deployStageExecutionProgressDetails,
+            String environmentId) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+        this.environmentId = environmentId;
+    }
+
+    /**
+     * The OCID of the environment where traffic is going.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("environmentId")
+    String environmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the instance group blue-green deployment load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary
+        extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "computeInstanceGroupBlueGreenDeploymentDeployStageId")
+        private String computeInstanceGroupBlueGreenDeploymentDeployStageId;
+
+        public Builder computeInstanceGroupBlueGreenDeploymentDeployStageId(
+                String computeInstanceGroupBlueGreenDeploymentDeployStageId) {
+            this.computeInstanceGroupBlueGreenDeploymentDeployStageId =
+                    computeInstanceGroupBlueGreenDeploymentDeployStageId;
+            this.__explicitlySet__.add("computeInstanceGroupBlueGreenDeploymentDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary build() {
+            ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary __instance__ =
+                    new ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            computeInstanceGroupBlueGreenDeploymentDeployStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .computeInstanceGroupBlueGreenDeploymentDeployStageId(
+                                    o.getComputeInstanceGroupBlueGreenDeploymentDeployStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String computeInstanceGroupBlueGreenDeploymentDeployStageId) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.computeInstanceGroupBlueGreenDeploymentDeployStageId =
+                computeInstanceGroupBlueGreenDeploymentDeployStageId;
+    }
+
+    /**
+     * The OCID of the upstream compute instance group blue-green deployment stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty(
+            "computeInstanceGroupBlueGreenDeploymentDeployStageId")
+    String computeInstanceGroupBlueGreenDeploymentDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupByQuerySelector.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupByQuerySelector.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the Compute instance group environment filtered by DSL expression of the compute instances.
+ * Specifies the Compute instance group environment filtered by the RQS query expression.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryApprovalDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryApprovalDeployStage.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the canary approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupCanaryApprovalDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupCanaryApprovalDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "computeInstanceGroupCanaryTrafficShiftDeployStageId")
+        private String computeInstanceGroupCanaryTrafficShiftDeployStageId;
+
+        public Builder computeInstanceGroupCanaryTrafficShiftDeployStageId(
+                String computeInstanceGroupCanaryTrafficShiftDeployStageId) {
+            this.computeInstanceGroupCanaryTrafficShiftDeployStageId =
+                    computeInstanceGroupCanaryTrafficShiftDeployStageId;
+            this.__explicitlySet__.add("computeInstanceGroupCanaryTrafficShiftDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+        private ApprovalPolicy approvalPolicy;
+
+        public Builder approvalPolicy(ApprovalPolicy approvalPolicy) {
+            this.approvalPolicy = approvalPolicy;
+            this.__explicitlySet__.add("approvalPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupCanaryApprovalDeployStage build() {
+            ComputeInstanceGroupCanaryApprovalDeployStage __instance__ =
+                    new ComputeInstanceGroupCanaryApprovalDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            computeInstanceGroupCanaryTrafficShiftDeployStageId,
+                            approvalPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupCanaryApprovalDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .computeInstanceGroupCanaryTrafficShiftDeployStageId(
+                                    o.getComputeInstanceGroupCanaryTrafficShiftDeployStageId())
+                            .approvalPolicy(o.getApprovalPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupCanaryApprovalDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String computeInstanceGroupCanaryTrafficShiftDeployStageId,
+            ApprovalPolicy approvalPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.computeInstanceGroupCanaryTrafficShiftDeployStageId =
+                computeInstanceGroupCanaryTrafficShiftDeployStageId;
+        this.approvalPolicy = approvalPolicy;
+    }
+
+    /**
+     * A compute instance group canary traffic shift stage OCID for load balancer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty(
+            "computeInstanceGroupCanaryTrafficShiftDeployStageId")
+    String computeInstanceGroupCanaryTrafficShiftDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+    ApprovalPolicy approvalPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Canary approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress
+        extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalActions")
+        private java.util.List<ApprovalAction> approvalActions;
+
+        public Builder approvalActions(java.util.List<ApprovalAction> approvalActions) {
+            this.approvalActions = approvalActions;
+            this.__explicitlySet__.add("approvalActions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress build() {
+            ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress __instance__ =
+                    new ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails,
+                            approvalActions);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails())
+                            .approvalActions(o.getApprovalActions());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails> deployStageExecutionProgressDetails,
+            java.util.List<ApprovalAction> approvalActions) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+        this.approvalActions = approvalActions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalActions")
+    java.util.List<ApprovalAction> approvalActions;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryApprovalDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryApprovalDeployStageSummary.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the canary approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupCanaryApprovalDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupCanaryApprovalDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "computeInstanceGroupCanaryTrafficShiftDeployStageId")
+        private String computeInstanceGroupCanaryTrafficShiftDeployStageId;
+
+        public Builder computeInstanceGroupCanaryTrafficShiftDeployStageId(
+                String computeInstanceGroupCanaryTrafficShiftDeployStageId) {
+            this.computeInstanceGroupCanaryTrafficShiftDeployStageId =
+                    computeInstanceGroupCanaryTrafficShiftDeployStageId;
+            this.__explicitlySet__.add("computeInstanceGroupCanaryTrafficShiftDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+        private ApprovalPolicy approvalPolicy;
+
+        public Builder approvalPolicy(ApprovalPolicy approvalPolicy) {
+            this.approvalPolicy = approvalPolicy;
+            this.__explicitlySet__.add("approvalPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupCanaryApprovalDeployStageSummary build() {
+            ComputeInstanceGroupCanaryApprovalDeployStageSummary __instance__ =
+                    new ComputeInstanceGroupCanaryApprovalDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            computeInstanceGroupCanaryTrafficShiftDeployStageId,
+                            approvalPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupCanaryApprovalDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .computeInstanceGroupCanaryTrafficShiftDeployStageId(
+                                    o.getComputeInstanceGroupCanaryTrafficShiftDeployStageId())
+                            .approvalPolicy(o.getApprovalPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupCanaryApprovalDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String computeInstanceGroupCanaryTrafficShiftDeployStageId,
+            ApprovalPolicy approvalPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.computeInstanceGroupCanaryTrafficShiftDeployStageId =
+                computeInstanceGroupCanaryTrafficShiftDeployStageId;
+        this.approvalPolicy = approvalPolicy;
+    }
+
+    /**
+     * A compute instance group canary traffic shift stage OCID for load balancer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty(
+            "computeInstanceGroupCanaryTrafficShiftDeployStageId")
+    String computeInstanceGroupCanaryTrafficShiftDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+    ApprovalPolicy approvalPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryDeployStage.java
@@ -1,0 +1,361 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupCanaryDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupCanaryDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupDeployEnvironmentId")
+        private String computeInstanceGroupDeployEnvironmentId;
+
+        public Builder computeInstanceGroupDeployEnvironmentId(
+                String computeInstanceGroupDeployEnvironmentId) {
+            this.computeInstanceGroupDeployEnvironmentId = computeInstanceGroupDeployEnvironmentId;
+            this.__explicitlySet__.add("computeInstanceGroupDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+        private String deploymentSpecDeployArtifactId;
+
+        public Builder deploymentSpecDeployArtifactId(String deploymentSpecDeployArtifactId) {
+            this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+            this.__explicitlySet__.add("deploymentSpecDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+        private java.util.List<String> deployArtifactIds;
+
+        public Builder deployArtifactIds(java.util.List<String> deployArtifactIds) {
+            this.deployArtifactIds = deployArtifactIds;
+            this.__explicitlySet__.add("deployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(ComputeInstanceGroupRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+        private LoadBalancerConfig testLoadBalancerConfig;
+
+        public Builder testLoadBalancerConfig(LoadBalancerConfig testLoadBalancerConfig) {
+            this.testLoadBalancerConfig = testLoadBalancerConfig;
+            this.__explicitlySet__.add("testLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+        private LoadBalancerConfig productionLoadBalancerConfig;
+
+        public Builder productionLoadBalancerConfig(
+                LoadBalancerConfig productionLoadBalancerConfig) {
+            this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+            this.__explicitlySet__.add("productionLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupCanaryDeployStage build() {
+            ComputeInstanceGroupCanaryDeployStage __instance__ =
+                    new ComputeInstanceGroupCanaryDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            computeInstanceGroupDeployEnvironmentId,
+                            deploymentSpecDeployArtifactId,
+                            deployArtifactIds,
+                            rolloutPolicy,
+                            testLoadBalancerConfig,
+                            productionLoadBalancerConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupCanaryDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .computeInstanceGroupDeployEnvironmentId(
+                                    o.getComputeInstanceGroupDeployEnvironmentId())
+                            .deploymentSpecDeployArtifactId(o.getDeploymentSpecDeployArtifactId())
+                            .deployArtifactIds(o.getDeployArtifactIds())
+                            .rolloutPolicy(o.getRolloutPolicy())
+                            .testLoadBalancerConfig(o.getTestLoadBalancerConfig())
+                            .productionLoadBalancerConfig(o.getProductionLoadBalancerConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupCanaryDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String computeInstanceGroupDeployEnvironmentId,
+            String deploymentSpecDeployArtifactId,
+            java.util.List<String> deployArtifactIds,
+            ComputeInstanceGroupRolloutPolicy rolloutPolicy,
+            LoadBalancerConfig testLoadBalancerConfig,
+            LoadBalancerConfig productionLoadBalancerConfig) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.computeInstanceGroupDeployEnvironmentId = computeInstanceGroupDeployEnvironmentId;
+        this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+        this.deployArtifactIds = deployArtifactIds;
+        this.rolloutPolicy = rolloutPolicy;
+        this.testLoadBalancerConfig = testLoadBalancerConfig;
+        this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+    }
+
+    /**
+     * A compute instance group environment OCID for Canary deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupDeployEnvironmentId")
+    String computeInstanceGroupDeployEnvironmentId;
+
+    /**
+     * The OCID of the artifact that contains the deployment specification.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+    String deploymentSpecDeployArtifactId;
+
+    /**
+     * The list of file artifact OCIDs to deploy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+    java.util.List<String> deployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+    LoadBalancerConfig testLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+    LoadBalancerConfig productionLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryDeployStageExecutionProgress.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupCanaryDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupCanaryDeployStageExecutionProgress
+        extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupCanaryDeployStageExecutionProgress build() {
+            ComputeInstanceGroupCanaryDeployStageExecutionProgress __instance__ =
+                    new ComputeInstanceGroupCanaryDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupCanaryDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupCanaryDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails>
+                    deployStageExecutionProgressDetails) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryDeployStageSummary.java
@@ -1,0 +1,361 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupCanaryDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupCanaryDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupDeployEnvironmentId")
+        private String computeInstanceGroupDeployEnvironmentId;
+
+        public Builder computeInstanceGroupDeployEnvironmentId(
+                String computeInstanceGroupDeployEnvironmentId) {
+            this.computeInstanceGroupDeployEnvironmentId = computeInstanceGroupDeployEnvironmentId;
+            this.__explicitlySet__.add("computeInstanceGroupDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+        private String deploymentSpecDeployArtifactId;
+
+        public Builder deploymentSpecDeployArtifactId(String deploymentSpecDeployArtifactId) {
+            this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+            this.__explicitlySet__.add("deploymentSpecDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+        private java.util.List<String> deployArtifactIds;
+
+        public Builder deployArtifactIds(java.util.List<String> deployArtifactIds) {
+            this.deployArtifactIds = deployArtifactIds;
+            this.__explicitlySet__.add("deployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(ComputeInstanceGroupRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+        private LoadBalancerConfig testLoadBalancerConfig;
+
+        public Builder testLoadBalancerConfig(LoadBalancerConfig testLoadBalancerConfig) {
+            this.testLoadBalancerConfig = testLoadBalancerConfig;
+            this.__explicitlySet__.add("testLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+        private LoadBalancerConfig productionLoadBalancerConfig;
+
+        public Builder productionLoadBalancerConfig(
+                LoadBalancerConfig productionLoadBalancerConfig) {
+            this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+            this.__explicitlySet__.add("productionLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupCanaryDeployStageSummary build() {
+            ComputeInstanceGroupCanaryDeployStageSummary __instance__ =
+                    new ComputeInstanceGroupCanaryDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            computeInstanceGroupDeployEnvironmentId,
+                            deploymentSpecDeployArtifactId,
+                            deployArtifactIds,
+                            rolloutPolicy,
+                            testLoadBalancerConfig,
+                            productionLoadBalancerConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupCanaryDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .computeInstanceGroupDeployEnvironmentId(
+                                    o.getComputeInstanceGroupDeployEnvironmentId())
+                            .deploymentSpecDeployArtifactId(o.getDeploymentSpecDeployArtifactId())
+                            .deployArtifactIds(o.getDeployArtifactIds())
+                            .rolloutPolicy(o.getRolloutPolicy())
+                            .testLoadBalancerConfig(o.getTestLoadBalancerConfig())
+                            .productionLoadBalancerConfig(o.getProductionLoadBalancerConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupCanaryDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String computeInstanceGroupDeployEnvironmentId,
+            String deploymentSpecDeployArtifactId,
+            java.util.List<String> deployArtifactIds,
+            ComputeInstanceGroupRolloutPolicy rolloutPolicy,
+            LoadBalancerConfig testLoadBalancerConfig,
+            LoadBalancerConfig productionLoadBalancerConfig) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.computeInstanceGroupDeployEnvironmentId = computeInstanceGroupDeployEnvironmentId;
+        this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+        this.deployArtifactIds = deployArtifactIds;
+        this.rolloutPolicy = rolloutPolicy;
+        this.testLoadBalancerConfig = testLoadBalancerConfig;
+        this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+    }
+
+    /**
+     * A compute instance group environment OCID for Canary deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupDeployEnvironmentId")
+    String computeInstanceGroupDeployEnvironmentId;
+
+    /**
+     * The OCID of the artifact that contains the deployment specification.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+    String deploymentSpecDeployArtifactId;
+
+    /**
+     * The list of file artifact OCIDs to deploy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+    java.util.List<String> deployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+    LoadBalancerConfig testLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+    LoadBalancerConfig productionLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryTrafficShiftDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryTrafficShiftDeployStage.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the instance group canary deployment load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupCanaryTrafficShiftDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupCanaryTrafficShiftDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupCanaryDeployStageId")
+        private String computeInstanceGroupCanaryDeployStageId;
+
+        public Builder computeInstanceGroupCanaryDeployStageId(
+                String computeInstanceGroupCanaryDeployStageId) {
+            this.computeInstanceGroupCanaryDeployStageId = computeInstanceGroupCanaryDeployStageId;
+            this.__explicitlySet__.add("computeInstanceGroupCanaryDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupCanaryTrafficShiftDeployStage build() {
+            ComputeInstanceGroupCanaryTrafficShiftDeployStage __instance__ =
+                    new ComputeInstanceGroupCanaryTrafficShiftDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            computeInstanceGroupCanaryDeployStageId,
+                            rolloutPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupCanaryTrafficShiftDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .computeInstanceGroupCanaryDeployStageId(
+                                    o.getComputeInstanceGroupCanaryDeployStageId())
+                            .rolloutPolicy(o.getRolloutPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupCanaryTrafficShiftDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String computeInstanceGroupCanaryDeployStageId,
+            LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.computeInstanceGroupCanaryDeployStageId = computeInstanceGroupCanaryDeployStageId;
+        this.rolloutPolicy = rolloutPolicy;
+    }
+
+    /**
+     * The OCID of an upstream compute instance group canary deployment stage ID in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupCanaryDeployStageId")
+    String computeInstanceGroupCanaryDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Canary deployment load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress
+        extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress build() {
+            ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress __instance__ =
+                    new ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails>
+                    deployStageExecutionProgressDetails) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the instance group canary deployment load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupCanaryDeployStageId")
+        private String computeInstanceGroupCanaryDeployStageId;
+
+        public Builder computeInstanceGroupCanaryDeployStageId(
+                String computeInstanceGroupCanaryDeployStageId) {
+            this.computeInstanceGroupCanaryDeployStageId = computeInstanceGroupCanaryDeployStageId;
+            this.__explicitlySet__.add("computeInstanceGroupCanaryDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary build() {
+            ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary __instance__ =
+                    new ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            computeInstanceGroupCanaryDeployStageId,
+                            rolloutPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .computeInstanceGroupCanaryDeployStageId(
+                                    o.getComputeInstanceGroupCanaryDeployStageId())
+                            .rolloutPolicy(o.getRolloutPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String computeInstanceGroupCanaryDeployStageId,
+            LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.computeInstanceGroupCanaryDeployStageId = computeInstanceGroupCanaryDeployStageId;
+        this.rolloutPolicy = rolloutPolicy;
+    }
+
+    /**
+     * A compute instance group canary stage OCID for load balancer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupCanaryDeployStageId")
+    String computeInstanceGroupCanaryDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupDeployEnvironment.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupDeployEnvironment.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the Compute instance group environment. The instances in the group is the combined results of each selectors in the instance group selectors.
+ * Specifies the Compute instance group environment. The combination of instances matching the selectors are included in the instance group.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupDeployStage.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the instance group rolling deployment stage.
+ * Specifies the Instance Group Rolling deployment stage.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupDeployStageExecutionProgress.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the execution details for the instance group rolling deployment stage.
+ * Specifies the execution details for the Instance Group Rolling deployment stage.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupDeployStageSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the instance group rolling deployment stage.
+ * Specifies the Instance Group Rolling deployment stage.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupFailurePolicyByCount.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupFailurePolicyByCount.java
@@ -74,7 +74,7 @@ public class ComputeInstanceGroupFailurePolicyByCount extends ComputeInstanceGro
     }
 
     /**
-     * The threshold count of failed instances in the group, which when reached or exceeded sets the stage as FAILED.
+     * The threshold count of failed instances in the group, which when reached or exceeded sets the stage as Failed.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("failureCount")
     Integer failureCount;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupFailurePolicyByPercentage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupFailurePolicyByPercentage.java
@@ -75,7 +75,7 @@ public class ComputeInstanceGroupFailurePolicyByPercentage
     }
 
     /**
-     * The failure percentage threshold, which when reached or exceeded sets the stage as FAILED. Percentage is computed as the ceiling value of the number of failed instances over the total count of the instances in the group.
+     * The failure percentage threshold, which when reached or exceeded sets the stage as Failed. Percentage is computed as the ceiling value of the number of failed instances over the total count of the instances in the group.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("failurePercentage")
     Integer failurePercentage;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupSelectorCollection.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ComputeInstanceGroupSelectorCollection.java
@@ -62,7 +62,7 @@ public class ComputeInstanceGroupSelectorCollection {
     }
 
     /**
-     * A list of selectors for the instance group. UNION operator is used for combining the instances selected by each selector.
+     * A list of selectors for the instance group. Union operator is used for combining the instances selected by each selector.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<ComputeInstanceGroupSelector> items;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupBlueGreenDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupBlueGreenDeployStageDetails.java
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateComputeInstanceGroupBlueGreenDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateComputeInstanceGroupBlueGreenDeployStageDetails
+        extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdA")
+        private String deployEnvironmentIdA;
+
+        public Builder deployEnvironmentIdA(String deployEnvironmentIdA) {
+            this.deployEnvironmentIdA = deployEnvironmentIdA;
+            this.__explicitlySet__.add("deployEnvironmentIdA");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdB")
+        private String deployEnvironmentIdB;
+
+        public Builder deployEnvironmentIdB(String deployEnvironmentIdB) {
+            this.deployEnvironmentIdB = deployEnvironmentIdB;
+            this.__explicitlySet__.add("deployEnvironmentIdB");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+        private String deploymentSpecDeployArtifactId;
+
+        public Builder deploymentSpecDeployArtifactId(String deploymentSpecDeployArtifactId) {
+            this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+            this.__explicitlySet__.add("deploymentSpecDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+        private java.util.List<String> deployArtifactIds;
+
+        public Builder deployArtifactIds(java.util.List<String> deployArtifactIds) {
+            this.deployArtifactIds = deployArtifactIds;
+            this.__explicitlySet__.add("deployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(ComputeInstanceGroupRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("failurePolicy")
+        private ComputeInstanceGroupFailurePolicy failurePolicy;
+
+        public Builder failurePolicy(ComputeInstanceGroupFailurePolicy failurePolicy) {
+            this.failurePolicy = failurePolicy;
+            this.__explicitlySet__.add("failurePolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+        private LoadBalancerConfig testLoadBalancerConfig;
+
+        public Builder testLoadBalancerConfig(LoadBalancerConfig testLoadBalancerConfig) {
+            this.testLoadBalancerConfig = testLoadBalancerConfig;
+            this.__explicitlySet__.add("testLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+        private LoadBalancerConfig productionLoadBalancerConfig;
+
+        public Builder productionLoadBalancerConfig(
+                LoadBalancerConfig productionLoadBalancerConfig) {
+            this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+            this.__explicitlySet__.add("productionLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateComputeInstanceGroupBlueGreenDeployStageDetails build() {
+            CreateComputeInstanceGroupBlueGreenDeployStageDetails __instance__ =
+                    new CreateComputeInstanceGroupBlueGreenDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            deployEnvironmentIdA,
+                            deployEnvironmentIdB,
+                            deploymentSpecDeployArtifactId,
+                            deployArtifactIds,
+                            rolloutPolicy,
+                            failurePolicy,
+                            testLoadBalancerConfig,
+                            productionLoadBalancerConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateComputeInstanceGroupBlueGreenDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .deployEnvironmentIdA(o.getDeployEnvironmentIdA())
+                            .deployEnvironmentIdB(o.getDeployEnvironmentIdB())
+                            .deploymentSpecDeployArtifactId(o.getDeploymentSpecDeployArtifactId())
+                            .deployArtifactIds(o.getDeployArtifactIds())
+                            .rolloutPolicy(o.getRolloutPolicy())
+                            .failurePolicy(o.getFailurePolicy())
+                            .testLoadBalancerConfig(o.getTestLoadBalancerConfig())
+                            .productionLoadBalancerConfig(o.getProductionLoadBalancerConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateComputeInstanceGroupBlueGreenDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String deployEnvironmentIdA,
+            String deployEnvironmentIdB,
+            String deploymentSpecDeployArtifactId,
+            java.util.List<String> deployArtifactIds,
+            ComputeInstanceGroupRolloutPolicy rolloutPolicy,
+            ComputeInstanceGroupFailurePolicy failurePolicy,
+            LoadBalancerConfig testLoadBalancerConfig,
+            LoadBalancerConfig productionLoadBalancerConfig) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.deployEnvironmentIdA = deployEnvironmentIdA;
+        this.deployEnvironmentIdB = deployEnvironmentIdB;
+        this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+        this.deployArtifactIds = deployArtifactIds;
+        this.rolloutPolicy = rolloutPolicy;
+        this.failurePolicy = failurePolicy;
+        this.testLoadBalancerConfig = testLoadBalancerConfig;
+        this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+    }
+
+    /**
+     * First compute instance group environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdA")
+    String deployEnvironmentIdA;
+
+    /**
+     * Second compute instance group environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployEnvironmentIdB")
+    String deployEnvironmentIdB;
+
+    /**
+     * The OCID of the artifact that contains the deployment specification.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+    String deploymentSpecDeployArtifactId;
+
+    /**
+     * The list of file artifact OCIDs to deploy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+    java.util.List<String> deployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("failurePolicy")
+    ComputeInstanceGroupFailurePolicy failurePolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+    LoadBalancerConfig testLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+    LoadBalancerConfig productionLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the instance group blue-green deployment load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails
+        extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "computeInstanceGroupBlueGreenDeploymentDeployStageId")
+        private String computeInstanceGroupBlueGreenDeploymentDeployStageId;
+
+        public Builder computeInstanceGroupBlueGreenDeploymentDeployStageId(
+                String computeInstanceGroupBlueGreenDeploymentDeployStageId) {
+            this.computeInstanceGroupBlueGreenDeploymentDeployStageId =
+                    computeInstanceGroupBlueGreenDeploymentDeployStageId;
+            this.__explicitlySet__.add("computeInstanceGroupBlueGreenDeploymentDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails build() {
+            CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails __instance__ =
+                    new CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            computeInstanceGroupBlueGreenDeploymentDeployStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .computeInstanceGroupBlueGreenDeploymentDeployStageId(
+                                    o.getComputeInstanceGroupBlueGreenDeploymentDeployStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String computeInstanceGroupBlueGreenDeploymentDeployStageId) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.computeInstanceGroupBlueGreenDeploymentDeployStageId =
+                computeInstanceGroupBlueGreenDeploymentDeployStageId;
+    }
+
+    /**
+     * The OCID of the upstream compute instance group blue-green deployment stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty(
+            "computeInstanceGroupBlueGreenDeploymentDeployStageId")
+    String computeInstanceGroupBlueGreenDeploymentDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupCanaryApprovalDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupCanaryApprovalDeployStageDetails.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the canary approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateComputeInstanceGroupCanaryApprovalDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateComputeInstanceGroupCanaryApprovalDeployStageDetails
+        extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "computeInstanceGroupCanaryTrafficShiftDeployStageId")
+        private String computeInstanceGroupCanaryTrafficShiftDeployStageId;
+
+        public Builder computeInstanceGroupCanaryTrafficShiftDeployStageId(
+                String computeInstanceGroupCanaryTrafficShiftDeployStageId) {
+            this.computeInstanceGroupCanaryTrafficShiftDeployStageId =
+                    computeInstanceGroupCanaryTrafficShiftDeployStageId;
+            this.__explicitlySet__.add("computeInstanceGroupCanaryTrafficShiftDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+        private ApprovalPolicy approvalPolicy;
+
+        public Builder approvalPolicy(ApprovalPolicy approvalPolicy) {
+            this.approvalPolicy = approvalPolicy;
+            this.__explicitlySet__.add("approvalPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateComputeInstanceGroupCanaryApprovalDeployStageDetails build() {
+            CreateComputeInstanceGroupCanaryApprovalDeployStageDetails __instance__ =
+                    new CreateComputeInstanceGroupCanaryApprovalDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            computeInstanceGroupCanaryTrafficShiftDeployStageId,
+                            approvalPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateComputeInstanceGroupCanaryApprovalDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .computeInstanceGroupCanaryTrafficShiftDeployStageId(
+                                    o.getComputeInstanceGroupCanaryTrafficShiftDeployStageId())
+                            .approvalPolicy(o.getApprovalPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateComputeInstanceGroupCanaryApprovalDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String computeInstanceGroupCanaryTrafficShiftDeployStageId,
+            ApprovalPolicy approvalPolicy) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.computeInstanceGroupCanaryTrafficShiftDeployStageId =
+                computeInstanceGroupCanaryTrafficShiftDeployStageId;
+        this.approvalPolicy = approvalPolicy;
+    }
+
+    /**
+     * A compute instance group canary traffic shift stage OCID for load balancer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty(
+            "computeInstanceGroupCanaryTrafficShiftDeployStageId")
+    String computeInstanceGroupCanaryTrafficShiftDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+    ApprovalPolicy approvalPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupCanaryDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupCanaryDeployStageDetails.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateComputeInstanceGroupCanaryDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateComputeInstanceGroupCanaryDeployStageDetails extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupDeployEnvironmentId")
+        private String computeInstanceGroupDeployEnvironmentId;
+
+        public Builder computeInstanceGroupDeployEnvironmentId(
+                String computeInstanceGroupDeployEnvironmentId) {
+            this.computeInstanceGroupDeployEnvironmentId = computeInstanceGroupDeployEnvironmentId;
+            this.__explicitlySet__.add("computeInstanceGroupDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+        private String deploymentSpecDeployArtifactId;
+
+        public Builder deploymentSpecDeployArtifactId(String deploymentSpecDeployArtifactId) {
+            this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+            this.__explicitlySet__.add("deploymentSpecDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+        private java.util.List<String> deployArtifactIds;
+
+        public Builder deployArtifactIds(java.util.List<String> deployArtifactIds) {
+            this.deployArtifactIds = deployArtifactIds;
+            this.__explicitlySet__.add("deployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(ComputeInstanceGroupRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+        private LoadBalancerConfig testLoadBalancerConfig;
+
+        public Builder testLoadBalancerConfig(LoadBalancerConfig testLoadBalancerConfig) {
+            this.testLoadBalancerConfig = testLoadBalancerConfig;
+            this.__explicitlySet__.add("testLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+        private LoadBalancerConfig productionLoadBalancerConfig;
+
+        public Builder productionLoadBalancerConfig(
+                LoadBalancerConfig productionLoadBalancerConfig) {
+            this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+            this.__explicitlySet__.add("productionLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateComputeInstanceGroupCanaryDeployStageDetails build() {
+            CreateComputeInstanceGroupCanaryDeployStageDetails __instance__ =
+                    new CreateComputeInstanceGroupCanaryDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            computeInstanceGroupDeployEnvironmentId,
+                            deploymentSpecDeployArtifactId,
+                            deployArtifactIds,
+                            rolloutPolicy,
+                            testLoadBalancerConfig,
+                            productionLoadBalancerConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateComputeInstanceGroupCanaryDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .computeInstanceGroupDeployEnvironmentId(
+                                    o.getComputeInstanceGroupDeployEnvironmentId())
+                            .deploymentSpecDeployArtifactId(o.getDeploymentSpecDeployArtifactId())
+                            .deployArtifactIds(o.getDeployArtifactIds())
+                            .rolloutPolicy(o.getRolloutPolicy())
+                            .testLoadBalancerConfig(o.getTestLoadBalancerConfig())
+                            .productionLoadBalancerConfig(o.getProductionLoadBalancerConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateComputeInstanceGroupCanaryDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String computeInstanceGroupDeployEnvironmentId,
+            String deploymentSpecDeployArtifactId,
+            java.util.List<String> deployArtifactIds,
+            ComputeInstanceGroupRolloutPolicy rolloutPolicy,
+            LoadBalancerConfig testLoadBalancerConfig,
+            LoadBalancerConfig productionLoadBalancerConfig) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.computeInstanceGroupDeployEnvironmentId = computeInstanceGroupDeployEnvironmentId;
+        this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+        this.deployArtifactIds = deployArtifactIds;
+        this.rolloutPolicy = rolloutPolicy;
+        this.testLoadBalancerConfig = testLoadBalancerConfig;
+        this.productionLoadBalancerConfig = productionLoadBalancerConfig;
+    }
+
+    /**
+     * A compute instance group environment OCID for Canary deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupDeployEnvironmentId")
+    String computeInstanceGroupDeployEnvironmentId;
+
+    /**
+     * The OCID of the artifact that contains the deployment specification.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+    String deploymentSpecDeployArtifactId;
+
+    /**
+     * The list of file artifact OCIDs to deploy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+    java.util.List<String> deployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+    LoadBalancerConfig testLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("productionLoadBalancerConfig")
+    LoadBalancerConfig productionLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the instance group canary deployment load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails
+        extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupCanaryDeployStageId")
+        private String computeInstanceGroupCanaryDeployStageId;
+
+        public Builder computeInstanceGroupCanaryDeployStageId(
+                String computeInstanceGroupCanaryDeployStageId) {
+            this.computeInstanceGroupCanaryDeployStageId = computeInstanceGroupCanaryDeployStageId;
+            this.__explicitlySet__.add("computeInstanceGroupCanaryDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails build() {
+            CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails __instance__ =
+                    new CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            computeInstanceGroupCanaryDeployStageId,
+                            rolloutPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .computeInstanceGroupCanaryDeployStageId(
+                                    o.getComputeInstanceGroupCanaryDeployStageId())
+                            .rolloutPolicy(o.getRolloutPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String computeInstanceGroupCanaryDeployStageId,
+            LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.computeInstanceGroupCanaryDeployStageId = computeInstanceGroupCanaryDeployStageId;
+        this.rolloutPolicy = rolloutPolicy;
+    }
+
+    /**
+     * A compute instance group canary stage OCID for load balancer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeInstanceGroupCanaryDeployStageId")
+    String computeInstanceGroupCanaryDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateComputeInstanceGroupDeployStageDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the instance group rolling deployment stage.
+ * Specifies the Instance Group Rolling deployment stage.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateDeployStageDetails.java
@@ -29,20 +29,32 @@ package com.oracle.bmc.devops.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = CreateManualApprovalDeployStageDetails.class,
-        name = "MANUAL_APPROVAL"
+        value = CreateOkeCanaryTrafficShiftDeployStageDetails.class,
+        name = "OKE_CANARY_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateOkeBlueGreenTrafficShiftDeployStageDetails.class,
+        name = "OKE_BLUE_GREEN_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateComputeInstanceGroupCanaryDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateWaitDeployStageDetails.class,
         name = "WAIT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = CreateOkeDeployStageDetails.class,
-        name = "OKE_DEPLOYMENT"
-    ),
-    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateLoadBalancerTrafficShiftDeployStageDetails.class,
         name = "LOAD_BALANCER_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateOkeBlueGreenDeployStageDetails.class,
+        name = "OKE_BLUE_GREEN_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateComputeInstanceGroupDeployStageDetails.class,
@@ -55,6 +67,34 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateFunctionDeployStageDetails.class,
         name = "DEPLOY_FUNCTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateOkeCanaryDeployStageDetails.class,
+        name = "OKE_CANARY_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateComputeInstanceGroupCanaryApprovalDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateManualApprovalDeployStageDetails.class,
+        name = "MANUAL_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateOkeDeployStageDetails.class,
+        name = "OKE_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateComputeInstanceGroupBlueGreenDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateOkeCanaryApprovalDeployStageDetails.class,
+        name = "OKE_CANARY_APPROVAL"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateDeploymentDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateDeploymentDetails.java
@@ -39,6 +39,10 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateSingleDeployStageDeploymentDetails.class,
         name = "SINGLE_STAGE_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateSingleDeployStageRedeploymentDetails.class,
+        name = "SINGLE_STAGE_REDEPLOYMENT"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeBlueGreenDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeBlueGreenDeployStageDetails.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateOkeBlueGreenDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateOkeBlueGreenDeployStageDetails extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+        private java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+        public Builder kubernetesManifestDeployArtifactIds(
+                java.util.List<String> kubernetesManifestDeployArtifactIds) {
+            this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+            this.__explicitlySet__.add("kubernetesManifestDeployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("blueGreenStrategy")
+        private OkeBlueGreenStrategy blueGreenStrategy;
+
+        public Builder blueGreenStrategy(OkeBlueGreenStrategy blueGreenStrategy) {
+            this.blueGreenStrategy = blueGreenStrategy;
+            this.__explicitlySet__.add("blueGreenStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateOkeBlueGreenDeployStageDetails build() {
+            CreateOkeBlueGreenDeployStageDetails __instance__ =
+                    new CreateOkeBlueGreenDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            okeClusterDeployEnvironmentId,
+                            kubernetesManifestDeployArtifactIds,
+                            blueGreenStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateOkeBlueGreenDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .kubernetesManifestDeployArtifactIds(
+                                    o.getKubernetesManifestDeployArtifactIds())
+                            .blueGreenStrategy(o.getBlueGreenStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateOkeBlueGreenDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String okeClusterDeployEnvironmentId,
+            java.util.List<String> kubernetesManifestDeployArtifactIds,
+            OkeBlueGreenStrategy blueGreenStrategy) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+        this.blueGreenStrategy = blueGreenStrategy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * List of Kubernetes manifest artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+    java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("blueGreenStrategy")
+    OkeBlueGreenStrategy blueGreenStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeBlueGreenTrafficShiftDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeBlueGreenTrafficShiftDeployStageDetails.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster blue-green deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateOkeBlueGreenTrafficShiftDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateOkeBlueGreenTrafficShiftDeployStageDetails extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeBlueGreenDeployStageId")
+        private String okeBlueGreenDeployStageId;
+
+        public Builder okeBlueGreenDeployStageId(String okeBlueGreenDeployStageId) {
+            this.okeBlueGreenDeployStageId = okeBlueGreenDeployStageId;
+            this.__explicitlySet__.add("okeBlueGreenDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateOkeBlueGreenTrafficShiftDeployStageDetails build() {
+            CreateOkeBlueGreenTrafficShiftDeployStageDetails __instance__ =
+                    new CreateOkeBlueGreenTrafficShiftDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            okeBlueGreenDeployStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateOkeBlueGreenTrafficShiftDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .okeBlueGreenDeployStageId(o.getOkeBlueGreenDeployStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateOkeBlueGreenTrafficShiftDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String okeBlueGreenDeployStageId) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.okeBlueGreenDeployStageId = okeBlueGreenDeployStageId;
+    }
+
+    /**
+     * The OCID of the upstream OKE blue-green deployment stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeBlueGreenDeployStageId")
+    String okeBlueGreenDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeCanaryApprovalDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeCanaryApprovalDeployStageDetails.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster canary deployment approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateOkeCanaryApprovalDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateOkeCanaryApprovalDeployStageDetails extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryTrafficShiftDeployStageId")
+        private String okeCanaryTrafficShiftDeployStageId;
+
+        public Builder okeCanaryTrafficShiftDeployStageId(
+                String okeCanaryTrafficShiftDeployStageId) {
+            this.okeCanaryTrafficShiftDeployStageId = okeCanaryTrafficShiftDeployStageId;
+            this.__explicitlySet__.add("okeCanaryTrafficShiftDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+        private ApprovalPolicy approvalPolicy;
+
+        public Builder approvalPolicy(ApprovalPolicy approvalPolicy) {
+            this.approvalPolicy = approvalPolicy;
+            this.__explicitlySet__.add("approvalPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateOkeCanaryApprovalDeployStageDetails build() {
+            CreateOkeCanaryApprovalDeployStageDetails __instance__ =
+                    new CreateOkeCanaryApprovalDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            okeCanaryTrafficShiftDeployStageId,
+                            approvalPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateOkeCanaryApprovalDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .okeCanaryTrafficShiftDeployStageId(
+                                    o.getOkeCanaryTrafficShiftDeployStageId())
+                            .approvalPolicy(o.getApprovalPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateOkeCanaryApprovalDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String okeCanaryTrafficShiftDeployStageId,
+            ApprovalPolicy approvalPolicy) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.okeCanaryTrafficShiftDeployStageId = okeCanaryTrafficShiftDeployStageId;
+        this.approvalPolicy = approvalPolicy;
+    }
+
+    /**
+     * The OCID of an upstream OKE canary deployment traffic shift stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryTrafficShiftDeployStageId")
+    String okeCanaryTrafficShiftDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+    ApprovalPolicy approvalPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeCanaryDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeCanaryDeployStageDetails.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateOkeCanaryDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateOkeCanaryDeployStageDetails extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+        private java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+        public Builder kubernetesManifestDeployArtifactIds(
+                java.util.List<String> kubernetesManifestDeployArtifactIds) {
+            this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+            this.__explicitlySet__.add("kubernetesManifestDeployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("canaryStrategy")
+        private OkeCanaryStrategy canaryStrategy;
+
+        public Builder canaryStrategy(OkeCanaryStrategy canaryStrategy) {
+            this.canaryStrategy = canaryStrategy;
+            this.__explicitlySet__.add("canaryStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateOkeCanaryDeployStageDetails build() {
+            CreateOkeCanaryDeployStageDetails __instance__ =
+                    new CreateOkeCanaryDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            okeClusterDeployEnvironmentId,
+                            kubernetesManifestDeployArtifactIds,
+                            canaryStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateOkeCanaryDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .kubernetesManifestDeployArtifactIds(
+                                    o.getKubernetesManifestDeployArtifactIds())
+                            .canaryStrategy(o.getCanaryStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateOkeCanaryDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String okeClusterDeployEnvironmentId,
+            java.util.List<String> kubernetesManifestDeployArtifactIds,
+            OkeCanaryStrategy canaryStrategy) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+        this.canaryStrategy = canaryStrategy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * List of Kubernetes manifest artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+    java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("canaryStrategy")
+    OkeCanaryStrategy canaryStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeCanaryTrafficShiftDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeCanaryTrafficShiftDeployStageDetails.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster canary deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateOkeCanaryTrafficShiftDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateOkeCanaryTrafficShiftDeployStageDetails extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryDeployStageId")
+        private String okeCanaryDeployStageId;
+
+        public Builder okeCanaryDeployStageId(String okeCanaryDeployStageId) {
+            this.okeCanaryDeployStageId = okeCanaryDeployStageId;
+            this.__explicitlySet__.add("okeCanaryDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateOkeCanaryTrafficShiftDeployStageDetails build() {
+            CreateOkeCanaryTrafficShiftDeployStageDetails __instance__ =
+                    new CreateOkeCanaryTrafficShiftDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            okeCanaryDeployStageId,
+                            rolloutPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateOkeCanaryTrafficShiftDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .okeCanaryDeployStageId(o.getOkeCanaryDeployStageId())
+                            .rolloutPolicy(o.getRolloutPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateOkeCanaryTrafficShiftDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String okeCanaryDeployStageId,
+            LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.okeCanaryDeployStageId = okeCanaryDeployStageId;
+        this.rolloutPolicy = rolloutPolicy;
+    }
+
+    /**
+     * The OCID of an upstream OKE canary deployment stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryDeployStageId")
+    String okeCanaryDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeClusterDeployEnvironmentDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeClusterDeployEnvironmentDetails.java
@@ -87,6 +87,15 @@ public class CreateOkeClusterDeployEnvironmentDetails extends CreateDeployEnviro
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkChannel")
+        private NetworkChannel networkChannel;
+
+        public Builder networkChannel(NetworkChannel networkChannel) {
+            this.networkChannel = networkChannel;
+            this.__explicitlySet__.add("networkChannel");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -98,7 +107,8 @@ public class CreateOkeClusterDeployEnvironmentDetails extends CreateDeployEnviro
                             projectId,
                             freeformTags,
                             definedTags,
-                            clusterId);
+                            clusterId,
+                            networkChannel);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -111,7 +121,8 @@ public class CreateOkeClusterDeployEnvironmentDetails extends CreateDeployEnviro
                             .projectId(o.getProjectId())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
-                            .clusterId(o.getClusterId());
+                            .clusterId(o.getClusterId())
+                            .networkChannel(o.getNetworkChannel());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -132,9 +143,11 @@ public class CreateOkeClusterDeployEnvironmentDetails extends CreateDeployEnviro
             String projectId,
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
-            String clusterId) {
+            String clusterId,
+            NetworkChannel networkChannel) {
         super(description, displayName, projectId, freeformTags, definedTags);
         this.clusterId = clusterId;
+        this.networkChannel = networkChannel;
     }
 
     /**
@@ -142,6 +155,9 @@ public class CreateOkeClusterDeployEnvironmentDetails extends CreateDeployEnviro
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("clusterId")
     String clusterId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkChannel")
+    NetworkChannel networkChannel;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeDeployStageDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the Kubernetes cluster deployment stage.
+ * Specifies the Container Engine for Kubernetes (OKE) cluster deployment stage.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -205,7 +205,7 @@ public class CreateOkeDeployStageDetails extends CreateDeployStageDetails {
     String okeClusterDeployEnvironmentId;
 
     /**
-     * List of Kubernetes manifest artifact OCIDs, the manifests should not include any job resource.
+     * List of Kubernetes manifest artifact OCIDs.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
     java.util.List<String> kubernetesManifestDeployArtifactIds;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateSingleDeployStageRedeploymentDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateSingleDeployStageRedeploymentDetails.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Details of a new deployment to be created that will rerun a single stage from a previously executed deployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateSingleDeployStageRedeploymentDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deploymentType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateSingleDeployStageRedeploymentDetails extends CreateDeploymentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("previousDeploymentId")
+        private String previousDeploymentId;
+
+        public Builder previousDeploymentId(String previousDeploymentId) {
+            this.previousDeploymentId = previousDeploymentId;
+            this.__explicitlySet__.add("previousDeploymentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateSingleDeployStageRedeploymentDetails build() {
+            CreateSingleDeployStageRedeploymentDetails __instance__ =
+                    new CreateSingleDeployStageRedeploymentDetails(
+                            deployPipelineId,
+                            displayName,
+                            freeformTags,
+                            definedTags,
+                            previousDeploymentId,
+                            deployStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateSingleDeployStageRedeploymentDetails o) {
+            Builder copiedBuilder =
+                    deployPipelineId(o.getDeployPipelineId())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .previousDeploymentId(o.getPreviousDeploymentId())
+                            .deployStageId(o.getDeployStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateSingleDeployStageRedeploymentDetails(
+            String deployPipelineId,
+            String displayName,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String previousDeploymentId,
+            String deployStageId) {
+        super(deployPipelineId, displayName, freeformTags, definedTags);
+        this.previousDeploymentId = previousDeploymentId;
+        this.deployStageId = deployStageId;
+    }
+
+    /**
+     * Specifies the OCID of the previous deployment to be redeployed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("previousDeploymentId")
+    String previousDeploymentId;
+
+    /**
+     * Specifies the OCID of the stage to be redeployed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+    String deployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployEnvironment.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployEnvironment.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * The target OCI resources, such as Compute instances, Container Engine for Kubernetes(OKE) clusters, or Function, where artifacts will be deployed.
+ * The target OCI resources, such as Compute instances, Container Engine for Kubernetes(OKE) clusters, or Function, where artifacts are deployed.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -96,6 +96,7 @@ public class DeployEnvironment {
         Deleting("DELETING"),
         Deleted("DELETED"),
         Failed("FAILED"),
+        NeedsAttention("NEEDS_ATTENTION"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStage.java
@@ -29,6 +29,10 @@ package com.oracle.bmc.devops.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupBlueGreenTrafficShiftDeployStage.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = LoadBalancerTrafficShiftDeployStage.class,
         name = "LOAD_BALANCER_TRAFFIC_SHIFT"
     ),
@@ -37,12 +41,52 @@ package com.oracle.bmc.devops.model;
         name = "INVOKE_FUNCTION"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = WaitDeployStage.class,
-        name = "WAIT"
+        value = OkeCanaryDeployStage.class,
+        name = "OKE_CANARY_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = OkeDeployStage.class,
         name = "OKE_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeCanaryTrafficShiftDeployStage.class,
+        name = "OKE_CANARY_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = FunctionDeployStage.class,
+        name = "DEPLOY_FUNCTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeBlueGreenDeployStage.class,
+        name = "OKE_BLUE_GREEN_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeCanaryApprovalDeployStage.class,
+        name = "OKE_CANARY_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupCanaryTrafficShiftDeployStage.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupCanaryApprovalDeployStage.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = WaitDeployStage.class,
+        name = "WAIT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupBlueGreenDeployStage.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupCanaryDeployStage.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeBlueGreenTrafficShiftDeployStage.class,
+        name = "OKE_BLUE_GREEN_TRAFFIC_SHIFT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ManualApprovalDeployStage.class,
@@ -51,10 +95,6 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ComputeInstanceGroupDeployStage.class,
         name = "COMPUTE_INSTANCE_GROUP_ROLLING_DEPLOYMENT"
-    ),
-    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = FunctionDeployStage.class,
-        name = "DEPLOY_FUNCTION"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
@@ -197,6 +237,17 @@ public class DeployStage {
     public enum DeployStageType {
         Wait("WAIT"),
         ComputeInstanceGroupRollingDeployment("COMPUTE_INSTANCE_GROUP_ROLLING_DEPLOYMENT"),
+        ComputeInstanceGroupBlueGreenDeployment("COMPUTE_INSTANCE_GROUP_BLUE_GREEN_DEPLOYMENT"),
+        ComputeInstanceGroupBlueGreenTrafficShift(
+                "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_TRAFFIC_SHIFT"),
+        ComputeInstanceGroupCanaryDeployment("COMPUTE_INSTANCE_GROUP_CANARY_DEPLOYMENT"),
+        ComputeInstanceGroupCanaryTrafficShift("COMPUTE_INSTANCE_GROUP_CANARY_TRAFFIC_SHIFT"),
+        ComputeInstanceGroupCanaryApproval("COMPUTE_INSTANCE_GROUP_CANARY_APPROVAL"),
+        OkeBlueGreenDeployment("OKE_BLUE_GREEN_DEPLOYMENT"),
+        OkeBlueGreenTrafficShift("OKE_BLUE_GREEN_TRAFFIC_SHIFT"),
+        OkeCanaryDeployment("OKE_CANARY_DEPLOYMENT"),
+        OkeCanaryTrafficShift("OKE_CANARY_TRAFFIC_SHIFT"),
+        OkeCanaryApproval("OKE_CANARY_APPROVAL"),
         OkeDeployment("OKE_DEPLOYMENT"),
         DeployFunction("DEPLOY_FUNCTION"),
         InvokeFunction("INVOKE_FUNCTION"),

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStageExecutionProgress.java
@@ -29,32 +29,72 @@ package com.oracle.bmc.devops.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = ManualApprovalDeployStageExecutionProgress.class,
-        name = "MANUAL_APPROVAL"
+        value = ComputeInstanceGroupBlueGreenTrafficShiftDeployStageExecutionProgress.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupCanaryDeployStageExecutionProgress.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeBlueGreenDeployStageExecutionProgress.class,
+        name = "OKE_BLUE_GREEN_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ComputeInstanceGroupDeployStageExecutionProgress.class,
         name = "COMPUTE_INSTANCE_GROUP_ROLLING_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = OkeDeployStageExecutionProgress.class,
-        name = "OKE_DEPLOYMENT"
+        value = OkeCanaryDeployStageExecutionProgress.class,
+        name = "OKE_CANARY_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = LoadBalancerTrafficShiftDeployStageExecutionProgress.class,
         name = "LOAD_BALANCER_TRAFFIC_SHIFT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = WaitDeployStageExecutionProgress.class,
+        name = "WAIT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupCanaryTrafficShiftDeployStageExecutionProgress.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeCanaryApprovalDeployStageExecutionProgress.class,
+        name = "OKE_CANARY_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ManualApprovalDeployStageExecutionProgress.class,
+        name = "MANUAL_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeDeployStageExecutionProgress.class,
+        name = "OKE_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = FunctionDeployStageExecutionProgress.class,
         name = "DEPLOY_FUNCTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeBlueGreenTrafficShiftDeployStageExecutionProgress.class,
+        name = "OKE_BLUE_GREEN_TRAFFIC_SHIFT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = InvokeFunctionDeployStageExecutionProgress.class,
         name = "INVOKE_FUNCTION"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = WaitDeployStageExecutionProgress.class,
-        name = "WAIT"
+        value = OkeCanaryTrafficShiftDeployStageExecutionProgress.class,
+        name = "OKE_CANARY_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupCanaryApprovalDeployStageExecutionProgress.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupBlueGreenDeployStageExecutionProgress.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_DEPLOYMENT"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStageSummary.java
@@ -29,20 +29,52 @@ package com.oracle.bmc.devops.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = WaitDeployStageSummary.class,
-        name = "WAIT"
+        value = ComputeInstanceGroupBlueGreenDeployStageSummary.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = ComputeInstanceGroupDeployStageSummary.class,
-        name = "COMPUTE_INSTANCE_GROUP_ROLLING_DEPLOYMENT"
+        value = ComputeInstanceGroupBlueGreenTrafficShiftDeployStageSummary.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeBlueGreenDeployStageSummary.class,
+        name = "OKE_BLUE_GREEN_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = WaitDeployStageSummary.class,
+        name = "WAIT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = OkeDeployStageSummary.class,
         name = "OKE_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupCanaryApprovalDeployStageSummary.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = InvokeFunctionDeployStageSummary.class,
         name = "INVOKE_FUNCTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeCanaryTrafficShiftDeployStageSummary.class,
+        name = "OKE_CANARY_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupDeployStageSummary.class,
+        name = "COMPUTE_INSTANCE_GROUP_ROLLING_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupCanaryDeployStageSummary.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeCanaryApprovalDeployStageSummary.class,
+        name = "OKE_CANARY_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeCanaryDeployStageSummary.class,
+        name = "OKE_CANARY_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = LoadBalancerTrafficShiftDeployStageSummary.class,
@@ -53,8 +85,16 @@ package com.oracle.bmc.devops.model;
         name = "MANUAL_APPROVAL"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeBlueGreenTrafficShiftDeployStageSummary.class,
+        name = "OKE_BLUE_GREEN_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = FunctionDeployStageSummary.class,
         name = "DEPLOY_FUNCTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ComputeInstanceGroupCanaryTrafficShiftDeployStageSummary.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_TRAFFIC_SHIFT"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Deployment.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Deployment.java
@@ -29,6 +29,10 @@ package com.oracle.bmc.devops.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = SingleDeployStageRedeployment.class,
+        name = "SINGLE_STAGE_REDEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = DeployPipelineDeployment.class,
         name = "PIPELINE_DEPLOYMENT"
     ),
@@ -181,13 +185,14 @@ public class Deployment {
     java.util.Map<String, java.util.Map<String, Object>> systemTags;
 
     /**
-     * Specifies type of Deployment
+     * Specifies type of deployment.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum DeploymentType {
         PipelineDeployment("PIPELINE_DEPLOYMENT"),
         PipelineRedeployment("PIPELINE_REDEPLOYMENT"),
         SingleStageDeployment("SINGLE_STAGE_DEPLOYMENT"),
+        SingleStageRedeployment("SINGLE_STAGE_REDEPLOYMENT"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeploymentSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeploymentSummary.java
@@ -39,6 +39,10 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = DeployPipelineDeploymentSummary.class,
         name = "PIPELINE_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = SingleDeployStageRedeploymentSummary.class,
+        name = "SINGLE_STAGE_REDEPLOYMENT"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/GenericDeployArtifactSource.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/GenericDeployArtifactSource.java
@@ -99,7 +99,7 @@ public class GenericDeployArtifactSource extends DeployArtifactSource {
     }
 
     /**
-     * The OCID of a repository
+     * The OCID of a repository.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
     String repositoryId;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/InvokeFunctionDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/InvokeFunctionDeployStageExecutionProgress.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the invoke function stage specific execution details.
+ * Specifies the Invoke Function stage specific execution details.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/LoadBalancerConfig.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/LoadBalancerConfig.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies config for load balancer traffic shift stages.
+ * Specifies configuration for load balancer traffic shift stages.
+ * The load balancer specified here should be an Application load balancer type.
+ * Network load balancers are not supported.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/LoadBalancerTrafficShiftDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/LoadBalancerTrafficShiftDeployStageExecutionProgress.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the load balancer traffic shift stage execution details.
+ * Specifies the load balancer Traffic Shift stage execution details.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/NetworkChannel.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/NetworkChannel.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the configuration needed when the target OCI resource, OKE cluster resides
+ *  in the customer's private network.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "networkChannelType",
+    defaultImpl = NetworkChannel.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PrivateEndpointChannel.class,
+        name = "PRIVATE_ENDPOINT_CHANNEL"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class NetworkChannel {
+
+    /**
+     * Network channel type.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum NetworkChannelType {
+        PrivateEndpointChannel("PRIVATE_ENDPOINT_CHANNEL"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, NetworkChannelType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (NetworkChannelType v : NetworkChannelType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        NetworkChannelType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static NetworkChannelType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'NetworkChannelType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/NginxBlueGreenStrategy.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/NginxBlueGreenStrategy.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the NGINX blue green release strategy.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = NginxBlueGreenStrategy.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "strategyType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NginxBlueGreenStrategy extends OkeBlueGreenStrategy {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("namespaceA")
+        private String namespaceA;
+
+        public Builder namespaceA(String namespaceA) {
+            this.namespaceA = namespaceA;
+            this.__explicitlySet__.add("namespaceA");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespaceB")
+        private String namespaceB;
+
+        public Builder namespaceB(String namespaceB) {
+            this.namespaceB = namespaceB;
+            this.__explicitlySet__.add("namespaceB");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ingressName")
+        private String ingressName;
+
+        public Builder ingressName(String ingressName) {
+            this.ingressName = ingressName;
+            this.__explicitlySet__.add("ingressName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NginxBlueGreenStrategy build() {
+            NginxBlueGreenStrategy __instance__ =
+                    new NginxBlueGreenStrategy(namespaceA, namespaceB, ingressName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NginxBlueGreenStrategy o) {
+            Builder copiedBuilder =
+                    namespaceA(o.getNamespaceA())
+                            .namespaceB(o.getNamespaceB())
+                            .ingressName(o.getIngressName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public NginxBlueGreenStrategy(String namespaceA, String namespaceB, String ingressName) {
+        super();
+        this.namespaceA = namespaceA;
+        this.namespaceB = namespaceB;
+        this.ingressName = ingressName;
+    }
+
+    /**
+     * Namespace A for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaceA")
+    String namespaceA;
+
+    /**
+     * Namespace B for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaceB")
+    String namespaceB;
+
+    /**
+     * Name of the Ingress resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ingressName")
+    String ingressName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/NginxCanaryStrategy.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/NginxCanaryStrategy.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the NGINX canary release strategy.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = NginxCanaryStrategy.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "strategyType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NginxCanaryStrategy extends OkeCanaryStrategy {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ingressName")
+        private String ingressName;
+
+        public Builder ingressName(String ingressName) {
+            this.ingressName = ingressName;
+            this.__explicitlySet__.add("ingressName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NginxCanaryStrategy build() {
+            NginxCanaryStrategy __instance__ = new NginxCanaryStrategy(namespace, ingressName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NginxCanaryStrategy o) {
+            Builder copiedBuilder = namespace(o.getNamespace()).ingressName(o.getIngressName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public NginxCanaryStrategy(String namespace, String ingressName) {
+        super();
+        this.namespace = namespace;
+        this.ingressName = ingressName;
+    }
+
+    /**
+     * Canary namespace to be used for Kubernetes canary deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    /**
+     * Name of the Ingress resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ingressName")
+    String ingressName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OcirDeployArtifactSource.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OcirDeployArtifactSource.java
@@ -84,7 +84,7 @@ public class OcirDeployArtifactSource extends DeployArtifactSource {
     }
 
     /**
-     * Specifies OCIR Image Path - optionally include tag.
+     * Specifies OCIR image path - optionally include tag.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("imageUri")
     String imageUri;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenDeployStage.java
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeBlueGreenDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeBlueGreenDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+        private java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+        public Builder kubernetesManifestDeployArtifactIds(
+                java.util.List<String> kubernetesManifestDeployArtifactIds) {
+            this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+            this.__explicitlySet__.add("kubernetesManifestDeployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("blueGreenStrategy")
+        private OkeBlueGreenStrategy blueGreenStrategy;
+
+        public Builder blueGreenStrategy(OkeBlueGreenStrategy blueGreenStrategy) {
+            this.blueGreenStrategy = blueGreenStrategy;
+            this.__explicitlySet__.add("blueGreenStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeBlueGreenDeployStage build() {
+            OkeBlueGreenDeployStage __instance__ =
+                    new OkeBlueGreenDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeClusterDeployEnvironmentId,
+                            kubernetesManifestDeployArtifactIds,
+                            blueGreenStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeBlueGreenDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .kubernetesManifestDeployArtifactIds(
+                                    o.getKubernetesManifestDeployArtifactIds())
+                            .blueGreenStrategy(o.getBlueGreenStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeBlueGreenDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeClusterDeployEnvironmentId,
+            java.util.List<String> kubernetesManifestDeployArtifactIds,
+            OkeBlueGreenStrategy blueGreenStrategy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+        this.blueGreenStrategy = blueGreenStrategy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * List of Kubernetes manifest artifact OCIDs
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+    java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("blueGreenStrategy")
+    OkeBlueGreenStrategy blueGreenStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenDeployStageExecutionProgress.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeBlueGreenDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeBlueGreenDeployStageExecutionProgress extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeBlueGreenDeployStageExecutionProgress build() {
+            OkeBlueGreenDeployStageExecutionProgress __instance__ =
+                    new OkeBlueGreenDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails,
+                            namespace);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeBlueGreenDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails())
+                            .namespace(o.getNamespace());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeBlueGreenDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails> deployStageExecutionProgressDetails,
+            String namespace) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+        this.namespace = namespace;
+    }
+
+    /**
+     * Namespace either environment A or environment B where artifacts are deployed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenDeployStageSummary.java
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeBlueGreenDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeBlueGreenDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+        private java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+        public Builder kubernetesManifestDeployArtifactIds(
+                java.util.List<String> kubernetesManifestDeployArtifactIds) {
+            this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+            this.__explicitlySet__.add("kubernetesManifestDeployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("blueGreenStrategy")
+        private OkeBlueGreenStrategy blueGreenStrategy;
+
+        public Builder blueGreenStrategy(OkeBlueGreenStrategy blueGreenStrategy) {
+            this.blueGreenStrategy = blueGreenStrategy;
+            this.__explicitlySet__.add("blueGreenStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeBlueGreenDeployStageSummary build() {
+            OkeBlueGreenDeployStageSummary __instance__ =
+                    new OkeBlueGreenDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeClusterDeployEnvironmentId,
+                            kubernetesManifestDeployArtifactIds,
+                            blueGreenStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeBlueGreenDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .kubernetesManifestDeployArtifactIds(
+                                    o.getKubernetesManifestDeployArtifactIds())
+                            .blueGreenStrategy(o.getBlueGreenStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeBlueGreenDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeClusterDeployEnvironmentId,
+            java.util.List<String> kubernetesManifestDeployArtifactIds,
+            OkeBlueGreenStrategy blueGreenStrategy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+        this.blueGreenStrategy = blueGreenStrategy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * List of Kubernetes manifest artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+    java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("blueGreenStrategy")
+    OkeBlueGreenStrategy blueGreenStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenStrategy.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenStrategy.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the required blue-green release strategy for OKE deployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "strategyType",
+    defaultImpl = OkeBlueGreenStrategy.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = NginxBlueGreenStrategy.class,
+        name = "NGINX_BLUE_GREEN_STRATEGY"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class OkeBlueGreenStrategy {
+
+    /**
+     * Blue-Green strategy type.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum StrategyType {
+        NginxBlueGreenStrategy("NGINX_BLUE_GREEN_STRATEGY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, StrategyType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (StrategyType v : StrategyType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        StrategyType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static StrategyType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'StrategyType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenTrafficShiftDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenTrafficShiftDeployStage.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster blue-green deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeBlueGreenTrafficShiftDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeBlueGreenTrafficShiftDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeBlueGreenDeployStageId")
+        private String okeBlueGreenDeployStageId;
+
+        public Builder okeBlueGreenDeployStageId(String okeBlueGreenDeployStageId) {
+            this.okeBlueGreenDeployStageId = okeBlueGreenDeployStageId;
+            this.__explicitlySet__.add("okeBlueGreenDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeBlueGreenTrafficShiftDeployStage build() {
+            OkeBlueGreenTrafficShiftDeployStage __instance__ =
+                    new OkeBlueGreenTrafficShiftDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeBlueGreenDeployStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeBlueGreenTrafficShiftDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeBlueGreenDeployStageId(o.getOkeBlueGreenDeployStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeBlueGreenTrafficShiftDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeBlueGreenDeployStageId) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeBlueGreenDeployStageId = okeBlueGreenDeployStageId;
+    }
+
+    /**
+     * The OCID of the upstream OKE blue-green deployment stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeBlueGreenDeployStageId")
+    String okeBlueGreenDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenTrafficShiftDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenTrafficShiftDeployStageExecutionProgress.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Blue-Green deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeBlueGreenTrafficShiftDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeBlueGreenTrafficShiftDeployStageExecutionProgress
+        extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeBlueGreenTrafficShiftDeployStageExecutionProgress build() {
+            OkeBlueGreenTrafficShiftDeployStageExecutionProgress __instance__ =
+                    new OkeBlueGreenTrafficShiftDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails,
+                            namespace);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeBlueGreenTrafficShiftDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails())
+                            .namespace(o.getNamespace());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeBlueGreenTrafficShiftDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails> deployStageExecutionProgressDetails,
+            String namespace) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+        this.namespace = namespace;
+    }
+
+    /**
+     * Namespace where traffic is going.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenTrafficShiftDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeBlueGreenTrafficShiftDeployStageSummary.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster blue-green deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeBlueGreenTrafficShiftDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeBlueGreenTrafficShiftDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeBlueGreenDeployStageId")
+        private String okeBlueGreenDeployStageId;
+
+        public Builder okeBlueGreenDeployStageId(String okeBlueGreenDeployStageId) {
+            this.okeBlueGreenDeployStageId = okeBlueGreenDeployStageId;
+            this.__explicitlySet__.add("okeBlueGreenDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeBlueGreenTrafficShiftDeployStageSummary build() {
+            OkeBlueGreenTrafficShiftDeployStageSummary __instance__ =
+                    new OkeBlueGreenTrafficShiftDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeBlueGreenDeployStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeBlueGreenTrafficShiftDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeBlueGreenDeployStageId(o.getOkeBlueGreenDeployStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeBlueGreenTrafficShiftDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeBlueGreenDeployStageId) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeBlueGreenDeployStageId = okeBlueGreenDeployStageId;
+    }
+
+    /**
+     * The OCID of the upstream OKE blue-green deployment stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeBlueGreenDeployStageId")
+    String okeBlueGreenDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryApprovalDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryApprovalDeployStage.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster canary deployment approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeCanaryApprovalDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeCanaryApprovalDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryTrafficShiftDeployStageId")
+        private String okeCanaryTrafficShiftDeployStageId;
+
+        public Builder okeCanaryTrafficShiftDeployStageId(
+                String okeCanaryTrafficShiftDeployStageId) {
+            this.okeCanaryTrafficShiftDeployStageId = okeCanaryTrafficShiftDeployStageId;
+            this.__explicitlySet__.add("okeCanaryTrafficShiftDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+        private ApprovalPolicy approvalPolicy;
+
+        public Builder approvalPolicy(ApprovalPolicy approvalPolicy) {
+            this.approvalPolicy = approvalPolicy;
+            this.__explicitlySet__.add("approvalPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeCanaryApprovalDeployStage build() {
+            OkeCanaryApprovalDeployStage __instance__ =
+                    new OkeCanaryApprovalDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeCanaryTrafficShiftDeployStageId,
+                            approvalPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeCanaryApprovalDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeCanaryTrafficShiftDeployStageId(
+                                    o.getOkeCanaryTrafficShiftDeployStageId())
+                            .approvalPolicy(o.getApprovalPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeCanaryApprovalDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeCanaryTrafficShiftDeployStageId,
+            ApprovalPolicy approvalPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeCanaryTrafficShiftDeployStageId = okeCanaryTrafficShiftDeployStageId;
+        this.approvalPolicy = approvalPolicy;
+    }
+
+    /**
+     * The OCID of an upstream OKE canary deployment traffic shift stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryTrafficShiftDeployStageId")
+    String okeCanaryTrafficShiftDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+    ApprovalPolicy approvalPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryApprovalDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryApprovalDeployStageExecutionProgress.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Canary approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeCanaryApprovalDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeCanaryApprovalDeployStageExecutionProgress extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalActions")
+        private java.util.List<ApprovalAction> approvalActions;
+
+        public Builder approvalActions(java.util.List<ApprovalAction> approvalActions) {
+            this.approvalActions = approvalActions;
+            this.__explicitlySet__.add("approvalActions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeCanaryApprovalDeployStageExecutionProgress build() {
+            OkeCanaryApprovalDeployStageExecutionProgress __instance__ =
+                    new OkeCanaryApprovalDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails,
+                            approvalActions);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeCanaryApprovalDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails())
+                            .approvalActions(o.getApprovalActions());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeCanaryApprovalDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails> deployStageExecutionProgressDetails,
+            java.util.List<ApprovalAction> approvalActions) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+        this.approvalActions = approvalActions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalActions")
+    java.util.List<ApprovalAction> approvalActions;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryApprovalDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryApprovalDeployStageSummary.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster canary deployment approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeCanaryApprovalDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeCanaryApprovalDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryTrafficShiftDeployStageId")
+        private String okeCanaryTrafficShiftDeployStageId;
+
+        public Builder okeCanaryTrafficShiftDeployStageId(
+                String okeCanaryTrafficShiftDeployStageId) {
+            this.okeCanaryTrafficShiftDeployStageId = okeCanaryTrafficShiftDeployStageId;
+            this.__explicitlySet__.add("okeCanaryTrafficShiftDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+        private ApprovalPolicy approvalPolicy;
+
+        public Builder approvalPolicy(ApprovalPolicy approvalPolicy) {
+            this.approvalPolicy = approvalPolicy;
+            this.__explicitlySet__.add("approvalPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeCanaryApprovalDeployStageSummary build() {
+            OkeCanaryApprovalDeployStageSummary __instance__ =
+                    new OkeCanaryApprovalDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeCanaryTrafficShiftDeployStageId,
+                            approvalPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeCanaryApprovalDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeCanaryTrafficShiftDeployStageId(
+                                    o.getOkeCanaryTrafficShiftDeployStageId())
+                            .approvalPolicy(o.getApprovalPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeCanaryApprovalDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeCanaryTrafficShiftDeployStageId,
+            ApprovalPolicy approvalPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeCanaryTrafficShiftDeployStageId = okeCanaryTrafficShiftDeployStageId;
+        this.approvalPolicy = approvalPolicy;
+    }
+
+    /**
+     * The OCID of an upstream OKE canary deployment traffic shift stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryTrafficShiftDeployStageId")
+    String okeCanaryTrafficShiftDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+    ApprovalPolicy approvalPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryDeployStage.java
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeCanaryDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeCanaryDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+        private java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+        public Builder kubernetesManifestDeployArtifactIds(
+                java.util.List<String> kubernetesManifestDeployArtifactIds) {
+            this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+            this.__explicitlySet__.add("kubernetesManifestDeployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("canaryStrategy")
+        private OkeCanaryStrategy canaryStrategy;
+
+        public Builder canaryStrategy(OkeCanaryStrategy canaryStrategy) {
+            this.canaryStrategy = canaryStrategy;
+            this.__explicitlySet__.add("canaryStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeCanaryDeployStage build() {
+            OkeCanaryDeployStage __instance__ =
+                    new OkeCanaryDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeClusterDeployEnvironmentId,
+                            kubernetesManifestDeployArtifactIds,
+                            canaryStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeCanaryDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .kubernetesManifestDeployArtifactIds(
+                                    o.getKubernetesManifestDeployArtifactIds())
+                            .canaryStrategy(o.getCanaryStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeCanaryDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeClusterDeployEnvironmentId,
+            java.util.List<String> kubernetesManifestDeployArtifactIds,
+            OkeCanaryStrategy canaryStrategy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+        this.canaryStrategy = canaryStrategy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * List of Kubernetes manifest artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+    java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("canaryStrategy")
+    OkeCanaryStrategy canaryStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryDeployStageExecutionProgress.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeCanaryDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeCanaryDeployStageExecutionProgress extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeCanaryDeployStageExecutionProgress build() {
+            OkeCanaryDeployStageExecutionProgress __instance__ =
+                    new OkeCanaryDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeCanaryDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeCanaryDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails>
+                    deployStageExecutionProgressDetails) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryDeployStageSummary.java
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeCanaryDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeCanaryDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+        private java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+        public Builder kubernetesManifestDeployArtifactIds(
+                java.util.List<String> kubernetesManifestDeployArtifactIds) {
+            this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+            this.__explicitlySet__.add("kubernetesManifestDeployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("canaryStrategy")
+        private OkeCanaryStrategy canaryStrategy;
+
+        public Builder canaryStrategy(OkeCanaryStrategy canaryStrategy) {
+            this.canaryStrategy = canaryStrategy;
+            this.__explicitlySet__.add("canaryStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeCanaryDeployStageSummary build() {
+            OkeCanaryDeployStageSummary __instance__ =
+                    new OkeCanaryDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeClusterDeployEnvironmentId,
+                            kubernetesManifestDeployArtifactIds,
+                            canaryStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeCanaryDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .kubernetesManifestDeployArtifactIds(
+                                    o.getKubernetesManifestDeployArtifactIds())
+                            .canaryStrategy(o.getCanaryStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeCanaryDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeClusterDeployEnvironmentId,
+            java.util.List<String> kubernetesManifestDeployArtifactIds,
+            OkeCanaryStrategy canaryStrategy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+        this.canaryStrategy = canaryStrategy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * List of Kubernetes manifest artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+    java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("canaryStrategy")
+    OkeCanaryStrategy canaryStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryStrategy.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryStrategy.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the required canary release strategy for OKE deployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "strategyType",
+    defaultImpl = OkeCanaryStrategy.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = NginxCanaryStrategy.class,
+        name = "NGINX_CANARY_STRATEGY"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class OkeCanaryStrategy {
+
+    /**
+     * Canary strategy type.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum StrategyType {
+        NginxCanaryStrategy("NGINX_CANARY_STRATEGY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, StrategyType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (StrategyType v : StrategyType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        StrategyType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static StrategyType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'StrategyType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryTrafficShiftDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryTrafficShiftDeployStage.java
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster canary deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeCanaryTrafficShiftDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeCanaryTrafficShiftDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryDeployStageId")
+        private String okeCanaryDeployStageId;
+
+        public Builder okeCanaryDeployStageId(String okeCanaryDeployStageId) {
+            this.okeCanaryDeployStageId = okeCanaryDeployStageId;
+            this.__explicitlySet__.add("okeCanaryDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeCanaryTrafficShiftDeployStage build() {
+            OkeCanaryTrafficShiftDeployStage __instance__ =
+                    new OkeCanaryTrafficShiftDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeCanaryDeployStageId,
+                            rolloutPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeCanaryTrafficShiftDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeCanaryDeployStageId(o.getOkeCanaryDeployStageId())
+                            .rolloutPolicy(o.getRolloutPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeCanaryTrafficShiftDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeCanaryDeployStageId,
+            LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeCanaryDeployStageId = okeCanaryDeployStageId;
+        this.rolloutPolicy = rolloutPolicy;
+    }
+
+    /**
+     * The OCID of an upstream OKE canary deployment stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryDeployStageId")
+    String okeCanaryDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryTrafficShiftDeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryTrafficShiftDeployStageExecutionProgress.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Canary deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeCanaryTrafficShiftDeployStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeCanaryTrafficShiftDeployStageExecutionProgress
+        extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeCanaryTrafficShiftDeployStageExecutionProgress build() {
+            OkeCanaryTrafficShiftDeployStageExecutionProgress __instance__ =
+                    new OkeCanaryTrafficShiftDeployStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeCanaryTrafficShiftDeployStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeCanaryTrafficShiftDeployStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails>
+                    deployStageExecutionProgressDetails) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryTrafficShiftDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeCanaryTrafficShiftDeployStageSummary.java
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster canary deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeCanaryTrafficShiftDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeCanaryTrafficShiftDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryDeployStageId")
+        private String okeCanaryDeployStageId;
+
+        public Builder okeCanaryDeployStageId(String okeCanaryDeployStageId) {
+            this.okeCanaryDeployStageId = okeCanaryDeployStageId;
+            this.__explicitlySet__.add("okeCanaryDeployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeCanaryTrafficShiftDeployStageSummary build() {
+            OkeCanaryTrafficShiftDeployStageSummary __instance__ =
+                    new OkeCanaryTrafficShiftDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeCanaryDeployStageId,
+                            rolloutPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeCanaryTrafficShiftDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeCanaryDeployStageId(o.getOkeCanaryDeployStageId())
+                            .rolloutPolicy(o.getRolloutPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeCanaryTrafficShiftDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeCanaryDeployStageId,
+            LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeCanaryDeployStageId = okeCanaryDeployStageId;
+        this.rolloutPolicy = rolloutPolicy;
+    }
+
+    /**
+     * The OCID of an upstream OKE canary deployment stage in this pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeCanaryDeployStageId")
+    String okeCanaryDeployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeClusterDeployEnvironment.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeClusterDeployEnvironment.java
@@ -150,6 +150,15 @@ public class OkeClusterDeployEnvironment extends DeployEnvironment {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkChannel")
+        private NetworkChannel networkChannel;
+
+        public Builder networkChannel(NetworkChannel networkChannel) {
+            this.networkChannel = networkChannel;
+            this.__explicitlySet__.add("networkChannel");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -168,7 +177,8 @@ public class OkeClusterDeployEnvironment extends DeployEnvironment {
                             freeformTags,
                             definedTags,
                             systemTags,
-                            clusterId);
+                            clusterId,
+                            networkChannel);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -188,7 +198,8 @@ public class OkeClusterDeployEnvironment extends DeployEnvironment {
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .systemTags(o.getSystemTags())
-                            .clusterId(o.getClusterId());
+                            .clusterId(o.getClusterId())
+                            .networkChannel(o.getNetworkChannel());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -216,7 +227,8 @@ public class OkeClusterDeployEnvironment extends DeployEnvironment {
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             java.util.Map<String, java.util.Map<String, Object>> systemTags,
-            String clusterId) {
+            String clusterId,
+            NetworkChannel networkChannel) {
         super(
                 id,
                 description,
@@ -231,6 +243,7 @@ public class OkeClusterDeployEnvironment extends DeployEnvironment {
                 definedTags,
                 systemTags);
         this.clusterId = clusterId;
+        this.networkChannel = networkChannel;
     }
 
     /**
@@ -238,6 +251,9 @@ public class OkeClusterDeployEnvironment extends DeployEnvironment {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("clusterId")
     String clusterId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkChannel")
+    NetworkChannel networkChannel;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeClusterDeployEnvironmentSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeClusterDeployEnvironmentSummary.java
@@ -150,6 +150,15 @@ public class OkeClusterDeployEnvironmentSummary extends DeployEnvironmentSummary
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkChannel")
+        private NetworkChannel networkChannel;
+
+        public Builder networkChannel(NetworkChannel networkChannel) {
+            this.networkChannel = networkChannel;
+            this.__explicitlySet__.add("networkChannel");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -168,7 +177,8 @@ public class OkeClusterDeployEnvironmentSummary extends DeployEnvironmentSummary
                             freeformTags,
                             definedTags,
                             systemTags,
-                            clusterId);
+                            clusterId,
+                            networkChannel);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -188,7 +198,8 @@ public class OkeClusterDeployEnvironmentSummary extends DeployEnvironmentSummary
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .systemTags(o.getSystemTags())
-                            .clusterId(o.getClusterId());
+                            .clusterId(o.getClusterId())
+                            .networkChannel(o.getNetworkChannel());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -216,7 +227,8 @@ public class OkeClusterDeployEnvironmentSummary extends DeployEnvironmentSummary
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             java.util.Map<String, java.util.Map<String, Object>> systemTags,
-            String clusterId) {
+            String clusterId,
+            NetworkChannel networkChannel) {
         super(
                 id,
                 description,
@@ -231,6 +243,7 @@ public class OkeClusterDeployEnvironmentSummary extends DeployEnvironmentSummary
                 definedTags,
                 systemTags);
         this.clusterId = clusterId;
+        this.networkChannel = networkChannel;
     }
 
     /**
@@ -238,6 +251,9 @@ public class OkeClusterDeployEnvironmentSummary extends DeployEnvironmentSummary
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("clusterId")
     String clusterId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkChannel")
+    NetworkChannel networkChannel;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeDeployStage.java
@@ -307,13 +307,13 @@ public class OkeDeployStage extends DeployStage {
     String okeClusterDeployEnvironmentId;
 
     /**
-     * List of Kubernetes manifest artifact OCIDs, the manifests should not include any job resource.
+     * List of Kubernetes manifest artifact OCIDs.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
     java.util.List<String> kubernetesManifestDeployArtifactIds;
 
     /**
-     * Default Namespace to be used for Kubernetes deployment when not specified in the manifest.
+     * Default namespace to be used for Kubernetes deployment when not specified in the manifest.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("namespace")
     String namespace;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeDeployStageSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the Kubernetes cluster deployment stage.
+ * Specifies the Container Engine for Kubernetes (OKE) cluster deployment stage.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -309,7 +309,7 @@ public class OkeDeployStageSummary extends DeployStageSummary {
     String okeClusterDeployEnvironmentId;
 
     /**
-     * List of Kubernetes manifest artifact OCIDs, the manifests should not include any job resource.
+     * List of Kubernetes manifest artifact OCIDs.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
     java.util.List<String> kubernetesManifestDeployArtifactIds;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/PrivateEndpointChannel.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/PrivateEndpointChannel.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the configuration to access private endpoint.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PrivateEndpointChannel.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "networkChannelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PrivateEndpointChannel extends NetworkChannel {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PrivateEndpointChannel build() {
+            PrivateEndpointChannel __instance__ = new PrivateEndpointChannel(subnetId, nsgIds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PrivateEndpointChannel o) {
+            Builder copiedBuilder = subnetId(o.getSubnetId()).nsgIds(o.getNsgIds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PrivateEndpointChannel(String subnetId, java.util.List<String> nsgIds) {
+        super();
+        this.subnetId = subnetId;
+        this.nsgIds = nsgIds;
+    }
+
+    /**
+     * The OCID of the subnet where Virtual Network Interface Cards (VNIC) resources are created for private endpoint access.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * An array of network security group OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/PutRepositoryRefDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/PutRepositoryRefDetails.java
@@ -41,7 +41,7 @@ package com.oracle.bmc.devops.model;
 public class PutRepositoryRefDetails {
 
     /**
-     * The type of reference (Branch or Tag).
+     * The type of reference (BRANCH or TAG).
      **/
     public enum RefType {
         Branch("BRANCH"),

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Repository.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Repository.java
@@ -365,8 +365,8 @@ public class Repository {
     String defaultBranch;
     /**
      * Type of repository:
-     * Mirrored - Repository created by mirroring an existing repository.
-     * Hosted - Repository created and hosted using OCI DevOps code repository.
+     * MIRRORED - Repository created by mirroring an existing repository.
+     * HOSTED - Repository created and hosted using OCI DevOps code repository.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -414,8 +414,8 @@ public class Repository {
     };
     /**
      * Type of repository:
-     * Mirrored - Repository created by mirroring an existing repository.
-     * Hosted - Repository created and hosted using OCI DevOps code repository.
+     * MIRRORED - Repository created by mirroring an existing repository.
+     * HOSTED - Repository created and hosted using OCI DevOps code repository.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("repositoryType")
@@ -558,8 +558,8 @@ public class Repository {
     };
     /**
      * Trigger build events supported for this repository:
-     * Push - Build is triggered when a push event occurs.
-     * Commit updates - Build is triggered when new commits are mirrored into a repository.
+     * PUSH - Build is triggered when a push event occurs.
+     * COMMIT_UPDATES - Build is triggered when new commits are mirrored into a repository.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("triggerBuildEvents")

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/RepositoryBranch.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/RepositoryBranch.java
@@ -57,6 +57,25 @@ public class RepositoryBranch extends RepositoryRef {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("commitId")
         private String commitId;
 
@@ -71,7 +90,13 @@ public class RepositoryBranch extends RepositoryRef {
 
         public RepositoryBranch build() {
             RepositoryBranch __instance__ =
-                    new RepositoryBranch(refName, fullRefName, repositoryId, commitId);
+                    new RepositoryBranch(
+                            refName,
+                            fullRefName,
+                            repositoryId,
+                            freeformTags,
+                            definedTags,
+                            commitId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -82,6 +107,8 @@ public class RepositoryBranch extends RepositoryRef {
                     refName(o.getRefName())
                             .fullRefName(o.getFullRefName())
                             .repositoryId(o.getRepositoryId())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
                             .commitId(o.getCommitId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -98,8 +125,13 @@ public class RepositoryBranch extends RepositoryRef {
 
     @Deprecated
     public RepositoryBranch(
-            String refName, String fullRefName, String repositoryId, String commitId) {
-        super(refName, fullRefName, repositoryId);
+            String refName,
+            String fullRefName,
+            String repositoryId,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String commitId) {
+        super(refName, fullRefName, repositoryId, freeformTags, definedTags);
         this.commitId = commitId;
     }
 

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/RepositoryRef.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/RepositoryRef.java
@@ -56,7 +56,19 @@ public class RepositoryRef {
     String repositoryId;
 
     /**
-     * The type of reference (Branch or Tag).
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.  See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: {@code {"bar-key": "value"}}
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The type of reference (BRANCH or TAG).
      **/
     @lombok.extern.slf4j.Slf4j
     public enum RefType {

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/RepositoryTag.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/RepositoryTag.java
@@ -57,6 +57,25 @@ public class RepositoryTag extends RepositoryRef {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("objectId")
         private String objectId;
 
@@ -71,7 +90,13 @@ public class RepositoryTag extends RepositoryRef {
 
         public RepositoryTag build() {
             RepositoryTag __instance__ =
-                    new RepositoryTag(refName, fullRefName, repositoryId, objectId);
+                    new RepositoryTag(
+                            refName,
+                            fullRefName,
+                            repositoryId,
+                            freeformTags,
+                            definedTags,
+                            objectId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -82,6 +107,8 @@ public class RepositoryTag extends RepositoryRef {
                     refName(o.getRefName())
                             .fullRefName(o.getFullRefName())
                             .repositoryId(o.getRepositoryId())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
                             .objectId(o.getObjectId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -97,8 +124,14 @@ public class RepositoryTag extends RepositoryRef {
     }
 
     @Deprecated
-    public RepositoryTag(String refName, String fullRefName, String repositoryId, String objectId) {
-        super(refName, fullRefName, repositoryId);
+    public RepositoryTag(
+            String refName,
+            String fullRefName,
+            String repositoryId,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String objectId) {
+        super(refName, fullRefName, repositoryId, freeformTags, definedTags);
         this.objectId = objectId;
     }
 

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/SingleDeployStageRedeployment.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/SingleDeployStageRedeployment.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Redeployment of a single stage of a previous deployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = SingleDeployStageRedeployment.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deploymentType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SingleDeployStageRedeployment extends Deployment {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineArtifacts")
+        private DeployPipelineArtifactCollection deployPipelineArtifacts;
+
+        public Builder deployPipelineArtifacts(
+                DeployPipelineArtifactCollection deployPipelineArtifacts) {
+            this.deployPipelineArtifacts = deployPipelineArtifacts;
+            this.__explicitlySet__.add("deployPipelineArtifacts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineEnvironments")
+        private DeployPipelineEnvironmentCollection deployPipelineEnvironments;
+
+        public Builder deployPipelineEnvironments(
+                DeployPipelineEnvironmentCollection deployPipelineEnvironments) {
+            this.deployPipelineEnvironments = deployPipelineEnvironments;
+            this.__explicitlySet__.add("deployPipelineEnvironments");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentArguments")
+        private DeploymentArgumentCollection deploymentArguments;
+
+        public Builder deploymentArguments(DeploymentArgumentCollection deploymentArguments) {
+            this.deploymentArguments = deploymentArguments;
+            this.__explicitlySet__.add("deploymentArguments");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactOverrideArguments")
+        private DeployArtifactOverrideArgumentCollection deployArtifactOverrideArguments;
+
+        public Builder deployArtifactOverrideArguments(
+                DeployArtifactOverrideArgumentCollection deployArtifactOverrideArguments) {
+            this.deployArtifactOverrideArguments = deployArtifactOverrideArguments;
+            this.__explicitlySet__.add("deployArtifactOverrideArguments");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentExecutionProgress")
+        private DeploymentExecutionProgress deploymentExecutionProgress;
+
+        public Builder deploymentExecutionProgress(
+                DeploymentExecutionProgress deploymentExecutionProgress) {
+            this.deploymentExecutionProgress = deploymentExecutionProgress;
+            this.__explicitlySet__.add("deploymentExecutionProgress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("previousDeploymentId")
+        private String previousDeploymentId;
+
+        public Builder previousDeploymentId(String previousDeploymentId) {
+            this.previousDeploymentId = previousDeploymentId;
+            this.__explicitlySet__.add("previousDeploymentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SingleDeployStageRedeployment build() {
+            SingleDeployStageRedeployment __instance__ =
+                    new SingleDeployStageRedeployment(
+                            deployPipelineArtifacts,
+                            deployPipelineEnvironments,
+                            id,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deploymentArguments,
+                            deployArtifactOverrideArguments,
+                            deploymentExecutionProgress,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            previousDeploymentId,
+                            deployStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SingleDeployStageRedeployment o) {
+            Builder copiedBuilder =
+                    deployPipelineArtifacts(o.getDeployPipelineArtifacts())
+                            .deployPipelineEnvironments(o.getDeployPipelineEnvironments())
+                            .id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deploymentArguments(o.getDeploymentArguments())
+                            .deployArtifactOverrideArguments(o.getDeployArtifactOverrideArguments())
+                            .deploymentExecutionProgress(o.getDeploymentExecutionProgress())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .previousDeploymentId(o.getPreviousDeploymentId())
+                            .deployStageId(o.getDeployStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public SingleDeployStageRedeployment(
+            DeployPipelineArtifactCollection deployPipelineArtifacts,
+            DeployPipelineEnvironmentCollection deployPipelineEnvironments,
+            String id,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeploymentArgumentCollection deploymentArguments,
+            DeployArtifactOverrideArgumentCollection deployArtifactOverrideArguments,
+            DeploymentExecutionProgress deploymentExecutionProgress,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String previousDeploymentId,
+            String deployStageId) {
+        super(
+                deployPipelineArtifacts,
+                deployPipelineEnvironments,
+                id,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deploymentArguments,
+                deployArtifactOverrideArguments,
+                deploymentExecutionProgress,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.previousDeploymentId = previousDeploymentId;
+        this.deployStageId = deployStageId;
+    }
+
+    /**
+     * Specifies the OCID of the previous deployment to be redeployed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("previousDeploymentId")
+    String previousDeploymentId;
+
+    /**
+     * Specifies the OCID of the stage to be redeployed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+    String deployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/SingleDeployStageRedeploymentSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/SingleDeployStageRedeploymentSummary.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Summary of a single stage redeployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = SingleDeployStageRedeploymentSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deploymentType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SingleDeployStageRedeploymentSummary extends DeploymentSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private Deployment.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(Deployment.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentArguments")
+        private DeploymentArgumentCollection deploymentArguments;
+
+        public Builder deploymentArguments(DeploymentArgumentCollection deploymentArguments) {
+            this.deploymentArguments = deploymentArguments;
+            this.__explicitlySet__.add("deploymentArguments");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactOverrideArguments")
+        private DeployArtifactOverrideArgumentCollection deployArtifactOverrideArguments;
+
+        public Builder deployArtifactOverrideArguments(
+                DeployArtifactOverrideArgumentCollection deployArtifactOverrideArguments) {
+            this.deployArtifactOverrideArguments = deployArtifactOverrideArguments;
+            this.__explicitlySet__.add("deployArtifactOverrideArguments");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("previousDeploymentId")
+        private String previousDeploymentId;
+
+        public Builder previousDeploymentId(String previousDeploymentId) {
+            this.previousDeploymentId = previousDeploymentId;
+            this.__explicitlySet__.add("previousDeploymentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SingleDeployStageRedeploymentSummary build() {
+            SingleDeployStageRedeploymentSummary __instance__ =
+                    new SingleDeployStageRedeploymentSummary(
+                            id,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            deploymentArguments,
+                            deployArtifactOverrideArguments,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            previousDeploymentId,
+                            deployStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SingleDeployStageRedeploymentSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .deploymentArguments(o.getDeploymentArguments())
+                            .deployArtifactOverrideArguments(o.getDeployArtifactOverrideArguments())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .previousDeploymentId(o.getPreviousDeploymentId())
+                            .deployStageId(o.getDeployStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public SingleDeployStageRedeploymentSummary(
+            String id,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            Deployment.LifecycleState lifecycleState,
+            DeploymentArgumentCollection deploymentArguments,
+            DeployArtifactOverrideArgumentCollection deployArtifactOverrideArguments,
+            String lifecycleDetails,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String previousDeploymentId,
+            String deployStageId) {
+        super(
+                id,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                deploymentArguments,
+                deployArtifactOverrideArguments,
+                lifecycleDetails,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.previousDeploymentId = previousDeploymentId;
+        this.deployStageId = deployStageId;
+    }
+
+    /**
+     * Specifies the OCID of the previous deployment to be redeployed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("previousDeploymentId")
+    String previousDeploymentId;
+
+    /**
+     * Specifies the OCID of the stage to be redeployed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+    String deployStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/TriggerSchedule.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/TriggerSchedule.java
@@ -70,9 +70,9 @@ public class TriggerSchedule {
 
     /**
      * Different types of trigger schedule:
-     * None - No automated synchronization schedule.
-     * Default - Trigger schedule is every 30 minutes.
-     * Custom - Custom triggering schedule.
+     * NONE - No automated synchronization schedule.
+     * DEFAULT - Trigger schedule is every 30 minutes.
+     * CUSTOM - Custom triggering schedule.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -121,9 +121,9 @@ public class TriggerSchedule {
     };
     /**
      * Different types of trigger schedule:
-     * None - No automated synchronization schedule.
-     * Default - Trigger schedule is every 30 minutes.
-     * Custom - Custom triggering schedule.
+     * NONE - No automated synchronization schedule.
+     * DEFAULT - Trigger schedule is every 30 minutes.
+     * CUSTOM - Custom triggering schedule.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scheduleType")

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupBlueGreenDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupBlueGreenDeployStageDetails.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateComputeInstanceGroupBlueGreenDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateComputeInstanceGroupBlueGreenDeployStageDetails
+        extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+        private String deploymentSpecDeployArtifactId;
+
+        public Builder deploymentSpecDeployArtifactId(String deploymentSpecDeployArtifactId) {
+            this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+            this.__explicitlySet__.add("deploymentSpecDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+        private java.util.List<String> deployArtifactIds;
+
+        public Builder deployArtifactIds(java.util.List<String> deployArtifactIds) {
+            this.deployArtifactIds = deployArtifactIds;
+            this.__explicitlySet__.add("deployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(ComputeInstanceGroupRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("failurePolicy")
+        private ComputeInstanceGroupFailurePolicy failurePolicy;
+
+        public Builder failurePolicy(ComputeInstanceGroupFailurePolicy failurePolicy) {
+            this.failurePolicy = failurePolicy;
+            this.__explicitlySet__.add("failurePolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+        private LoadBalancerConfig testLoadBalancerConfig;
+
+        public Builder testLoadBalancerConfig(LoadBalancerConfig testLoadBalancerConfig) {
+            this.testLoadBalancerConfig = testLoadBalancerConfig;
+            this.__explicitlySet__.add("testLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateComputeInstanceGroupBlueGreenDeployStageDetails build() {
+            UpdateComputeInstanceGroupBlueGreenDeployStageDetails __instance__ =
+                    new UpdateComputeInstanceGroupBlueGreenDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            deploymentSpecDeployArtifactId,
+                            deployArtifactIds,
+                            rolloutPolicy,
+                            failurePolicy,
+                            testLoadBalancerConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateComputeInstanceGroupBlueGreenDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .deploymentSpecDeployArtifactId(o.getDeploymentSpecDeployArtifactId())
+                            .deployArtifactIds(o.getDeployArtifactIds())
+                            .rolloutPolicy(o.getRolloutPolicy())
+                            .failurePolicy(o.getFailurePolicy())
+                            .testLoadBalancerConfig(o.getTestLoadBalancerConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateComputeInstanceGroupBlueGreenDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String deploymentSpecDeployArtifactId,
+            java.util.List<String> deployArtifactIds,
+            ComputeInstanceGroupRolloutPolicy rolloutPolicy,
+            ComputeInstanceGroupFailurePolicy failurePolicy,
+            LoadBalancerConfig testLoadBalancerConfig) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+        this.deployArtifactIds = deployArtifactIds;
+        this.rolloutPolicy = rolloutPolicy;
+        this.failurePolicy = failurePolicy;
+        this.testLoadBalancerConfig = testLoadBalancerConfig;
+    }
+
+    /**
+     * The OCID of the artifact that contains the deployment specification.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+    String deploymentSpecDeployArtifactId;
+
+    /**
+     * The list of file artifact OCIDs to deploy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+    java.util.List<String> deployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("failurePolicy")
+    ComputeInstanceGroupFailurePolicy failurePolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+    LoadBalancerConfig testLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the instance group blue-green deployment load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails
+        extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails build() {
+            UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails __instance__ =
+                    new UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the canary approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails
+        extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+        private ApprovalPolicy approvalPolicy;
+
+        public Builder approvalPolicy(ApprovalPolicy approvalPolicy) {
+            this.approvalPolicy = approvalPolicy;
+            this.__explicitlySet__.add("approvalPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails build() {
+            UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails __instance__ =
+                    new UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            approvalPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .approvalPolicy(o.getApprovalPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            ApprovalPolicy approvalPolicy) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.approvalPolicy = approvalPolicy;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+    ApprovalPolicy approvalPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupCanaryDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupCanaryDeployStageDetails.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Instance Group Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateComputeInstanceGroupCanaryDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateComputeInstanceGroupCanaryDeployStageDetails extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+        private String deploymentSpecDeployArtifactId;
+
+        public Builder deploymentSpecDeployArtifactId(String deploymentSpecDeployArtifactId) {
+            this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+            this.__explicitlySet__.add("deploymentSpecDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+        private java.util.List<String> deployArtifactIds;
+
+        public Builder deployArtifactIds(java.util.List<String> deployArtifactIds) {
+            this.deployArtifactIds = deployArtifactIds;
+            this.__explicitlySet__.add("deployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(ComputeInstanceGroupRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+        private LoadBalancerConfig testLoadBalancerConfig;
+
+        public Builder testLoadBalancerConfig(LoadBalancerConfig testLoadBalancerConfig) {
+            this.testLoadBalancerConfig = testLoadBalancerConfig;
+            this.__explicitlySet__.add("testLoadBalancerConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateComputeInstanceGroupCanaryDeployStageDetails build() {
+            UpdateComputeInstanceGroupCanaryDeployStageDetails __instance__ =
+                    new UpdateComputeInstanceGroupCanaryDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            deploymentSpecDeployArtifactId,
+                            deployArtifactIds,
+                            rolloutPolicy,
+                            testLoadBalancerConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateComputeInstanceGroupCanaryDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .deploymentSpecDeployArtifactId(o.getDeploymentSpecDeployArtifactId())
+                            .deployArtifactIds(o.getDeployArtifactIds())
+                            .rolloutPolicy(o.getRolloutPolicy())
+                            .testLoadBalancerConfig(o.getTestLoadBalancerConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateComputeInstanceGroupCanaryDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String deploymentSpecDeployArtifactId,
+            java.util.List<String> deployArtifactIds,
+            ComputeInstanceGroupRolloutPolicy rolloutPolicy,
+            LoadBalancerConfig testLoadBalancerConfig) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.deploymentSpecDeployArtifactId = deploymentSpecDeployArtifactId;
+        this.deployArtifactIds = deployArtifactIds;
+        this.rolloutPolicy = rolloutPolicy;
+        this.testLoadBalancerConfig = testLoadBalancerConfig;
+    }
+
+    /**
+     * The OCID of the artifact that contains the deployment specification.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentSpecDeployArtifactId")
+    String deploymentSpecDeployArtifactId;
+
+    /**
+     * The list of file artifact OCIDs to deploy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactIds")
+    java.util.List<String> deployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    ComputeInstanceGroupRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("testLoadBalancerConfig")
+    LoadBalancerConfig testLoadBalancerConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies load balancer traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails
+        extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails build() {
+            UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails __instance__ =
+                    new UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            rolloutPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .rolloutPolicy(o.getRolloutPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.rolloutPolicy = rolloutPolicy;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateComputeInstanceGroupDeployStageDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the instance group rolling deployment stage.
+ * Specifies the Instance Group Rolling deployment stage.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateDeployStageDetails.java
@@ -29,28 +29,68 @@ package com.oracle.bmc.devops.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = UpdateOkeDeployStageDetails.class,
-        name = "OKE_DEPLOYMENT"
+        value = UpdateOkeCanaryTrafficShiftDeployStageDetails.class,
+        name = "OKE_CANARY_TRAFFIC_SHIFT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = UpdateLoadBalancerTrafficShiftDeployStageDetails.class,
-        name = "LOAD_BALANCER_TRAFFIC_SHIFT"
+        value = UpdateOkeCanaryDeployStageDetails.class,
+        name = "OKE_CANARY_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateComputeInstanceGroupDeployStageDetails.class,
         name = "COMPUTE_INSTANCE_GROUP_ROLLING_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateOkeCanaryApprovalDeployStageDetails.class,
+        name = "OKE_CANARY_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateOkeDeployStageDetails.class,
+        name = "OKE_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateComputeInstanceGroupCanaryApprovalDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_APPROVAL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateLoadBalancerTrafficShiftDeployStageDetails.class,
+        name = "LOAD_BALANCER_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateOkeBlueGreenDeployStageDetails.class,
+        name = "OKE_BLUE_GREEN_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateWaitDeployStageDetails.class,
         name = "WAIT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateOkeBlueGreenTrafficShiftDeployStageDetails.class,
+        name = "OKE_BLUE_GREEN_TRAFFIC_SHIFT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateManualApprovalDeployStageDetails.class,
         name = "MANUAL_APPROVAL"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateComputeInstanceGroupBlueGreenDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateComputeInstanceGroupCanaryDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateFunctionDeployStageDetails.class,
         name = "DEPLOY_FUNCTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateComputeInstanceGroupBlueGreenTrafficShiftDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_TRAFFIC_SHIFT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateComputeInstanceGroupCanaryTrafficShiftDeployStageDetails.class,
+        name = "COMPUTE_INSTANCE_GROUP_CANARY_TRAFFIC_SHIFT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateInvokeFunctionDeployStageDetails.class,

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateDeploymentDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateDeploymentDetails.java
@@ -39,6 +39,10 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateDeployPipelineDeploymentDetails.class,
         name = "PIPELINE_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateSingleDeployStageRedeploymentDetails.class,
+        name = "SINGLE_STAGE_REDEPLOYMENT"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateGithubAccessTokenConnectionDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateGithubAccessTokenConnectionDetails.java
@@ -124,7 +124,7 @@ public class UpdateGithubAccessTokenConnectionDetails extends UpdateConnectionDe
     }
 
     /**
-     * The OCID of personal access token saved in secret store.
+     * OCID of personal access token saved in secret store
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("accessToken")
     String accessToken;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeBlueGreenDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeBlueGreenDeployStageDetails.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Blue-Green deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOkeBlueGreenDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOkeBlueGreenDeployStageDetails extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+        private java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+        public Builder kubernetesManifestDeployArtifactIds(
+                java.util.List<String> kubernetesManifestDeployArtifactIds) {
+            this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+            this.__explicitlySet__.add("kubernetesManifestDeployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOkeBlueGreenDeployStageDetails build() {
+            UpdateOkeBlueGreenDeployStageDetails __instance__ =
+                    new UpdateOkeBlueGreenDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            kubernetesManifestDeployArtifactIds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOkeBlueGreenDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .kubernetesManifestDeployArtifactIds(
+                                    o.getKubernetesManifestDeployArtifactIds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateOkeBlueGreenDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.List<String> kubernetesManifestDeployArtifactIds) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+    }
+
+    /**
+     * List of Kubernetes manifest artifact OCIDs, the manifests should not include any job resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+    java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeBlueGreenTrafficShiftDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeBlueGreenTrafficShiftDeployStageDetails.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster blue-green deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOkeBlueGreenTrafficShiftDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOkeBlueGreenTrafficShiftDeployStageDetails extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOkeBlueGreenTrafficShiftDeployStageDetails build() {
+            UpdateOkeBlueGreenTrafficShiftDeployStageDetails __instance__ =
+                    new UpdateOkeBlueGreenTrafficShiftDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOkeBlueGreenTrafficShiftDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateOkeBlueGreenTrafficShiftDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeCanaryApprovalDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeCanaryApprovalDeployStageDetails.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster canary deployment approval stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOkeCanaryApprovalDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOkeCanaryApprovalDeployStageDetails extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+        private ApprovalPolicy approvalPolicy;
+
+        public Builder approvalPolicy(ApprovalPolicy approvalPolicy) {
+            this.approvalPolicy = approvalPolicy;
+            this.__explicitlySet__.add("approvalPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOkeCanaryApprovalDeployStageDetails build() {
+            UpdateOkeCanaryApprovalDeployStageDetails __instance__ =
+                    new UpdateOkeCanaryApprovalDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            approvalPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOkeCanaryApprovalDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .approvalPolicy(o.getApprovalPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateOkeCanaryApprovalDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            ApprovalPolicy approvalPolicy) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.approvalPolicy = approvalPolicy;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("approvalPolicy")
+    ApprovalPolicy approvalPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeCanaryDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeCanaryDeployStageDetails.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster Canary deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOkeCanaryDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOkeCanaryDeployStageDetails extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+        private java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+        public Builder kubernetesManifestDeployArtifactIds(
+                java.util.List<String> kubernetesManifestDeployArtifactIds) {
+            this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+            this.__explicitlySet__.add("kubernetesManifestDeployArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOkeCanaryDeployStageDetails build() {
+            UpdateOkeCanaryDeployStageDetails __instance__ =
+                    new UpdateOkeCanaryDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            kubernetesManifestDeployArtifactIds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOkeCanaryDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .kubernetesManifestDeployArtifactIds(
+                                    o.getKubernetesManifestDeployArtifactIds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateOkeCanaryDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.List<String> kubernetesManifestDeployArtifactIds) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.kubernetesManifestDeployArtifactIds = kubernetesManifestDeployArtifactIds;
+    }
+
+    /**
+     * List of Kubernetes manifest artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
+    java.util.List<String> kubernetesManifestDeployArtifactIds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeCanaryTrafficShiftDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeCanaryTrafficShiftDeployStageDetails.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Container Engine for Kubernetes (OKE) cluster canary deployment traffic shift stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOkeCanaryTrafficShiftDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOkeCanaryTrafficShiftDeployStageDetails extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+        private LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+        public Builder rolloutPolicy(LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+            this.rolloutPolicy = rolloutPolicy;
+            this.__explicitlySet__.add("rolloutPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOkeCanaryTrafficShiftDeployStageDetails build() {
+            UpdateOkeCanaryTrafficShiftDeployStageDetails __instance__ =
+                    new UpdateOkeCanaryTrafficShiftDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            rolloutPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOkeCanaryTrafficShiftDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .rolloutPolicy(o.getRolloutPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateOkeCanaryTrafficShiftDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.rolloutPolicy = rolloutPolicy;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rolloutPolicy")
+    LoadBalancerTrafficShiftRolloutPolicy rolloutPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeClusterDeployEnvironmentDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeClusterDeployEnvironmentDetails.java
@@ -78,13 +78,27 @@ public class UpdateOkeClusterDeployEnvironmentDetails extends UpdateDeployEnviro
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkChannel")
+        private NetworkChannel networkChannel;
+
+        public Builder networkChannel(NetworkChannel networkChannel) {
+            this.networkChannel = networkChannel;
+            this.__explicitlySet__.add("networkChannel");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateOkeClusterDeployEnvironmentDetails build() {
             UpdateOkeClusterDeployEnvironmentDetails __instance__ =
                     new UpdateOkeClusterDeployEnvironmentDetails(
-                            description, displayName, freeformTags, definedTags, clusterId);
+                            description,
+                            displayName,
+                            freeformTags,
+                            definedTags,
+                            clusterId,
+                            networkChannel);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -96,7 +110,8 @@ public class UpdateOkeClusterDeployEnvironmentDetails extends UpdateDeployEnviro
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
-                            .clusterId(o.getClusterId());
+                            .clusterId(o.getClusterId())
+                            .networkChannel(o.getNetworkChannel());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -116,9 +131,11 @@ public class UpdateOkeClusterDeployEnvironmentDetails extends UpdateDeployEnviro
             String displayName,
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
-            String clusterId) {
+            String clusterId,
+            NetworkChannel networkChannel) {
         super(description, displayName, freeformTags, definedTags);
         this.clusterId = clusterId;
+        this.networkChannel = networkChannel;
     }
 
     /**
@@ -126,6 +143,9 @@ public class UpdateOkeClusterDeployEnvironmentDetails extends UpdateDeployEnviro
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("clusterId")
     String clusterId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkChannel")
+    NetworkChannel networkChannel;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeDeployStageDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the Kubernetes cluster deployment stage.
+ * Specifies the Container Engine for Kubernetes (OKE) cluster deployment stage.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -192,7 +192,7 @@ public class UpdateOkeDeployStageDetails extends UpdateDeployStageDetails {
     String okeClusterDeployEnvironmentId;
 
     /**
-     * List of Kubernetes manifest artifact OCIDs, the manifests should not include any job resource.
+     * List of Kubernetes manifest artifact OCIDs.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetesManifestDeployArtifactIds")
     java.util.List<String> kubernetesManifestDeployArtifactIds;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateSingleDeployStageRedeploymentDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateSingleDeployStageRedeploymentDetails.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Update details for a single stage redeployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateSingleDeployStageRedeploymentDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deploymentType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateSingleDeployStageRedeploymentDetails extends UpdateDeploymentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateSingleDeployStageRedeploymentDetails build() {
+            UpdateSingleDeployStageRedeploymentDetails __instance__ =
+                    new UpdateSingleDeployStageRedeploymentDetails(
+                            displayName, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateSingleDeployStageRedeploymentDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateSingleDeployStageRedeploymentDetails(
+            String displayName,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+        super(displayName, freeformTags, definedTags);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/requests/CreateDeployStageRequest.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/requests/CreateDeployStageRequest.java
@@ -22,7 +22,7 @@ public class CreateDeployStageRequest
                 com.oracle.bmc.devops.model.CreateDeployStageDetails> {
 
     /**
-     * Details for the new DeployStage.
+     * Details for the new deployment stage.
      */
     private com.oracle.bmc.devops.model.CreateDeployStageDetails createDeployStageDetails;
 

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/requests/GetRepoFileDiffRequest.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/requests/GetRepoFileDiffRequest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.requests;
+
+import com.oracle.bmc.devops.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/devops/GetRepoFileDiffExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetRepoFileDiffRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetRepoFileDiffRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique repository identifier.
+     */
+    private String repositoryId;
+
+    /**
+     * The branch to compare changes against.
+     */
+    private String baseVersion;
+
+    /**
+     * The branch where changes are coming from.
+     */
+    private String targetVersion;
+
+    /**
+     * A filter to return only commits that affect any of the specified paths.
+     */
+    private String filePath;
+
+    /**
+     * Boolean to indicate whether to use merge base or most recent revision.
+     */
+    private Boolean isComparisonFromMergeBase;
+
+    /**
+     * Unique Oracle-assigned identifier for the request.  If you need to contact Oracle about a particular request, provide the request ID.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetRepoFileDiffRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetRepoFileDiffRequest o) {
+            repositoryId(o.getRepositoryId());
+            baseVersion(o.getBaseVersion());
+            targetVersion(o.getTargetVersion());
+            filePath(o.getFilePath());
+            isComparisonFromMergeBase(o.getIsComparisonFromMergeBase());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetRepoFileDiffRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetRepoFileDiffRequest
+         */
+        public GetRepoFileDiffRequest build() {
+            GetRepoFileDiffRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/requests/GetRepoFileLinesRequest.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/requests/GetRepoFileLinesRequest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.requests;
+
+import com.oracle.bmc.devops.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/devops/GetRepoFileLinesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetRepoFileLinesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetRepoFileLinesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique repository identifier.
+     */
+    private String repositoryId;
+
+    /**
+     * Retrieve file lines from specific revision.
+     */
+    private String revision;
+
+    /**
+     * A filter to return only commits that affect any of the specified paths.
+     */
+    private String filePath;
+
+    /**
+     * Line number from where to start returning file lines.
+     */
+    private Integer startLineNumber;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * Unique Oracle-assigned identifier for the request.  If you need to contact Oracle about a particular request, provide the request ID.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetRepoFileLinesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetRepoFileLinesRequest o) {
+            repositoryId(o.getRepositoryId());
+            revision(o.getRevision());
+            filePath(o.getFilePath());
+            startLineNumber(o.getStartLineNumber());
+            limit(o.getLimit());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetRepoFileLinesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetRepoFileLinesRequest
+         */
+        public GetRepoFileLinesRequest build() {
+            GetRepoFileLinesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/responses/GetFileDiffResponse.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/responses/GetFileDiffResponse.java
@@ -23,6 +23,11 @@ public class GetFileDiffResponse extends com.oracle.bmc.responses.BmcResponse {
     private String opcRequestId;
 
     /**
+     * This API will be deprecated on Wed, 29 Mar 2023 01:00:00 GMT. Please use "/repositories/{repositoryId}/file/diffs"
+     */
+    private String sunset;
+
+    /**
      * The returned FileDiffResponse instance.
      */
     private com.oracle.bmc.devops.model.FileDiffResponse fileDiffResponse;
@@ -31,16 +36,19 @@ public class GetFileDiffResponse extends com.oracle.bmc.responses.BmcResponse {
         "__httpStatusCode__",
         "etag",
         "opcRequestId",
+        "sunset",
         "fileDiffResponse"
     })
     private GetFileDiffResponse(
             int __httpStatusCode__,
             String etag,
             String opcRequestId,
+            String sunset,
             com.oracle.bmc.devops.model.FileDiffResponse fileDiffResponse) {
         super(__httpStatusCode__);
         this.etag = etag;
         this.opcRequestId = opcRequestId;
+        this.sunset = sunset;
         this.fileDiffResponse = fileDiffResponse;
     }
 
@@ -60,6 +68,7 @@ public class GetFileDiffResponse extends com.oracle.bmc.responses.BmcResponse {
             __httpStatusCode__(o.get__httpStatusCode__());
             etag(o.getEtag());
             opcRequestId(o.getOpcRequestId());
+            sunset(o.getSunset());
             fileDiffResponse(o.getFileDiffResponse());
 
             return this;
@@ -67,7 +76,7 @@ public class GetFileDiffResponse extends com.oracle.bmc.responses.BmcResponse {
 
         public GetFileDiffResponse build() {
             return new GetFileDiffResponse(
-                    __httpStatusCode__, etag, opcRequestId, fileDiffResponse);
+                    __httpStatusCode__, etag, opcRequestId, sunset, fileDiffResponse);
         }
     }
 }

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/responses/GetRepoFileDiffResponse.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/responses/GetRepoFileDiffResponse.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.responses;
+
+import com.oracle.bmc.devops.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetRepoFileDiffResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, provide the request ID.
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned FileDiffResponse instance.
+     */
+    private com.oracle.bmc.devops.model.FileDiffResponse fileDiffResponse;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "etag",
+        "opcRequestId",
+        "fileDiffResponse"
+    })
+    private GetRepoFileDiffResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.devops.model.FileDiffResponse fileDiffResponse) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.fileDiffResponse = fileDiffResponse;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetRepoFileDiffResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            fileDiffResponse(o.getFileDiffResponse());
+
+            return this;
+        }
+
+        public GetRepoFileDiffResponse build() {
+            return new GetRepoFileDiffResponse(
+                    __httpStatusCode__, etag, opcRequestId, fileDiffResponse);
+        }
+    }
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/responses/GetRepoFileLinesResponse.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/responses/GetRepoFileLinesResponse.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.responses;
+
+import com.oracle.bmc.devops.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetRepoFileLinesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, provide the request ID.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * The returned RepositoryFileLines instance.
+     */
+    private com.oracle.bmc.devops.model.RepositoryFileLines repositoryFileLines;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "etag",
+        "repositoryFileLines"
+    })
+    private GetRepoFileLinesResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String etag,
+            com.oracle.bmc.devops.model.RepositoryFileLines repositoryFileLines) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.etag = etag;
+        this.repositoryFileLines = repositoryFileLines;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetRepoFileLinesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            repositoryFileLines(o.getRepositoryFileLines());
+
+            return this;
+        }
+
+        public GetRepoFileLinesResponse build() {
+            return new GetRepoFileLinesResponse(
+                    __httpStatusCode__, opcRequestId, etag, repositoryFileLines);
+        }
+    }
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/responses/GetRepositoryFileLinesResponse.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/responses/GetRepositoryFileLinesResponse.java
@@ -23,6 +23,11 @@ public class GetRepositoryFileLinesResponse extends com.oracle.bmc.responses.Bmc
     private String etag;
 
     /**
+     * This API will be deprecated on Wed, 29 Mar 2023 01:00:00 GMT. Please use "/repositories/{repositoryId}/file/lines"
+     */
+    private String sunset;
+
+    /**
      * The returned RepositoryFileLines instance.
      */
     private com.oracle.bmc.devops.model.RepositoryFileLines repositoryFileLines;
@@ -31,16 +36,19 @@ public class GetRepositoryFileLinesResponse extends com.oracle.bmc.responses.Bmc
         "__httpStatusCode__",
         "opcRequestId",
         "etag",
+        "sunset",
         "repositoryFileLines"
     })
     private GetRepositoryFileLinesResponse(
             int __httpStatusCode__,
             String opcRequestId,
             String etag,
+            String sunset,
             com.oracle.bmc.devops.model.RepositoryFileLines repositoryFileLines) {
         super(__httpStatusCode__);
         this.opcRequestId = opcRequestId;
         this.etag = etag;
+        this.sunset = sunset;
         this.repositoryFileLines = repositoryFileLines;
     }
 
@@ -60,6 +68,7 @@ public class GetRepositoryFileLinesResponse extends com.oracle.bmc.responses.Bmc
             __httpStatusCode__(o.get__httpStatusCode__());
             opcRequestId(o.getOpcRequestId());
             etag(o.getEtag());
+            sunset(o.getSunset());
             repositoryFileLines(o.getRepositoryFileLines());
 
             return this;
@@ -67,7 +76,7 @@ public class GetRepositoryFileLinesResponse extends com.oracle.bmc.responses.Bmc
 
         public GetRepositoryFileLinesResponse build() {
             return new GetRepositoryFileLinesResponse(
-                    __httpStatusCode__, opcRequestId, etag, repositoryFileLines);
+                    __httpStatusCode__, opcRequestId, etag, sunset, repositoryFileLines);
         }
     }
 }

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identitydataplane/pom.xml
+++ b/bmc-identitydataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-identitydataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementService.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementService.java
@@ -47,6 +47,18 @@ public interface JavaManagementService extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Deletes the work request specified by an identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/CancelWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CancelWorkRequest API.
+     */
+    CancelWorkRequestResponse cancelWorkRequest(CancelWorkRequestRequest request);
+
+    /**
      * Move a specified Fleet into the compartment identified in the POST form. When provided, If-Match is checked against ETag values of the resource.
      *
      * @param request The request object containing the details to send
@@ -60,6 +72,19 @@ public interface JavaManagementService extends AutoCloseable {
     ChangeFleetCompartmentResponse changeFleetCompartment(ChangeFleetCompartmentRequest request);
 
     /**
+     * Add a new record to the fleet blocklist.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/CreateBlocklistExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateBlocklist API.
+     */
+    CreateBlocklistResponse createBlocklist(CreateBlocklistRequest request);
+
+    /**
      * Create a new Fleet using the information provided.
      *
      * @param request The request object containing the details to send
@@ -71,6 +96,18 @@ public interface JavaManagementService extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/CreateFleetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateFleet API.
      */
     CreateFleetResponse createFleet(CreateFleetRequest request);
+
+    /**
+     * Deletes the blocklist record specified by an identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/DeleteBlocklistExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteBlocklist API.
+     */
+    DeleteBlocklistResponse deleteBlocklist(DeleteBlocklistRequest request);
 
     /**
      * Deletes the Fleet specified by an identifier.
@@ -122,6 +159,19 @@ public interface JavaManagementService extends AutoCloseable {
     GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request);
 
     /**
+     * Returns a list of blocklist entities contained by a fleet.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/ListBlocklistsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListBlocklists API.
+     */
+    ListBlocklistsResponse listBlocklists(ListBlocklistsRequest request);
+
+    /**
      * Returns a list of all the Fleets contained by a compartment. The query parameter `compartmentId`
      * is required unless the query parameter `id` is specified.
      *
@@ -136,6 +186,18 @@ public interface JavaManagementService extends AutoCloseable {
     ListFleetsResponse listFleets(ListFleetsRequest request);
 
     /**
+     * List Java installation sites in a Fleet filtered by query parameters.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/ListInstallationSitesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListInstallationSites API.
+     */
+    ListInstallationSitesResponse listInstallationSites(ListInstallationSitesRequest request);
+
+    /**
      * List Java Runtime usage in a specified host filtered by query parameters.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -146,6 +208,19 @@ public interface JavaManagementService extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/ListJreUsageExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListJreUsage API.
      */
     ListJreUsageResponse listJreUsage(ListJreUsageRequest request);
+
+    /**
+     * Retrieve a (paginated) list of work items for a specified work request.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/ListWorkItemsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkItems API.
+     */
+    ListWorkItemsResponse listWorkItems(ListWorkItemsRequest request);
 
     /**
      * Retrieve a (paginated) list of errors for a specified work request.
@@ -174,7 +249,7 @@ public interface JavaManagementService extends AutoCloseable {
     ListWorkRequestLogsResponse listWorkRequestLogs(ListWorkRequestLogsRequest request);
 
     /**
-     * List the work requests in a compartment. The query parameter `compartmentId` is required unless the query parameter `id` is specified.
+     * List the work requests in a compartment. The query parameter `compartmentId` is required unless the query parameter `id` or `fleetId` is specified.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -185,6 +260,19 @@ public interface JavaManagementService extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.
      */
     ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request);
+
+    /**
+     * Remove Java installation sites in a Fleet.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/RemoveFleetInstallationSitesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RemoveFleetInstallationSites API.
+     */
+    RemoveFleetInstallationSitesResponse removeFleetInstallationSites(
+            RemoveFleetInstallationSitesRequest request);
 
     /**
      * List application usage in a Fleet filtered by query parameters.

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementServiceAsync.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementServiceAsync.java
@@ -46,6 +46,22 @@ public interface JavaManagementServiceAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Deletes the work request specified by an identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CancelWorkRequestResponse> cancelWorkRequest(
+            CancelWorkRequestRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CancelWorkRequestRequest, CancelWorkRequestResponse>
+                    handler);
+
+    /**
      * Move a specified Fleet into the compartment identified in the POST form. When provided, If-Match is checked against ETag values of the resource.
      *
      *
@@ -63,6 +79,22 @@ public interface JavaManagementServiceAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Add a new record to the fleet blocklist.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateBlocklistResponse> createBlocklist(
+            CreateBlocklistRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateBlocklistRequest, CreateBlocklistResponse>
+                    handler);
+
+    /**
      * Create a new Fleet using the information provided.
      *
      *
@@ -76,6 +108,21 @@ public interface JavaManagementServiceAsync extends AutoCloseable {
     java.util.concurrent.Future<CreateFleetResponse> createFleet(
             CreateFleetRequest request,
             com.oracle.bmc.responses.AsyncHandler<CreateFleetRequest, CreateFleetResponse> handler);
+
+    /**
+     * Deletes the blocklist record specified by an identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteBlocklistResponse> deleteBlocklist(
+            DeleteBlocklistRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteBlocklistRequest, DeleteBlocklistResponse>
+                    handler);
 
     /**
      * Deletes the Fleet specified by an identifier.
@@ -137,6 +184,22 @@ public interface JavaManagementServiceAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Returns a list of blocklist entities contained by a fleet.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListBlocklistsResponse> listBlocklists(
+            ListBlocklistsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListBlocklistsRequest, ListBlocklistsResponse>
+                    handler);
+
+    /**
      * Returns a list of all the Fleets contained by a compartment. The query parameter `compartmentId`
      * is required unless the query parameter `id` is specified.
      *
@@ -153,6 +216,22 @@ public interface JavaManagementServiceAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListFleetsRequest, ListFleetsResponse> handler);
 
     /**
+     * List Java installation sites in a Fleet filtered by query parameters.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListInstallationSitesResponse> listInstallationSites(
+            ListInstallationSitesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListInstallationSitesRequest, ListInstallationSitesResponse>
+                    handler);
+
+    /**
      * List Java Runtime usage in a specified host filtered by query parameters.
      *
      * @param request The request object containing the details to send
@@ -165,6 +244,22 @@ public interface JavaManagementServiceAsync extends AutoCloseable {
     java.util.concurrent.Future<ListJreUsageResponse> listJreUsage(
             ListJreUsageRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListJreUsageRequest, ListJreUsageResponse>
+                    handler);
+
+    /**
+     * Retrieve a (paginated) list of work items for a specified work request.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListWorkItemsResponse> listWorkItems(
+            ListWorkItemsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListWorkItemsRequest, ListWorkItemsResponse>
                     handler);
 
     /**
@@ -202,7 +297,7 @@ public interface JavaManagementServiceAsync extends AutoCloseable {
                     handler);
 
     /**
-     * List the work requests in a compartment. The query parameter `compartmentId` is required unless the query parameter `id` is specified.
+     * List the work requests in a compartment. The query parameter `compartmentId` is required unless the query parameter `id` or `fleetId` is specified.
      *
      *
      * @param request The request object containing the details to send
@@ -215,6 +310,23 @@ public interface JavaManagementServiceAsync extends AutoCloseable {
     java.util.concurrent.Future<ListWorkRequestsResponse> listWorkRequests(
             ListWorkRequestsRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListWorkRequestsRequest, ListWorkRequestsResponse>
+                    handler);
+
+    /**
+     * Remove Java installation sites in a Fleet.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RemoveFleetInstallationSitesResponse> removeFleetInstallationSites(
+            RemoveFleetInstallationSitesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            RemoveFleetInstallationSitesRequest,
+                            RemoveFleetInstallationSitesResponse>
                     handler);
 
     /**

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementServiceAsyncClient.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementServiceAsyncClient.java
@@ -379,6 +379,45 @@ public class JavaManagementServiceAsyncClient implements JavaManagementServiceAs
     }
 
     @Override
+    public java.util.concurrent.Future<CancelWorkRequestResponse> cancelWorkRequest(
+            CancelWorkRequestRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CancelWorkRequestRequest, CancelWorkRequestResponse>
+                    handler) {
+        LOG.trace("Called async cancelWorkRequest");
+        final CancelWorkRequestRequest interceptedRequest =
+                CancelWorkRequestConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CancelWorkRequestConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CancelWorkRequestResponse>
+                transformer = CancelWorkRequestConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<CancelWorkRequestRequest, CancelWorkRequestResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CancelWorkRequestRequest, CancelWorkRequestResponse>,
+                        java.util.concurrent.Future<CancelWorkRequestResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CancelWorkRequestRequest, CancelWorkRequestResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeFleetCompartmentResponse> changeFleetCompartment(
             ChangeFleetCompartmentRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -426,6 +465,51 @@ public class JavaManagementServiceAsyncClient implements JavaManagementServiceAs
     }
 
     @Override
+    public java.util.concurrent.Future<CreateBlocklistResponse> createBlocklist(
+            CreateBlocklistRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateBlocklistRequest, CreateBlocklistResponse>
+                    handler) {
+        LOG.trace("Called async createBlocklist");
+        final CreateBlocklistRequest interceptedRequest =
+                CreateBlocklistConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateBlocklistConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateBlocklistResponse>
+                transformer = CreateBlocklistConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CreateBlocklistRequest, CreateBlocklistResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateBlocklistRequest, CreateBlocklistResponse>,
+                        java.util.concurrent.Future<CreateBlocklistResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getCreateBlocklistDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateBlocklistRequest, CreateBlocklistResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateFleetResponse> createFleet(
             CreateFleetRequest request,
             final com.oracle.bmc.responses.AsyncHandler<CreateFleetRequest, CreateFleetResponse>
@@ -457,6 +541,45 @@ public class JavaManagementServiceAsyncClient implements JavaManagementServiceAs
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     CreateFleetRequest, CreateFleetResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteBlocklistResponse> deleteBlocklist(
+            DeleteBlocklistRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteBlocklistRequest, DeleteBlocklistResponse>
+                    handler) {
+        LOG.trace("Called async deleteBlocklist");
+        final DeleteBlocklistRequest interceptedRequest =
+                DeleteBlocklistConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteBlocklistConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteBlocklistResponse>
+                transformer = DeleteBlocklistConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteBlocklistRequest, DeleteBlocklistResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteBlocklistRequest, DeleteBlocklistResponse>,
+                        java.util.concurrent.Future<DeleteBlocklistResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteBlocklistRequest, DeleteBlocklistResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -627,6 +750,45 @@ public class JavaManagementServiceAsyncClient implements JavaManagementServiceAs
     }
 
     @Override
+    public java.util.concurrent.Future<ListBlocklistsResponse> listBlocklists(
+            ListBlocklistsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListBlocklistsRequest, ListBlocklistsResponse>
+                    handler) {
+        LOG.trace("Called async listBlocklists");
+        final ListBlocklistsRequest interceptedRequest =
+                ListBlocklistsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBlocklistsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListBlocklistsResponse>
+                transformer = ListBlocklistsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListBlocklistsRequest, ListBlocklistsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListBlocklistsRequest, ListBlocklistsResponse>,
+                        java.util.concurrent.Future<ListBlocklistsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListBlocklistsRequest, ListBlocklistsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListFleetsResponse> listFleets(
             ListFleetsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<ListFleetsRequest, ListFleetsResponse>
@@ -651,6 +813,47 @@ public class JavaManagementServiceAsyncClient implements JavaManagementServiceAs
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListFleetsRequest, ListFleetsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListInstallationSitesResponse> listInstallationSites(
+            ListInstallationSitesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListInstallationSitesRequest, ListInstallationSitesResponse>
+                    handler) {
+        LOG.trace("Called async listInstallationSites");
+        final ListInstallationSitesRequest interceptedRequest =
+                ListInstallationSitesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListInstallationSitesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListInstallationSitesResponse>
+                transformer = ListInstallationSitesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListInstallationSitesRequest, ListInstallationSitesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListInstallationSitesRequest, ListInstallationSitesResponse>,
+                        java.util.concurrent.Future<ListInstallationSitesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListInstallationSitesRequest, ListInstallationSitesResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -689,6 +892,44 @@ public class JavaManagementServiceAsyncClient implements JavaManagementServiceAs
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListJreUsageRequest, ListJreUsageResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListWorkItemsResponse> listWorkItems(
+            ListWorkItemsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListWorkItemsRequest, ListWorkItemsResponse>
+                    handler) {
+        LOG.trace("Called async listWorkItems");
+        final ListWorkItemsRequest interceptedRequest =
+                ListWorkItemsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkItemsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkItemsResponse>
+                transformer = ListWorkItemsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListWorkItemsRequest, ListWorkItemsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListWorkItemsRequest, ListWorkItemsResponse>,
+                        java.util.concurrent.Future<ListWorkItemsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListWorkItemsRequest, ListWorkItemsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -810,6 +1051,56 @@ public class JavaManagementServiceAsyncClient implements JavaManagementServiceAs
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListWorkRequestsRequest, ListWorkRequestsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<RemoveFleetInstallationSitesResponse>
+            removeFleetInstallationSites(
+                    RemoveFleetInstallationSitesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    RemoveFleetInstallationSitesRequest,
+                                    RemoveFleetInstallationSitesResponse>
+                            handler) {
+        LOG.trace("Called async removeFleetInstallationSites");
+        final RemoveFleetInstallationSitesRequest interceptedRequest =
+                RemoveFleetInstallationSitesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveFleetInstallationSitesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RemoveFleetInstallationSitesResponse>
+                transformer = RemoveFleetInstallationSitesConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        RemoveFleetInstallationSitesRequest, RemoveFleetInstallationSitesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RemoveFleetInstallationSitesRequest,
+                                RemoveFleetInstallationSitesResponse>,
+                        java.util.concurrent.Future<RemoveFleetInstallationSitesResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getRemoveFleetInstallationSitesDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RemoveFleetInstallationSitesRequest, RemoveFleetInstallationSitesResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementServiceClient.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementServiceClient.java
@@ -463,6 +463,36 @@ public class JavaManagementServiceClient implements JavaManagementService {
     }
 
     @Override
+    public CancelWorkRequestResponse cancelWorkRequest(CancelWorkRequestRequest request) {
+        LOG.trace("Called cancelWorkRequest");
+        final CancelWorkRequestRequest interceptedRequest =
+                CancelWorkRequestConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CancelWorkRequestConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CancelWorkRequestResponse>
+                transformer = CancelWorkRequestConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeFleetCompartmentResponse changeFleetCompartment(
             ChangeFleetCompartmentRequest request) {
         LOG.trace("Called changeFleetCompartment");
@@ -498,6 +528,40 @@ public class JavaManagementServiceClient implements JavaManagementService {
     }
 
     @Override
+    public CreateBlocklistResponse createBlocklist(CreateBlocklistRequest request) {
+        LOG.trace("Called createBlocklist");
+        final CreateBlocklistRequest interceptedRequest =
+                CreateBlocklistConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateBlocklistConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateBlocklistResponse>
+                transformer = CreateBlocklistConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateBlocklistDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateFleetResponse createFleet(CreateFleetRequest request) {
         LOG.trace("Called createFleet");
         final CreateFleetRequest interceptedRequest =
@@ -526,6 +590,36 @@ public class JavaManagementServiceClient implements JavaManagementService {
                                                 ib,
                                                 retriedRequest.getCreateFleetDetails(),
                                                 retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteBlocklistResponse deleteBlocklist(DeleteBlocklistRequest request) {
+        LOG.trace("Called deleteBlocklist");
+        final DeleteBlocklistRequest interceptedRequest =
+                DeleteBlocklistConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteBlocklistConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteBlocklistResponse>
+                transformer = DeleteBlocklistConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });
@@ -650,6 +744,35 @@ public class JavaManagementServiceClient implements JavaManagementService {
     }
 
     @Override
+    public ListBlocklistsResponse listBlocklists(ListBlocklistsRequest request) {
+        LOG.trace("Called listBlocklists");
+        final ListBlocklistsRequest interceptedRequest =
+                ListBlocklistsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBlocklistsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListBlocklistsResponse>
+                transformer = ListBlocklistsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListFleetsResponse listFleets(ListFleetsRequest request) {
         LOG.trace("Called listFleets");
         final ListFleetsRequest interceptedRequest = ListFleetsConverter.interceptRequest(request);
@@ -657,6 +780,36 @@ public class JavaManagementServiceClient implements JavaManagementService {
                 ListFleetsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListFleetsResponse> transformer =
                 ListFleetsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListInstallationSitesResponse listInstallationSites(
+            ListInstallationSitesRequest request) {
+        LOG.trace("Called listInstallationSites");
+        final ListInstallationSitesRequest interceptedRequest =
+                ListInstallationSitesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListInstallationSitesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListInstallationSitesResponse>
+                transformer = ListInstallationSitesConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -686,6 +839,35 @@ public class JavaManagementServiceClient implements JavaManagementService {
                 ListJreUsageConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListJreUsageResponse>
                 transformer = ListJreUsageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListWorkItemsResponse listWorkItems(ListWorkItemsRequest request) {
+        LOG.trace("Called listWorkItems");
+        final ListWorkItemsRequest interceptedRequest =
+                ListWorkItemsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkItemsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkItemsResponse>
+                transformer = ListWorkItemsConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -789,6 +971,43 @@ public class JavaManagementServiceClient implements JavaManagementService {
                             retryRequest,
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public RemoveFleetInstallationSitesResponse removeFleetInstallationSites(
+            RemoveFleetInstallationSitesRequest request) {
+        LOG.trace("Called removeFleetInstallationSites");
+        final RemoveFleetInstallationSitesRequest interceptedRequest =
+                RemoveFleetInstallationSitesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveFleetInstallationSitesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RemoveFleetInstallationSitesResponse>
+                transformer = RemoveFleetInstallationSitesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getRemoveFleetInstallationSitesDetails(),
+                                                retriedRequest);
                                 return transformer.apply(response);
                             });
                 });

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementServicePaginators.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/JavaManagementServicePaginators.java
@@ -31,6 +31,118 @@ public class JavaManagementServicePaginators {
     private final JavaManagementService client;
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listBlocklists operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListBlocklistsResponse> listBlocklistsResponseIterator(
+            final ListBlocklistsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListBlocklistsRequest.Builder, ListBlocklistsRequest, ListBlocklistsResponse>(
+                new com.google.common.base.Supplier<ListBlocklistsRequest.Builder>() {
+                    @Override
+                    public ListBlocklistsRequest.Builder get() {
+                        return ListBlocklistsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListBlocklistsResponse, String>() {
+                    @Override
+                    public String apply(ListBlocklistsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListBlocklistsRequest.Builder>,
+                        ListBlocklistsRequest>() {
+                    @Override
+                    public ListBlocklistsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListBlocklistsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListBlocklistsRequest, ListBlocklistsResponse>() {
+                    @Override
+                    public ListBlocklistsResponse apply(ListBlocklistsRequest request) {
+                        return client.listBlocklists(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.jms.model.Blocklist} objects
+     * contained in responses from the listBlocklists operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.jms.model.Blocklist} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.jms.model.Blocklist> listBlocklistsRecordIterator(
+            final ListBlocklistsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListBlocklistsRequest.Builder, ListBlocklistsRequest, ListBlocklistsResponse,
+                com.oracle.bmc.jms.model.Blocklist>(
+                new com.google.common.base.Supplier<ListBlocklistsRequest.Builder>() {
+                    @Override
+                    public ListBlocklistsRequest.Builder get() {
+                        return ListBlocklistsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListBlocklistsResponse, String>() {
+                    @Override
+                    public String apply(ListBlocklistsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListBlocklistsRequest.Builder>,
+                        ListBlocklistsRequest>() {
+                    @Override
+                    public ListBlocklistsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListBlocklistsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListBlocklistsRequest, ListBlocklistsResponse>() {
+                    @Override
+                    public ListBlocklistsResponse apply(ListBlocklistsRequest request) {
+                        return client.listBlocklists(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListBlocklistsResponse,
+                        java.util.List<com.oracle.bmc.jms.model.Blocklist>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.jms.model.Blocklist> apply(
+                            ListBlocklistsResponse response) {
+                        return response.getBlocklistCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listFleets operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -141,6 +253,121 @@ public class JavaManagementServicePaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listInstallationSites operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListInstallationSitesResponse> listInstallationSitesResponseIterator(
+            final ListInstallationSitesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListInstallationSitesRequest.Builder, ListInstallationSitesRequest,
+                ListInstallationSitesResponse>(
+                new com.google.common.base.Supplier<ListInstallationSitesRequest.Builder>() {
+                    @Override
+                    public ListInstallationSitesRequest.Builder get() {
+                        return ListInstallationSitesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListInstallationSitesResponse, String>() {
+                    @Override
+                    public String apply(ListInstallationSitesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListInstallationSitesRequest.Builder>,
+                        ListInstallationSitesRequest>() {
+                    @Override
+                    public ListInstallationSitesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListInstallationSitesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListInstallationSitesRequest, ListInstallationSitesResponse>() {
+                    @Override
+                    public ListInstallationSitesResponse apply(
+                            ListInstallationSitesRequest request) {
+                        return client.listInstallationSites(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.jms.model.InstallationSiteSummary} objects
+     * contained in responses from the listInstallationSites operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.jms.model.InstallationSiteSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.jms.model.InstallationSiteSummary>
+            listInstallationSitesRecordIterator(final ListInstallationSitesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListInstallationSitesRequest.Builder, ListInstallationSitesRequest,
+                ListInstallationSitesResponse, com.oracle.bmc.jms.model.InstallationSiteSummary>(
+                new com.google.common.base.Supplier<ListInstallationSitesRequest.Builder>() {
+                    @Override
+                    public ListInstallationSitesRequest.Builder get() {
+                        return ListInstallationSitesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListInstallationSitesResponse, String>() {
+                    @Override
+                    public String apply(ListInstallationSitesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListInstallationSitesRequest.Builder>,
+                        ListInstallationSitesRequest>() {
+                    @Override
+                    public ListInstallationSitesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListInstallationSitesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListInstallationSitesRequest, ListInstallationSitesResponse>() {
+                    @Override
+                    public ListInstallationSitesResponse apply(
+                            ListInstallationSitesRequest request) {
+                        return client.listInstallationSites(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListInstallationSitesResponse,
+                        java.util.List<com.oracle.bmc.jms.model.InstallationSiteSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.jms.model.InstallationSiteSummary> apply(
+                            ListInstallationSitesResponse response) {
+                        return response.getInstallationSiteCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listJreUsage operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -245,6 +472,116 @@ public class JavaManagementServicePaginators {
                     public java.util.List<com.oracle.bmc.jms.model.JreUsage> apply(
                             ListJreUsageResponse response) {
                         return response.getJreUsageCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listWorkItems operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListWorkItemsResponse> listWorkItemsResponseIterator(
+            final ListWorkItemsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListWorkItemsRequest.Builder, ListWorkItemsRequest, ListWorkItemsResponse>(
+                new com.google.common.base.Supplier<ListWorkItemsRequest.Builder>() {
+                    @Override
+                    public ListWorkItemsRequest.Builder get() {
+                        return ListWorkItemsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkItemsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkItemsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkItemsRequest.Builder>,
+                        ListWorkItemsRequest>() {
+                    @Override
+                    public ListWorkItemsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkItemsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListWorkItemsRequest, ListWorkItemsResponse>() {
+                    @Override
+                    public ListWorkItemsResponse apply(ListWorkItemsRequest request) {
+                        return client.listWorkItems(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.jms.model.WorkItemSummary} objects
+     * contained in responses from the listWorkItems operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.jms.model.WorkItemSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.jms.model.WorkItemSummary> listWorkItemsRecordIterator(
+            final ListWorkItemsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListWorkItemsRequest.Builder, ListWorkItemsRequest, ListWorkItemsResponse,
+                com.oracle.bmc.jms.model.WorkItemSummary>(
+                new com.google.common.base.Supplier<ListWorkItemsRequest.Builder>() {
+                    @Override
+                    public ListWorkItemsRequest.Builder get() {
+                        return ListWorkItemsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkItemsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkItemsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkItemsRequest.Builder>,
+                        ListWorkItemsRequest>() {
+                    @Override
+                    public ListWorkItemsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkItemsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListWorkItemsRequest, ListWorkItemsResponse>() {
+                    @Override
+                    public ListWorkItemsResponse apply(ListWorkItemsRequest request) {
+                        return client.listWorkItems(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkItemsResponse,
+                        java.util.List<com.oracle.bmc.jms.model.WorkItemSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.jms.model.WorkItemSummary> apply(
+                            ListWorkItemsResponse response) {
+                        return response.getWorkItemCollection().getItems();
                     }
                 });
     }

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/CancelWorkRequestConverter.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/CancelWorkRequestConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.jms.model.*;
+import com.oracle.bmc.jms.requests.*;
+import com.oracle.bmc.jms.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.extern.slf4j.Slf4j
+public class CancelWorkRequestConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.jms.requests.CancelWorkRequestRequest interceptRequest(
+            com.oracle.bmc.jms.requests.CancelWorkRequestRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.jms.requests.CancelWorkRequestRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkRequestId(), "workRequestId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210610")
+                        .path("workRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkRequestId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.jms.responses.CancelWorkRequestResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.jms.responses.CancelWorkRequestResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.jms.responses.CancelWorkRequestResponse>() {
+                            @Override
+                            public com.oracle.bmc.jms.responses.CancelWorkRequestResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.jms.responses.CancelWorkRequestResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.jms.responses.CancelWorkRequestResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.jms.responses
+                                                        .CancelWorkRequestResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.jms.responses.CancelWorkRequestResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/CreateBlocklistConverter.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/CreateBlocklistConverter.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.jms.model.*;
+import com.oracle.bmc.jms.requests.*;
+import com.oracle.bmc.jms.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.extern.slf4j.Slf4j
+public class CreateBlocklistConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.jms.requests.CreateBlocklistRequest interceptRequest(
+            com.oracle.bmc.jms.requests.CreateBlocklistRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.jms.requests.CreateBlocklistRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getFleetId(), "fleetId must not be blank");
+        Validate.notNull(request.getCreateBlocklistDetails(), "createBlocklistDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210610")
+                        .path("fleets")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getFleetId()))
+                        .path("blocklists");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.jms.responses.CreateBlocklistResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.jms.responses.CreateBlocklistResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.jms.responses.CreateBlocklistResponse>() {
+                            @Override
+                            public com.oracle.bmc.jms.responses.CreateBlocklistResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.jms.responses.CreateBlocklistResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.jms.model.Blocklist>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.jms.model.Blocklist.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.jms.model.Blocklist>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.jms.responses.CreateBlocklistResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.jms.responses.CreateBlocklistResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.blocklist(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.oracle.bmc.jms.responses.CreateBlocklistResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/DeleteBlocklistConverter.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/DeleteBlocklistConverter.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.jms.model.*;
+import com.oracle.bmc.jms.requests.*;
+import com.oracle.bmc.jms.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.extern.slf4j.Slf4j
+public class DeleteBlocklistConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.jms.requests.DeleteBlocklistRequest interceptRequest(
+            com.oracle.bmc.jms.requests.DeleteBlocklistRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.jms.requests.DeleteBlocklistRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getFleetId(), "fleetId must not be blank");
+        Validate.notBlank(request.getBlocklistKey(), "blocklistKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210610")
+                        .path("fleets")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getFleetId()))
+                        .path("blocklists")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBlocklistKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.jms.responses.DeleteBlocklistResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.jms.responses.DeleteBlocklistResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.jms.responses.DeleteBlocklistResponse>() {
+                            @Override
+                            public com.oracle.bmc.jms.responses.DeleteBlocklistResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.jms.responses.DeleteBlocklistResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.jms.responses.DeleteBlocklistResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.jms.responses.DeleteBlocklistResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.jms.responses.DeleteBlocklistResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/GetWorkRequestConverter.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/GetWorkRequestConverter.java
@@ -113,6 +113,15 @@ public class GetWorkRequestConverter {
                                                     Float.class));
                                 }
 
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
                                 com.oracle.bmc.jms.responses.GetWorkRequestResponse
                                         responseWrapper = builder.build();
 

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/ListBlocklistsConverter.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/ListBlocklistsConverter.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.jms.model.*;
+import com.oracle.bmc.jms.requests.*;
+import com.oracle.bmc.jms.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.extern.slf4j.Slf4j
+public class ListBlocklistsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.jms.requests.ListBlocklistsRequest interceptRequest(
+            com.oracle.bmc.jms.requests.ListBlocklistsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.jms.requests.ListBlocklistsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getFleetId(), "fleetId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210610")
+                        .path("fleets")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getFleetId()))
+                        .path("blocklists");
+
+        if (request.getOperation() != null) {
+            target =
+                    target.queryParam(
+                            "operation",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getOperation().getValue()));
+        }
+
+        if (request.getManagedInstanceId() != null) {
+            target =
+                    target.queryParam(
+                            "managedInstanceId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getManagedInstanceId()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.jms.responses.ListBlocklistsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.jms.responses.ListBlocklistsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.jms.responses.ListBlocklistsResponse>() {
+                            @Override
+                            public com.oracle.bmc.jms.responses.ListBlocklistsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.jms.responses.ListBlocklistsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.jms.model
+                                                                .BlocklistCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.jms.model.BlocklistCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.jms.model.BlocklistCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.jms.responses.ListBlocklistsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.jms.responses.ListBlocklistsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.blocklistCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.jms.responses.ListBlocklistsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/ListInstallationSitesConverter.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/ListInstallationSitesConverter.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.jms.model.*;
+import com.oracle.bmc.jms.requests.*;
+import com.oracle.bmc.jms.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.extern.slf4j.Slf4j
+public class ListInstallationSitesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.jms.requests.ListInstallationSitesRequest interceptRequest(
+            com.oracle.bmc.jms.requests.ListInstallationSitesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.jms.requests.ListInstallationSitesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getFleetId(), "fleetId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210610")
+                        .path("fleets")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getFleetId()))
+                        .path("installationSites");
+
+        if (request.getJreVendor() != null) {
+            target =
+                    target.queryParam(
+                            "jreVendor",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getJreVendor()));
+        }
+
+        if (request.getJreDistribution() != null) {
+            target =
+                    target.queryParam(
+                            "jreDistribution",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getJreDistribution()));
+        }
+
+        if (request.getJreVersion() != null) {
+            target =
+                    target.queryParam(
+                            "jreVersion",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getJreVersion()));
+        }
+
+        if (request.getInstallationPath() != null) {
+            target =
+                    target.queryParam(
+                            "installationPath",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstallationPath()));
+        }
+
+        if (request.getApplicationId() != null) {
+            target =
+                    target.queryParam(
+                            "applicationId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getApplicationId()));
+        }
+
+        if (request.getManagedInstanceId() != null) {
+            target =
+                    target.queryParam(
+                            "managedInstanceId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getManagedInstanceId()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getOsFamily() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "osFamily",
+                            request.getOsFamily(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getJreSecurityStatus() != null) {
+            target =
+                    target.queryParam(
+                            "jreSecurityStatus",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getJreSecurityStatus().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.jms.responses.ListInstallationSitesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.jms.responses.ListInstallationSitesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.jms.responses.ListInstallationSitesResponse>() {
+                            @Override
+                            public com.oracle.bmc.jms.responses.ListInstallationSitesResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.jms.responses.ListInstallationSitesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.jms.model
+                                                                .InstallationSiteCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.jms.model
+                                                                        .InstallationSiteCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.jms.model.InstallationSiteCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.jms.responses.ListInstallationSitesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.jms.responses
+                                                        .ListInstallationSitesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.installationSiteCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.jms.responses.ListInstallationSitesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/ListWorkItemsConverter.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/ListWorkItemsConverter.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.jms.model.*;
+import com.oracle.bmc.jms.requests.*;
+import com.oracle.bmc.jms.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.extern.slf4j.Slf4j
+public class ListWorkItemsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.jms.requests.ListWorkItemsRequest interceptRequest(
+            com.oracle.bmc.jms.requests.ListWorkItemsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.jms.requests.ListWorkItemsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkRequestId(), "workRequestId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210610")
+                        .path("workRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkRequestId()))
+                        .path("workItems");
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.jms.responses.ListWorkItemsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.jms.responses.ListWorkItemsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.jms.responses.ListWorkItemsResponse>() {
+                            @Override
+                            public com.oracle.bmc.jms.responses.ListWorkItemsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.jms.responses.ListWorkItemsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.jms.model
+                                                                .WorkItemCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.jms.model.WorkItemCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.jms.model.WorkItemCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.jms.responses.ListWorkItemsResponse.Builder builder =
+                                        com.oracle.bmc.jms.responses.ListWorkItemsResponse.builder()
+                                                .__httpStatusCode__(rawResponse.getStatus());
+
+                                builder.workItemCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.jms.responses.ListWorkItemsResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/ListWorkRequestsConverter.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/ListWorkRequestsConverter.java
@@ -47,6 +47,14 @@ public class ListWorkRequestsConverter {
                                     request.getId()));
         }
 
+        if (request.getFleetId() != null) {
+            target =
+                    target.queryParam(
+                            "fleetId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getFleetId()));
+        }
+
         if (request.getPage() != null) {
             target =
                     target.queryParam(

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/RemoveFleetInstallationSitesConverter.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/internal/http/RemoveFleetInstallationSitesConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.jms.model.*;
+import com.oracle.bmc.jms.requests.*;
+import com.oracle.bmc.jms.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.extern.slf4j.Slf4j
+public class RemoveFleetInstallationSitesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.jms.requests.RemoveFleetInstallationSitesRequest interceptRequest(
+            com.oracle.bmc.jms.requests.RemoveFleetInstallationSitesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.jms.requests.RemoveFleetInstallationSitesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getFleetId(), "fleetId must not be blank");
+        Validate.notNull(
+                request.getRemoveFleetInstallationSitesDetails(),
+                "removeFleetInstallationSitesDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210610")
+                        .path("fleets")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getFleetId()))
+                        .path("actions")
+                        .path("removeInstallationSites");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.jms.responses.RemoveFleetInstallationSitesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.jms.responses.RemoveFleetInstallationSitesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.jms.responses
+                                        .RemoveFleetInstallationSitesResponse>() {
+                            @Override
+                            public com.oracle.bmc.jms.responses.RemoveFleetInstallationSitesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.jms.responses.RemoveFleetInstallationSitesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.jms.responses.RemoveFleetInstallationSitesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.jms.responses
+                                                        .RemoveFleetInstallationSitesResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.jms.responses.RemoveFleetInstallationSitesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/ActionType.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/ActionType.java
@@ -15,6 +15,7 @@ public enum ActionType {
     InProgress("IN_PROGRESS"),
     Related("RELATED"),
     Updated("UPDATED"),
+    Failed("FAILED"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/Blocklist.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/Blocklist.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * The blocklist record to prevent a target resource from certain operation with reason.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Blocklist.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Blocklist {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private BlocklistTarget target;
+
+        public Builder target(BlocklistTarget target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("operation")
+        private OperationType operation;
+
+        public Builder operation(OperationType operation) {
+            this.operation = operation;
+            this.__explicitlySet__.add("operation");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("reason")
+        private String reason;
+
+        public Builder reason(String reason) {
+            this.reason = reason;
+            this.__explicitlySet__.add("reason");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Blocklist build() {
+            Blocklist __instance__ = new Blocklist(key, target, operation, reason);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Blocklist o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .target(o.getTarget())
+                            .operation(o.getOperation())
+                            .reason(o.getReason());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique identifier of this blocklist record.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    BlocklistTarget target;
+
+    /**
+     * The operation type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("operation")
+    OperationType operation;
+
+    /**
+     * The reason for why the operation is blocklisted
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reason")
+    String reason;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/BlocklistCollection.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/BlocklistCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * Results of a blocklist search. Contains Blocklist records.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BlocklistCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BlocklistCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<Blocklist> items;
+
+        public Builder items(java.util.List<Blocklist> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BlocklistCollection build() {
+            BlocklistCollection __instance__ = new BlocklistCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BlocklistCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The blocklist
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<Blocklist> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/BlocklistEntry.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/BlocklistEntry.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * An entry for blocklist to describe blocked operation and reason.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = BlocklistEntry.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BlocklistEntry {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("operation")
+        private OperationType operation;
+
+        public Builder operation(OperationType operation) {
+            this.operation = operation;
+            this.__explicitlySet__.add("operation");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("reason")
+        private String reason;
+
+        public Builder reason(String reason) {
+            this.reason = reason;
+            this.__explicitlySet__.add("reason");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BlocklistEntry build() {
+            BlocklistEntry __instance__ = new BlocklistEntry(operation, reason);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BlocklistEntry o) {
+            Builder copiedBuilder = operation(o.getOperation()).reason(o.getReason());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The operation type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("operation")
+    OperationType operation;
+
+    /**
+     * The reason why the operation is blocklisted.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reason")
+    String reason;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/BlocklistSortBy.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/BlocklistSortBy.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * The field to sort blocklist records.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+public enum BlocklistSortBy {
+    Operation("operation"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, BlocklistSortBy> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (BlocklistSortBy v : BlocklistSortBy.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    BlocklistSortBy(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static BlocklistSortBy create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid BlocklistSortBy: " + key);
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/BlocklistTarget.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/BlocklistTarget.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * A resource to blocklist for certain operation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = BlocklistTarget.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BlocklistTarget {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("fleetId")
+        private String fleetId;
+
+        public Builder fleetId(String fleetId) {
+            this.fleetId = fleetId;
+            this.__explicitlySet__.add("fleetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceId")
+        private String managedInstanceId;
+
+        public Builder managedInstanceId(String managedInstanceId) {
+            this.managedInstanceId = managedInstanceId;
+            this.__explicitlySet__.add("managedInstanceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("installationKey")
+        private String installationKey;
+
+        public Builder installationKey(String installationKey) {
+            this.installationKey = installationKey;
+            this.__explicitlySet__.add("installationKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BlocklistTarget build() {
+            BlocklistTarget __instance__ =
+                    new BlocklistTarget(fleetId, managedInstanceId, installationKey);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BlocklistTarget o) {
+            Builder copiedBuilder =
+                    fleetId(o.getFleetId())
+                            .managedInstanceId(o.getManagedInstanceId())
+                            .installationKey(o.getInstallationKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the fleet.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fleetId")
+    String fleetId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the related managed instance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceId")
+    String managedInstanceId;
+
+    /**
+     * The unique identifier for the installation of Java Runtime at a specific path on a specific operating system.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("installationKey")
+    String installationKey;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/CreateBlocklistDetails.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/CreateBlocklistDetails.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * The blocklist record details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateBlocklistDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateBlocklistDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private BlocklistTarget target;
+
+        public Builder target(BlocklistTarget target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("operation")
+        private OperationType operation;
+
+        public Builder operation(OperationType operation) {
+            this.operation = operation;
+            this.__explicitlySet__.add("operation");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("reason")
+        private String reason;
+
+        public Builder reason(String reason) {
+            this.reason = reason;
+            this.__explicitlySet__.add("reason");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateBlocklistDetails build() {
+            CreateBlocklistDetails __instance__ =
+                    new CreateBlocklistDetails(target, operation, reason);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateBlocklistDetails o) {
+            Builder copiedBuilder =
+                    target(o.getTarget()).operation(o.getOperation()).reason(o.getReason());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    BlocklistTarget target;
+
+    /**
+     * The operation type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("operation")
+    OperationType operation;
+
+    /**
+     * The reason for why the operation is blocklisted
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reason")
+    String reason;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/CreateFleetDetails.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/CreateFleetDetails.java
@@ -53,6 +53,24 @@ public class CreateFleetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("inventoryLog")
+        private CustomLog inventoryLog;
+
+        public Builder inventoryLog(CustomLog inventoryLog) {
+            this.inventoryLog = inventoryLog;
+            this.__explicitlySet__.add("inventoryLog");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("operationLog")
+        private CustomLog operationLog;
+
+        public Builder operationLog(CustomLog operationLog) {
+            this.operationLog = operationLog;
+            this.__explicitlySet__.add("operationLog");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -78,7 +96,13 @@ public class CreateFleetDetails {
         public CreateFleetDetails build() {
             CreateFleetDetails __instance__ =
                     new CreateFleetDetails(
-                            displayName, compartmentId, description, definedTags, freeformTags);
+                            displayName,
+                            compartmentId,
+                            description,
+                            inventoryLog,
+                            operationLog,
+                            definedTags,
+                            freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -89,6 +113,8 @@ public class CreateFleetDetails {
                     displayName(o.getDisplayName())
                             .compartmentId(o.getCompartmentId())
                             .description(o.getDescription())
+                            .inventoryLog(o.getInventoryLog())
+                            .operationLog(o.getOperationLog())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -121,6 +147,12 @@ public class CreateFleetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("inventoryLog")
+    CustomLog inventoryLog;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operationLog")
+    CustomLog operationLog;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/CustomLog.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/CustomLog.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * Custom Log for inventory or operation log.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = CustomLog.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CustomLog {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("logGroupId")
+        private String logGroupId;
+
+        public Builder logGroupId(String logGroupId) {
+            this.logGroupId = logGroupId;
+            this.__explicitlySet__.add("logGroupId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("logId")
+        private String logId;
+
+        public Builder logId(String logId) {
+            this.logId = logId;
+            this.__explicitlySet__.add("logId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CustomLog build() {
+            CustomLog __instance__ = new CustomLog(logGroupId, logId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CustomLog o) {
+            Builder copiedBuilder = logGroupId(o.getLogGroupId()).logId(o.getLogId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the log group.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("logGroupId")
+    String logGroupId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the log.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("logId")
+    String logId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/ExistingInstallationSiteId.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/ExistingInstallationSiteId.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * The essential properties to identity a Java installation site.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ExistingInstallationSiteId.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ExistingInstallationSiteId {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceId")
+        private String managedInstanceId;
+
+        public Builder managedInstanceId(String managedInstanceId) {
+            this.managedInstanceId = managedInstanceId;
+            this.__explicitlySet__.add("managedInstanceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("installationKey")
+        private String installationKey;
+
+        public Builder installationKey(String installationKey) {
+            this.installationKey = installationKey;
+            this.__explicitlySet__.add("installationKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ExistingInstallationSiteId build() {
+            ExistingInstallationSiteId __instance__ =
+                    new ExistingInstallationSiteId(managedInstanceId, installationKey);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ExistingInstallationSiteId o) {
+            Builder copiedBuilder =
+                    managedInstanceId(o.getManagedInstanceId())
+                            .installationKey(o.getInstallationKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the related managed instance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceId")
+    String managedInstanceId;
+
+    /**
+     * The unique identifier for the installation of a Java Runtime at a specific path on a specific operating system.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("installationKey")
+    String installationKey;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/Fleet.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/Fleet.java
@@ -97,6 +97,24 @@ public class Fleet {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("inventoryLog")
+        private CustomLog inventoryLog;
+
+        public Builder inventoryLog(CustomLog inventoryLog) {
+            this.inventoryLog = inventoryLog;
+            this.__explicitlySet__.add("inventoryLog");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("operationLog")
+        private CustomLog operationLog;
+
+        public Builder operationLog(CustomLog operationLog) {
+            this.operationLog = operationLog;
+            this.__explicitlySet__.add("operationLog");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -157,6 +175,8 @@ public class Fleet {
                             approximateInstallationCount,
                             approximateApplicationCount,
                             approximateManagedInstanceCount,
+                            inventoryLog,
+                            operationLog,
                             timeCreated,
                             lifecycleState,
                             definedTags,
@@ -177,6 +197,8 @@ public class Fleet {
                             .approximateInstallationCount(o.getApproximateInstallationCount())
                             .approximateApplicationCount(o.getApproximateApplicationCount())
                             .approximateManagedInstanceCount(o.getApproximateManagedInstanceCount())
+                            .inventoryLog(o.getInventoryLog())
+                            .operationLog(o.getOperationLog())
                             .timeCreated(o.getTimeCreated())
                             .lifecycleState(o.getLifecycleState())
                             .definedTags(o.getDefinedTags())
@@ -251,6 +273,12 @@ public class Fleet {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("approximateManagedInstanceCount")
     Integer approximateManagedInstanceCount;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("inventoryLog")
+    CustomLog inventoryLog;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operationLog")
+    CustomLog operationLog;
 
     /**
      * The creation date and time of the Fleet (formatted according to [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339)).

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/FleetSummary.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/FleetSummary.java
@@ -98,6 +98,24 @@ public class FleetSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("inventoryLog")
+        private CustomLog inventoryLog;
+
+        public Builder inventoryLog(CustomLog inventoryLog) {
+            this.inventoryLog = inventoryLog;
+            this.__explicitlySet__.add("inventoryLog");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("operationLog")
+        private CustomLog operationLog;
+
+        public Builder operationLog(CustomLog operationLog) {
+            this.operationLog = operationLog;
+            this.__explicitlySet__.add("operationLog");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -158,6 +176,8 @@ public class FleetSummary {
                             approximateInstallationCount,
                             approximateApplicationCount,
                             approximateManagedInstanceCount,
+                            inventoryLog,
+                            operationLog,
                             timeCreated,
                             lifecycleState,
                             definedTags,
@@ -178,6 +198,8 @@ public class FleetSummary {
                             .approximateInstallationCount(o.getApproximateInstallationCount())
                             .approximateApplicationCount(o.getApproximateApplicationCount())
                             .approximateManagedInstanceCount(o.getApproximateManagedInstanceCount())
+                            .inventoryLog(o.getInventoryLog())
+                            .operationLog(o.getOperationLog())
                             .timeCreated(o.getTimeCreated())
                             .lifecycleState(o.getLifecycleState())
                             .definedTags(o.getDefinedTags())
@@ -252,6 +274,12 @@ public class FleetSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("approximateManagedInstanceCount")
     Integer approximateManagedInstanceCount;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("inventoryLog")
+    CustomLog inventoryLog;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operationLog")
+    CustomLog operationLog;
 
     /**
      * The creation date and time of the Fleet (formatted according to [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339)).

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/InstallationSite.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/InstallationSite.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * Installation site of a Java Runtime.
+ * An installation site is a Java Runtime installed at a specific path on a managed instance.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = InstallationSite.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InstallationSite {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("installationKey")
+        private String installationKey;
+
+        public Builder installationKey(String installationKey) {
+            this.installationKey = installationKey;
+            this.__explicitlySet__.add("installationKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceId")
+        private String managedInstanceId;
+
+        public Builder managedInstanceId(String managedInstanceId) {
+            this.managedInstanceId = managedInstanceId;
+            this.__explicitlySet__.add("managedInstanceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("jre")
+        private JavaRuntimeId jre;
+
+        public Builder jre(JavaRuntimeId jre) {
+            this.jre = jre;
+            this.__explicitlySet__.add("jre");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("path")
+        private String path;
+
+        public Builder path(String path) {
+            this.path = path;
+            this.__explicitlySet__.add("path");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("operatingSystem")
+        private OperatingSystem operatingSystem;
+
+        public Builder operatingSystem(OperatingSystem operatingSystem) {
+            this.operatingSystem = operatingSystem;
+            this.__explicitlySet__.add("operatingSystem");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approximateApplicationCount")
+        private Integer approximateApplicationCount;
+
+        public Builder approximateApplicationCount(Integer approximateApplicationCount) {
+            this.approximateApplicationCount = approximateApplicationCount;
+            this.__explicitlySet__.add("approximateApplicationCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastSeen")
+        private java.util.Date timeLastSeen;
+
+        public Builder timeLastSeen(java.util.Date timeLastSeen) {
+            this.timeLastSeen = timeLastSeen;
+            this.__explicitlySet__.add("timeLastSeen");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("blocklist")
+        private java.util.List<BlocklistEntry> blocklist;
+
+        public Builder blocklist(java.util.List<BlocklistEntry> blocklist) {
+            this.blocklist = blocklist;
+            this.__explicitlySet__.add("blocklist");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceType")
+        private ManagedInstanceType managedInstanceType;
+
+        public Builder managedInstanceType(ManagedInstanceType managedInstanceType) {
+            this.managedInstanceType = managedInstanceType;
+            this.__explicitlySet__.add("managedInstanceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InstallationSite build() {
+            InstallationSite __instance__ =
+                    new InstallationSite(
+                            installationKey,
+                            managedInstanceId,
+                            jre,
+                            path,
+                            operatingSystem,
+                            approximateApplicationCount,
+                            timeLastSeen,
+                            blocklist,
+                            lifecycleState,
+                            managedInstanceType,
+                            hostname);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InstallationSite o) {
+            Builder copiedBuilder =
+                    installationKey(o.getInstallationKey())
+                            .managedInstanceId(o.getManagedInstanceId())
+                            .jre(o.getJre())
+                            .path(o.getPath())
+                            .operatingSystem(o.getOperatingSystem())
+                            .approximateApplicationCount(o.getApproximateApplicationCount())
+                            .timeLastSeen(o.getTimeLastSeen())
+                            .blocklist(o.getBlocklist())
+                            .lifecycleState(o.getLifecycleState())
+                            .managedInstanceType(o.getManagedInstanceType())
+                            .hostname(o.getHostname());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique identifier for the installation of a Java Runtime at a specific path on a specific operating system.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("installationKey")
+    String installationKey;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the related managed instance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceId")
+    String managedInstanceId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("jre")
+    JavaRuntimeId jre;
+
+    /**
+     * The file system path of the installation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("path")
+    String path;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operatingSystem")
+    OperatingSystem operatingSystem;
+
+    /**
+     * The approximate count of applications running on this installation
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("approximateApplicationCount")
+    Integer approximateApplicationCount;
+
+    /**
+     * The date and time the resource was _last_ reported to JMS.
+     * This is potentially _after_ the specified time period provided by the filters.
+     * For example, a resource can be last reported to JMS before the start of a specified time period,
+     * if it is also reported during the time period.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastSeen")
+    java.util.Date timeLastSeen;
+
+    /**
+     * The list of operations that are blocklisted.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("blocklist")
+    java.util.List<BlocklistEntry> blocklist;
+
+    /**
+     * The lifecycle state of the installation site.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The type of the source of events.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceType")
+    ManagedInstanceType managedInstanceType;
+
+    /**
+     * The hostname of the managed instance (if applicable).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+    String hostname;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/InstallationSiteCollection.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/InstallationSiteCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * Results of an installation site search. Contains installation sites.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InstallationSiteCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InstallationSiteCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<InstallationSiteSummary> items;
+
+        public Builder items(java.util.List<InstallationSiteSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InstallationSiteCollection build() {
+            InstallationSiteCollection __instance__ = new InstallationSiteCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InstallationSiteCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A list of Java installation sites.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<InstallationSiteSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/InstallationSiteSortBy.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/InstallationSiteSortBy.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * The field to sort installation sites.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+public enum InstallationSiteSortBy {
+    ManagedInstanceId("managedInstanceId"),
+    JreDistribution("jreDistribution"),
+    JreVendor("jreVendor"),
+    JreVersion("jreVersion"),
+    Path("path"),
+    ApproximateApplicationCount("approximateApplicationCount"),
+    OsName("osName"),
+    SecurityStatus("securityStatus"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, InstallationSiteSortBy> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (InstallationSiteSortBy v : InstallationSiteSortBy.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    InstallationSiteSortBy(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static InstallationSiteSortBy create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid InstallationSiteSortBy: " + key);
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/InstallationSiteSummary.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/InstallationSiteSummary.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * Installation site of a Java Runtime.
+ * An installation site is a Java Runtime installed at a specific path on a managed instance.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InstallationSiteSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InstallationSiteSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("installationKey")
+        private String installationKey;
+
+        public Builder installationKey(String installationKey) {
+            this.installationKey = installationKey;
+            this.__explicitlySet__.add("installationKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceId")
+        private String managedInstanceId;
+
+        public Builder managedInstanceId(String managedInstanceId) {
+            this.managedInstanceId = managedInstanceId;
+            this.__explicitlySet__.add("managedInstanceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("jre")
+        private JavaRuntimeId jre;
+
+        public Builder jre(JavaRuntimeId jre) {
+            this.jre = jre;
+            this.__explicitlySet__.add("jre");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("securityStatus")
+        private JreSecurityStatus securityStatus;
+
+        public Builder securityStatus(JreSecurityStatus securityStatus) {
+            this.securityStatus = securityStatus;
+            this.__explicitlySet__.add("securityStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("path")
+        private String path;
+
+        public Builder path(String path) {
+            this.path = path;
+            this.__explicitlySet__.add("path");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("operatingSystem")
+        private OperatingSystem operatingSystem;
+
+        public Builder operatingSystem(OperatingSystem operatingSystem) {
+            this.operatingSystem = operatingSystem;
+            this.__explicitlySet__.add("operatingSystem");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("approximateApplicationCount")
+        private Integer approximateApplicationCount;
+
+        public Builder approximateApplicationCount(Integer approximateApplicationCount) {
+            this.approximateApplicationCount = approximateApplicationCount;
+            this.__explicitlySet__.add("approximateApplicationCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastSeen")
+        private java.util.Date timeLastSeen;
+
+        public Builder timeLastSeen(java.util.Date timeLastSeen) {
+            this.timeLastSeen = timeLastSeen;
+            this.__explicitlySet__.add("timeLastSeen");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("blocklist")
+        private java.util.List<BlocklistEntry> blocklist;
+
+        public Builder blocklist(java.util.List<BlocklistEntry> blocklist) {
+            this.blocklist = blocklist;
+            this.__explicitlySet__.add("blocklist");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InstallationSiteSummary build() {
+            InstallationSiteSummary __instance__ =
+                    new InstallationSiteSummary(
+                            installationKey,
+                            managedInstanceId,
+                            jre,
+                            securityStatus,
+                            path,
+                            operatingSystem,
+                            approximateApplicationCount,
+                            timeLastSeen,
+                            blocklist,
+                            lifecycleState);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InstallationSiteSummary o) {
+            Builder copiedBuilder =
+                    installationKey(o.getInstallationKey())
+                            .managedInstanceId(o.getManagedInstanceId())
+                            .jre(o.getJre())
+                            .securityStatus(o.getSecurityStatus())
+                            .path(o.getPath())
+                            .operatingSystem(o.getOperatingSystem())
+                            .approximateApplicationCount(o.getApproximateApplicationCount())
+                            .timeLastSeen(o.getTimeLastSeen())
+                            .blocklist(o.getBlocklist())
+                            .lifecycleState(o.getLifecycleState());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique identifier for the installation of Java Runtime at a specific path on a specific operating system.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("installationKey")
+    String installationKey;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the related managed instance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("managedInstanceId")
+    String managedInstanceId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("jre")
+    JavaRuntimeId jre;
+
+    /**
+     * The security status of the Java Runtime.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("securityStatus")
+    JreSecurityStatus securityStatus;
+
+    /**
+     * The file system path of the installation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("path")
+    String path;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operatingSystem")
+    OperatingSystem operatingSystem;
+
+    /**
+     * The approximate count of applications running on this installation
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("approximateApplicationCount")
+    Integer approximateApplicationCount;
+
+    /**
+     * The date and time the resource was _last_ reported to JMS.
+     * This is potentially _after_ the specified time period provided by the filters.
+     * For example, a resource can be last reported to JMS before the start of a specified time period,
+     * if it is also reported during the time period.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastSeen")
+    java.util.Date timeLastSeen;
+
+    /**
+     * The list of operations that are blocklisted.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("blocklist")
+    java.util.List<BlocklistEntry> blocklist;
+
+    /**
+     * The lifecycle state of the installation site.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/JavaRuntimeId.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/JavaRuntimeId.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * The essential properties to identify a Java Runtime.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JavaRuntimeId.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class JavaRuntimeId {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vendor")
+        private String vendor;
+
+        public Builder vendor(String vendor) {
+            this.vendor = vendor;
+            this.__explicitlySet__.add("vendor");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("distribution")
+        private String distribution;
+
+        public Builder distribution(String distribution) {
+            this.distribution = distribution;
+            this.__explicitlySet__.add("distribution");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("jreKey")
+        private String jreKey;
+
+        public Builder jreKey(String jreKey) {
+            this.jreKey = jreKey;
+            this.__explicitlySet__.add("jreKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public JavaRuntimeId build() {
+            JavaRuntimeId __instance__ = new JavaRuntimeId(version, vendor, distribution, jreKey);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(JavaRuntimeId o) {
+            Builder copiedBuilder =
+                    version(o.getVersion())
+                            .vendor(o.getVendor())
+                            .distribution(o.getDistribution())
+                            .jreKey(o.getJreKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The version of the Java Runtime.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    /**
+     * The vendor of the Java Runtime.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vendor")
+    String vendor;
+
+    /**
+     * The distribution of a Java Runtime is the name of the lineage of product to which it belongs, for example _Java(TM) SE Runtime Environment_.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("distribution")
+    String distribution;
+
+    /**
+     * The unique identifier for a Java Runtime.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("jreKey")
+    String jreKey;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/JreUsage.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/JreUsage.java
@@ -141,6 +141,16 @@ public class JreUsage {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("approximatePendingWorkRequestCount")
+        private Integer approximatePendingWorkRequestCount;
+
+        public Builder approximatePendingWorkRequestCount(
+                Integer approximatePendingWorkRequestCount) {
+            this.approximatePendingWorkRequestCount = approximatePendingWorkRequestCount;
+            this.__explicitlySet__.add("approximatePendingWorkRequestCount");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeStart")
         private java.util.Date timeStart;
 
@@ -196,6 +206,7 @@ public class JreUsage {
                             approximateInstallationCount,
                             approximateApplicationCount,
                             approximateManagedInstanceCount,
+                            approximatePendingWorkRequestCount,
                             timeStart,
                             timeEnd,
                             timeFirstSeen,
@@ -220,6 +231,8 @@ public class JreUsage {
                             .approximateInstallationCount(o.getApproximateInstallationCount())
                             .approximateApplicationCount(o.getApproximateApplicationCount())
                             .approximateManagedInstanceCount(o.getApproximateManagedInstanceCount())
+                            .approximatePendingWorkRequestCount(
+                                    o.getApproximatePendingWorkRequestCount())
                             .timeStart(o.getTimeStart())
                             .timeEnd(o.getTimeEnd())
                             .timeFirstSeen(o.getTimeFirstSeen())
@@ -314,6 +327,12 @@ public class JreUsage {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("approximateManagedInstanceCount")
     Integer approximateManagedInstanceCount;
+
+    /**
+     * The approximate count of work requests working on this Java Runtime.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("approximatePendingWorkRequestCount")
+    Integer approximatePendingWorkRequestCount;
 
     /**
      * Lower bound of the specified time period filter. JMS provides a view of the data that is _per day_. The query uses only the date element of the parameter.

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/LifecycleState.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/LifecycleState.java
@@ -15,6 +15,7 @@ public enum LifecycleState {
     Deleted("DELETED"),
     Deleting("DELETING"),
     Failed("FAILED"),
+    NeedsAttention("NEEDS_ATTENTION"),
     Updating("UPDATING"),
 
     /**

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/OperationType.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/OperationType.java
@@ -14,6 +14,8 @@ public enum OperationType {
     DeleteFleet("DELETE_FLEET"),
     MoveFleet("MOVE_FLEET"),
     UpdateFleet("UPDATE_FLEET"),
+    UpdateFleetAgentConfiguration("UPDATE_FLEET_AGENT_CONFIGURATION"),
+    DeleteJavaInstallation("DELETE_JAVA_INSTALLATION"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/Principal.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/Principal.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * An authorized principal.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Principal.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Principal {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Principal build() {
+            Principal __instance__ = new Principal(id, displayName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Principal o) {
+            Builder copiedBuilder = id(o.getId()).displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the principal.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The name of the principal.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/RemoveFleetInstallationSitesDetails.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/RemoveFleetInstallationSitesDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * The list of Java installation sites to remove.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RemoveFleetInstallationSitesDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RemoveFleetInstallationSitesDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("installationSites")
+        private java.util.List<ExistingInstallationSiteId> installationSites;
+
+        public Builder installationSites(
+                java.util.List<ExistingInstallationSiteId> installationSites) {
+            this.installationSites = installationSites;
+            this.__explicitlySet__.add("installationSites");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RemoveFleetInstallationSitesDetails build() {
+            RemoveFleetInstallationSitesDetails __instance__ =
+                    new RemoveFleetInstallationSitesDetails(installationSites);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RemoveFleetInstallationSitesDetails o) {
+            Builder copiedBuilder = installationSites(o.getInstallationSites());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The list of installation sites to remove.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("installationSites")
+    java.util.List<ExistingInstallationSiteId> installationSites;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/UpdateFleetDetails.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/UpdateFleetDetails.java
@@ -44,6 +44,24 @@ public class UpdateFleetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("inventoryLog")
+        private CustomLog inventoryLog;
+
+        public Builder inventoryLog(CustomLog inventoryLog) {
+            this.inventoryLog = inventoryLog;
+            this.__explicitlySet__.add("inventoryLog");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("operationLog")
+        private CustomLog operationLog;
+
+        public Builder operationLog(CustomLog operationLog) {
+            this.operationLog = operationLog;
+            this.__explicitlySet__.add("operationLog");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -68,7 +86,13 @@ public class UpdateFleetDetails {
 
         public UpdateFleetDetails build() {
             UpdateFleetDetails __instance__ =
-                    new UpdateFleetDetails(displayName, description, definedTags, freeformTags);
+                    new UpdateFleetDetails(
+                            displayName,
+                            description,
+                            inventoryLog,
+                            operationLog,
+                            definedTags,
+                            freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -78,6 +102,8 @@ public class UpdateFleetDetails {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
+                            .inventoryLog(o.getInventoryLog())
+                            .operationLog(o.getOperationLog())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -104,6 +130,12 @@ public class UpdateFleetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("inventoryLog")
+    CustomLog inventoryLog;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operationLog")
+    CustomLog operationLog;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/WorkItemCollection.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/WorkItemCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * A list of WorkItem.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkItemCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkItemCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<WorkItemSummary> items;
+
+        public Builder items(java.util.List<WorkItemSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkItemCollection build() {
+            WorkItemCollection __instance__ = new WorkItemCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkItemCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A list of work request items.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<WorkItemSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/WorkItemStatus.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/WorkItemStatus.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * Possible operation status.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.extern.slf4j.Slf4j
+public enum WorkItemStatus {
+    Accepted("ACCEPTED"),
+    InProgress("IN_PROGRESS"),
+    Canceling("CANCELING"),
+    Canceled("CANCELED"),
+    Succeeded("SUCCEEDED"),
+    NeedsAttention("NEEDS_ATTENTION"),
+    Retrying("RETRYING"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, WorkItemStatus> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (WorkItemStatus v : WorkItemStatus.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    WorkItemStatus(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static WorkItemStatus create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'WorkItemStatus', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/WorkItemSummary.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/WorkItemSummary.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.model;
+
+/**
+ * The LCM work request for a JVM installation site.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = WorkItemSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkItemSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("workRequestId")
+        private String workRequestId;
+
+        public Builder workRequestId(String workRequestId) {
+            this.workRequestId = workRequestId;
+            this.__explicitlySet__.add("workRequestId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("installationSite")
+        private InstallationSite installationSite;
+
+        public Builder installationSite(InstallationSite installationSite) {
+            this.installationSite = installationSite;
+            this.__explicitlySet__.add("installationSite");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private WorkItemStatus status;
+
+        public Builder status(WorkItemStatus status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retryCount")
+        private Integer retryCount;
+
+        public Builder retryCount(Integer retryCount) {
+            this.retryCount = retryCount;
+            this.__explicitlySet__.add("retryCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastUpdated")
+        private java.util.Date timeLastUpdated;
+
+        public Builder timeLastUpdated(java.util.Date timeLastUpdated) {
+            this.timeLastUpdated = timeLastUpdated;
+            this.__explicitlySet__.add("timeLastUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkItemSummary build() {
+            WorkItemSummary __instance__ =
+                    new WorkItemSummary(
+                            id,
+                            workRequestId,
+                            installationSite,
+                            status,
+                            retryCount,
+                            timeLastUpdated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkItemSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .workRequestId(o.getWorkRequestId())
+                            .installationSite(o.getInstallationSite())
+                            .status(o.getStatus())
+                            .retryCount(o.getRetryCount())
+                            .timeLastUpdated(o.getTimeLastUpdated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique ID of ths work item.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The OCID of the work request created this work item.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("workRequestId")
+    String workRequestId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("installationSite")
+    InstallationSite installationSite;
+
+    /**
+     * The status of the work item.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    WorkItemStatus status;
+
+    /**
+     * Number of times this work item is retried.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retryCount")
+    Integer retryCount;
+
+    /**
+     * The date and time the work item was last updated. (formatted according to [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339)).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastUpdated")
+    java.util.Date timeLastUpdated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/model/WorkRequest.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/model/WorkRequest.java
@@ -105,6 +105,42 @@ public class WorkRequest {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+        private Principal createdBy;
+
+        public Builder createdBy(Principal createdBy) {
+            this.createdBy = createdBy;
+            this.__explicitlySet__.add("createdBy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastUpdated")
+        private java.util.Date timeLastUpdated;
+
+        public Builder timeLastUpdated(java.util.Date timeLastUpdated) {
+            this.timeLastUpdated = timeLastUpdated;
+            this.__explicitlySet__.add("timeLastUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("totalTaskCount")
+        private Integer totalTaskCount;
+
+        public Builder totalTaskCount(Integer totalTaskCount) {
+            this.totalTaskCount = totalTaskCount;
+            this.__explicitlySet__.add("totalTaskCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("completedTaskCount")
+        private Integer completedTaskCount;
+
+        public Builder completedTaskCount(Integer completedTaskCount) {
+            this.completedTaskCount = completedTaskCount;
+            this.__explicitlySet__.add("completedTaskCount");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -119,7 +155,11 @@ public class WorkRequest {
                             percentComplete,
                             timeAccepted,
                             timeStarted,
-                            timeFinished);
+                            timeFinished,
+                            createdBy,
+                            timeLastUpdated,
+                            totalTaskCount,
+                            completedTaskCount);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -135,7 +175,11 @@ public class WorkRequest {
                             .percentComplete(o.getPercentComplete())
                             .timeAccepted(o.getTimeAccepted())
                             .timeStarted(o.getTimeStarted())
-                            .timeFinished(o.getTimeFinished());
+                            .timeFinished(o.getTimeFinished())
+                            .createdBy(o.getCreatedBy())
+                            .timeLastUpdated(o.getTimeLastUpdated())
+                            .totalTaskCount(o.getTotalTaskCount())
+                            .completedTaskCount(o.getCompletedTaskCount());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -209,6 +253,28 @@ public class WorkRequest {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
     java.util.Date timeFinished;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+    Principal createdBy;
+
+    /**
+     * The date and time the work request percentage was last updated. (formatted according to [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339)).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastUpdated")
+    java.util.Date timeLastUpdated;
+
+    /**
+     * The total number of tasks to be executed for this work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalTaskCount")
+    Integer totalTaskCount;
+
+    /**
+     * The number of tasks had been executed to a terminal state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("completedTaskCount")
+    Integer completedTaskCount;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/CancelWorkRequestRequest.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/CancelWorkRequestRequest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.requests;
+
+import com.oracle.bmc.jms.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/CancelWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CancelWorkRequestRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CancelWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the asynchronous work request.
+     */
+    private String workRequestId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * ETag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the ETag you
+     * provide matches the resource's current ETag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CancelWorkRequestRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CancelWorkRequestRequest o) {
+            workRequestId(o.getWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CancelWorkRequestRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CancelWorkRequestRequest
+         */
+        public CancelWorkRequestRequest build() {
+            CancelWorkRequestRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/CreateBlocklistRequest.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/CreateBlocklistRequest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.requests;
+
+import com.oracle.bmc.jms.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/CreateBlocklistExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateBlocklistRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateBlocklistRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.jms.model.CreateBlocklistDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Fleet.
+     */
+    private String fleetId;
+
+    /**
+     * Details for the new blocklist record.
+     */
+    private com.oracle.bmc.jms.model.CreateBlocklistDetails createBlocklistDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.jms.model.CreateBlocklistDetails getBody$() {
+        return createBlocklistDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateBlocklistRequest, com.oracle.bmc.jms.model.CreateBlocklistDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateBlocklistRequest o) {
+            fleetId(o.getFleetId());
+            createBlocklistDetails(o.getCreateBlocklistDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateBlocklistRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateBlocklistRequest
+         */
+        public CreateBlocklistRequest build() {
+            CreateBlocklistRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(com.oracle.bmc.jms.model.CreateBlocklistDetails body) {
+            createBlocklistDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/DeleteBlocklistRequest.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/DeleteBlocklistRequest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.requests;
+
+import com.oracle.bmc.jms.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/DeleteBlocklistExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteBlocklistRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteBlocklistRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Fleet.
+     */
+    private String fleetId;
+
+    /**
+     * The unique identifier of the blocklist record.
+     */
+    private String blocklistKey;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * ETag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the ETag you
+     * provide matches the resource's current ETag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteBlocklistRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteBlocklistRequest o) {
+            fleetId(o.getFleetId());
+            blocklistKey(o.getBlocklistKey());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteBlocklistRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteBlocklistRequest
+         */
+        public DeleteBlocklistRequest build() {
+            DeleteBlocklistRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/ListBlocklistsRequest.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/ListBlocklistsRequest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.requests;
+
+import com.oracle.bmc.jms.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/ListBlocklistsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListBlocklistsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListBlocklistsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Fleet.
+     */
+    private String fleetId;
+
+    /**
+     * The operation type.
+     */
+    private com.oracle.bmc.jms.model.OperationType operation;
+
+    /**
+     * The Fleet-unique identifier of the related managed instance.
+     */
+    private String managedInstanceId;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. The token is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order, either 'asc' or 'desc'.
+     */
+    private com.oracle.bmc.jms.model.SortOrder sortOrder;
+
+    /**
+     * The field to sort blocklist records. Only one sort order may be provided.
+     * Default order for _operation_ is **ascending**.
+     * If no value is specified _operation_ is default.
+     *
+     */
+    private com.oracle.bmc.jms.model.BlocklistSortBy sortBy;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListBlocklistsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBlocklistsRequest o) {
+            fleetId(o.getFleetId());
+            operation(o.getOperation());
+            managedInstanceId(o.getManagedInstanceId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListBlocklistsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListBlocklistsRequest
+         */
+        public ListBlocklistsRequest build() {
+            ListBlocklistsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/ListInstallationSitesRequest.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/ListInstallationSitesRequest.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.requests;
+
+import com.oracle.bmc.jms.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/ListInstallationSitesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListInstallationSitesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListInstallationSitesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Fleet.
+     */
+    private String fleetId;
+
+    /**
+     * The vendor of the related Java Runtime.
+     */
+    private String jreVendor;
+
+    /**
+     * The distribution of the related Java Runtime.
+     */
+    private String jreDistribution;
+
+    /**
+     * The version of the related Java Runtime.
+     */
+    private String jreVersion;
+
+    /**
+     * The file system path of the installation.
+     */
+    private String installationPath;
+
+    /**
+     * The Fleet-unique identifier of the related application.
+     */
+    private String applicationId;
+
+    /**
+     * The Fleet-unique identifier of the related managed instance.
+     */
+    private String managedInstanceId;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. The token is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order, either 'asc' or 'desc'.
+     */
+    private com.oracle.bmc.jms.model.SortOrder sortOrder;
+
+    /**
+     * The field to sort installation sites. Only one sort order may be provided.
+     * Default order for _timeLastSeen_, and _jreVersion_, _approximateApplicationCount_ is **descending**.
+     * Default order for _managedInstanceId_, _jreDistribution_, _jreVendor_ and _osName_ is **ascending**.
+     * If no value is specified _managedInstanceId_ is default.
+     *
+     */
+    private com.oracle.bmc.jms.model.InstallationSiteSortBy sortBy;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The operating system type.
+     */
+    private java.util.List<com.oracle.bmc.jms.model.OsFamily> osFamily;
+
+    /**
+     * The security status of the Java Runtime.
+     */
+    private com.oracle.bmc.jms.model.JreSecurityStatus jreSecurityStatus;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListInstallationSitesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        private java.util.List<com.oracle.bmc.jms.model.OsFamily> osFamily = null;
+
+        /**
+         * The operating system type.
+         * @return this builder instance
+         */
+        public Builder osFamily(java.util.List<com.oracle.bmc.jms.model.OsFamily> osFamily) {
+            this.osFamily = osFamily;
+            return this;
+        }
+
+        /**
+         * Singular setter. The operating system type.
+         * @return this builder instance
+         */
+        public Builder osFamily(OsFamily singularValue) {
+            return this.osFamily(java.util.Arrays.asList(singularValue));
+        }
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListInstallationSitesRequest o) {
+            fleetId(o.getFleetId());
+            jreVendor(o.getJreVendor());
+            jreDistribution(o.getJreDistribution());
+            jreVersion(o.getJreVersion());
+            installationPath(o.getInstallationPath());
+            applicationId(o.getApplicationId());
+            managedInstanceId(o.getManagedInstanceId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            osFamily(o.getOsFamily());
+            jreSecurityStatus(o.getJreSecurityStatus());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListInstallationSitesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListInstallationSitesRequest
+         */
+        public ListInstallationSitesRequest build() {
+            ListInstallationSitesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/ListWorkItemsRequest.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/ListWorkItemsRequest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.requests;
+
+import com.oracle.bmc.jms.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/ListWorkItemsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkItemsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkItemsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the asynchronous work request.
+     */
+    private String workRequestId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The page token representing the page at which to start retrieving results. The token is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListWorkItemsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkItemsRequest o) {
+            workRequestId(o.getWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            page(o.getPage());
+            limit(o.getLimit());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListWorkItemsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListWorkItemsRequest
+         */
+        public ListWorkItemsRequest build() {
+            ListWorkItemsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/ListWorkRequestsRequest.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/ListWorkRequestsRequest.java
@@ -31,6 +31,11 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
     private String id;
 
     /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the fleet.
+     */
+    private String fleetId;
+
+    /**
      * The client request ID for tracing.
      */
     private String opcRequestId;
@@ -82,6 +87,7 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
         public Builder copy(ListWorkRequestsRequest o) {
             compartmentId(o.getCompartmentId());
             id(o.getId());
+            fleetId(o.getFleetId());
             opcRequestId(o.getOpcRequestId());
             page(o.getPage());
             limit(o.getLimit());

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/RemoveFleetInstallationSitesRequest.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/requests/RemoveFleetInstallationSitesRequest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.requests;
+
+import com.oracle.bmc.jms.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/jms/RemoveFleetInstallationSitesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use RemoveFleetInstallationSitesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RemoveFleetInstallationSitesRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.jms.model.RemoveFleetInstallationSitesDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Fleet.
+     */
+    private String fleetId;
+
+    /**
+     * List of installation sites to be deleted.
+     */
+    private com.oracle.bmc.jms.model.RemoveFleetInstallationSitesDetails
+            removeFleetInstallationSitesDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * ETag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the ETag you
+     * provide matches the resource's current ETag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.jms.model.RemoveFleetInstallationSitesDetails getBody$() {
+        return removeFleetInstallationSitesDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RemoveFleetInstallationSitesRequest,
+                    com.oracle.bmc.jms.model.RemoveFleetInstallationSitesDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveFleetInstallationSitesRequest o) {
+            fleetId(o.getFleetId());
+            removeFleetInstallationSitesDetails(o.getRemoveFleetInstallationSitesDetails());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RemoveFleetInstallationSitesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RemoveFleetInstallationSitesRequest
+         */
+        public RemoveFleetInstallationSitesRequest build() {
+            RemoveFleetInstallationSitesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(com.oracle.bmc.jms.model.RemoveFleetInstallationSitesDetails body) {
+            removeFleetInstallationSitesDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/CancelWorkRequestResponse.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/CancelWorkRequestResponse.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.responses;
+
+import com.oracle.bmc.jms.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CancelWorkRequestResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcRequestId"})
+    private CancelWorkRequestResponse(int __httpStatusCode__, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CancelWorkRequestResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public CancelWorkRequestResponse build() {
+            return new CancelWorkRequestResponse(__httpStatusCode__, opcRequestId);
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/CreateBlocklistResponse.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/CreateBlocklistResponse.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.responses;
+
+import com.oracle.bmc.jms.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateBlocklistResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned Blocklist instance.
+     */
+    private com.oracle.bmc.jms.model.Blocklist blocklist;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcRequestId", "etag", "blocklist"})
+    private CreateBlocklistResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String etag,
+            com.oracle.bmc.jms.model.Blocklist blocklist) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.etag = etag;
+        this.blocklist = blocklist;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateBlocklistResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            blocklist(o.getBlocklist());
+
+            return this;
+        }
+
+        public CreateBlocklistResponse build() {
+            return new CreateBlocklistResponse(__httpStatusCode__, opcRequestId, etag, blocklist);
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/DeleteBlocklistResponse.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/DeleteBlocklistResponse.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.responses;
+
+import com.oracle.bmc.jms.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteBlocklistResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcRequestId"})
+    private DeleteBlocklistResponse(int __httpStatusCode__, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteBlocklistResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public DeleteBlocklistResponse build() {
+            return new DeleteBlocklistResponse(__httpStatusCode__, opcRequestId);
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/GetWorkRequestResponse.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/GetWorkRequestResponse.java
@@ -25,6 +25,12 @@ public class GetWorkRequestResponse extends com.oracle.bmc.responses.BmcResponse
     private Float retryAfter;
 
     /**
+     * For optimistic concurrency control. See {@code if-match}.
+     *
+     */
+    private String etag;
+
+    /**
      * The returned WorkRequest instance.
      */
     private com.oracle.bmc.jms.model.WorkRequest workRequest;
@@ -33,16 +39,19 @@ public class GetWorkRequestResponse extends com.oracle.bmc.responses.BmcResponse
         "__httpStatusCode__",
         "opcRequestId",
         "retryAfter",
+        "etag",
         "workRequest"
     })
     private GetWorkRequestResponse(
             int __httpStatusCode__,
             String opcRequestId,
             Float retryAfter,
+            String etag,
             com.oracle.bmc.jms.model.WorkRequest workRequest) {
         super(__httpStatusCode__);
         this.opcRequestId = opcRequestId;
         this.retryAfter = retryAfter;
+        this.etag = etag;
         this.workRequest = workRequest;
     }
 
@@ -62,6 +71,7 @@ public class GetWorkRequestResponse extends com.oracle.bmc.responses.BmcResponse
             __httpStatusCode__(o.get__httpStatusCode__());
             opcRequestId(o.getOpcRequestId());
             retryAfter(o.getRetryAfter());
+            etag(o.getEtag());
             workRequest(o.getWorkRequest());
 
             return this;
@@ -69,7 +79,7 @@ public class GetWorkRequestResponse extends com.oracle.bmc.responses.BmcResponse
 
         public GetWorkRequestResponse build() {
             return new GetWorkRequestResponse(
-                    __httpStatusCode__, opcRequestId, retryAfter, workRequest);
+                    __httpStatusCode__, opcRequestId, retryAfter, etag, workRequest);
         }
     }
 }

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/ListBlocklistsResponse.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/ListBlocklistsResponse.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.responses;
+
+import com.oracle.bmc.jms.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListBlocklistsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * Include this value as the {@code page} parameter for the subsequent GET request to get the next batch of items.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned BlocklistCollection instance.
+     */
+    private com.oracle.bmc.jms.model.BlocklistCollection blocklistCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "blocklistCollection"
+    })
+    private ListBlocklistsResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            com.oracle.bmc.jms.model.BlocklistCollection blocklistCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.blocklistCollection = blocklistCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBlocklistsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            blocklistCollection(o.getBlocklistCollection());
+
+            return this;
+        }
+
+        public ListBlocklistsResponse build() {
+            return new ListBlocklistsResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, blocklistCollection);
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/ListInstallationSitesResponse.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/ListInstallationSitesResponse.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.responses;
+
+import com.oracle.bmc.jms.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListInstallationSitesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * Include this value as the {@code page} parameter for the subsequent GET request to get the next batch of items.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned InstallationSiteCollection instance.
+     */
+    private com.oracle.bmc.jms.model.InstallationSiteCollection installationSiteCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "installationSiteCollection"
+    })
+    private ListInstallationSitesResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            com.oracle.bmc.jms.model.InstallationSiteCollection installationSiteCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.installationSiteCollection = installationSiteCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListInstallationSitesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            installationSiteCollection(o.getInstallationSiteCollection());
+
+            return this;
+        }
+
+        public ListInstallationSitesResponse build() {
+            return new ListInstallationSitesResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, installationSiteCollection);
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/ListWorkItemsResponse.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/ListWorkItemsResponse.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.responses;
+
+import com.oracle.bmc.jms.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkItemsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * Include this value as the {@code page} parameter for the subsequent GET request to get the next batch of items.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned WorkItemCollection instance.
+     */
+    private com.oracle.bmc.jms.model.WorkItemCollection workItemCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcNextPage",
+        "opcRequestId",
+        "workItemCollection"
+    })
+    private ListWorkItemsResponse(
+            int __httpStatusCode__,
+            String opcNextPage,
+            String opcRequestId,
+            com.oracle.bmc.jms.model.WorkItemCollection workItemCollection) {
+        super(__httpStatusCode__);
+        this.opcNextPage = opcNextPage;
+        this.opcRequestId = opcRequestId;
+        this.workItemCollection = workItemCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkItemsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            workItemCollection(o.getWorkItemCollection());
+
+            return this;
+        }
+
+        public ListWorkItemsResponse build() {
+            return new ListWorkItemsResponse(
+                    __httpStatusCode__, opcNextPage, opcRequestId, workItemCollection);
+        }
+    }
+}

--- a/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/RemoveFleetInstallationSitesResponse.java
+++ b/bmc-jms/src/main/java/com/oracle/bmc/jms/responses/RemoveFleetInstallationSitesResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.jms.responses;
+
+import com.oracle.bmc.jms.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210610")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RemoveFleetInstallationSitesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query the status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private RemoveFleetInstallationSitesResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveFleetInstallationSitesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public RemoveFleetInstallationSitesResponse build() {
+            return new RemoveFleetInstallationSitesResponse(
+                    __httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/Account.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/Account.java
@@ -51,7 +51,7 @@ public interface Account extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/GetLaunchEligibilityExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetLaunchEligibility API.
@@ -63,7 +63,7 @@ public interface Account extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/GetThirdPartyPaidListingEligibilityExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetThirdPartyPaidListingEligibility API.

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/AccountClient.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/AccountClient.java
@@ -394,7 +394,7 @@ public class AccountClient implements Account {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -426,7 +426,7 @@ public class AccountClient implements Account {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/Marketplace.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/Marketplace.java
@@ -51,7 +51,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ChangePublicationCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangePublicationCompartment API.
@@ -66,7 +66,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/CreateAcceptedAgreementExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateAcceptedAgreement API.
@@ -78,7 +78,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/CreatePublicationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreatePublication API.
@@ -93,7 +93,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/DeleteAcceptedAgreementExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteAcceptedAgreement API.
@@ -105,7 +105,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/DeletePublicationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeletePublication API.
@@ -118,7 +118,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/GetAcceptedAgreementExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAcceptedAgreement API.
@@ -132,7 +132,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/GetAgreementExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAgreement API.
@@ -159,7 +159,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/GetListingExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetListing API.
@@ -185,7 +185,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/GetPackageExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPackage API.
@@ -197,7 +197,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/GetPublicationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPublication API.
@@ -209,7 +209,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/GetPublicationPackageExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPublicationPackage API.
@@ -223,7 +223,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListAcceptedAgreementsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAcceptedAgreements API.
@@ -236,7 +236,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListAgreementsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAgreements API.
@@ -250,7 +250,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListCategoriesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListCategories API.
@@ -277,7 +277,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListListingsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListListings API.
@@ -303,7 +303,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListPackagesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListPackages API.
@@ -315,7 +315,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListPublicationPackagesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListPublicationPackages API.
@@ -327,7 +327,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListPublicationsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListPublications API.
@@ -340,7 +340,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListPublishersExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListPublishers API.
@@ -352,7 +352,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListReportTypesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListReportTypes API.
@@ -364,7 +364,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListReportsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListReports API.
@@ -376,7 +376,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/ListTaxesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListTaxes API.
@@ -390,7 +390,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/SearchListingsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SearchListings API.
@@ -403,7 +403,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/UpdateAcceptedAgreementExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateAcceptedAgreement API.
@@ -415,7 +415,7 @@ public interface Marketplace extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/marketplace/UpdatePublicationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdatePublication API.

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/MarketplaceClient.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/MarketplaceClient.java
@@ -474,7 +474,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -510,7 +510,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -544,7 +544,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -579,7 +579,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -609,7 +609,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -639,7 +639,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -668,7 +668,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -696,7 +696,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -724,7 +724,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -753,7 +753,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -783,7 +783,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -813,7 +813,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -842,7 +842,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -871,7 +871,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -900,7 +900,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -929,7 +929,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -959,7 +959,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -988,7 +988,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1017,7 +1017,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1046,7 +1046,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1075,7 +1075,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1103,7 +1103,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1132,7 +1132,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1166,7 +1166,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -1200,7 +1200,7 @@ public class MarketplaceClient implements Marketplace {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/ArchitectureType.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/ArchitectureType.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.marketplace.model;
+
+/**
+ * Possible values for a listings compatbile architecture
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+public enum ArchitectureType {
+    X86("X86"),
+    Arm("ARM"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, ArchitectureType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (ArchitectureType v : ArchitectureType.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    ArchitectureType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static ArchitectureType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid ArchitectureType: " + key);
+    }
+}

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/IneligibilityReasonEnum.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/IneligibilityReasonEnum.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.marketplace.model;
+
+/**
+ * Possible values of on why a tenant cannot launch a listing
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.extern.slf4j.Slf4j
+public enum IneligibilityReasonEnum {
+    IneligibleAccountCountry("INELIGIBLE_ACCOUNT_COUNTRY"),
+    IneligibleRegion("INELIGIBLE_REGION"),
+    IneligibleAccountBlacklisted("INELIGIBLE_ACCOUNT_BLACKLISTED"),
+    IneligibleAccountFeatureDisabled("INELIGIBLE_ACCOUNT_FEATURE_DISABLED"),
+    IneligibleAccountCurrency("INELIGIBLE_ACCOUNT_CURRENCY"),
+    IneligibleAccountNotPaid("INELIGIBLE_ACCOUNT_NOT_PAID"),
+    IneligibleAccountInternal("INELIGIBLE_ACCOUNT_INTERNAL"),
+    IneligibleAccountGovSubscription("INELIGIBLE_ACCOUNT_GOV_SUBSCRIPTION"),
+    IneligiblePaidListingThrottled("INELIGIBLE_PAID_LISTING_THROTTLED"),
+    NotAuthorized("NOT_AUTHORIZED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, IneligibilityReasonEnum> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (IneligibilityReasonEnum v : IneligibilityReasonEnum.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    IneligibilityReasonEnum(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static IneligibilityReasonEnum create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'IneligibilityReasonEnum', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/InternationalMarketPrice.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/InternationalMarketPrice.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.marketplace.model;
+
+/**
+ * The model for international market pricing.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InternationalMarketPrice.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InternationalMarketPrice {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("currencyCode")
+        private PricingCurrencyEnum currencyCode;
+
+        public Builder currencyCode(PricingCurrencyEnum currencyCode) {
+            this.currencyCode = currencyCode;
+            this.__explicitlySet__.add("currencyCode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("currencySymbol")
+        private String currencySymbol;
+
+        public Builder currencySymbol(String currencySymbol) {
+            this.currencySymbol = currencySymbol;
+            this.__explicitlySet__.add("currencySymbol");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rate")
+        private Double rate;
+
+        public Builder rate(Double rate) {
+            this.rate = rate;
+            this.__explicitlySet__.add("rate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InternationalMarketPrice build() {
+            InternationalMarketPrice __instance__ =
+                    new InternationalMarketPrice(currencyCode, currencySymbol, rate);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InternationalMarketPrice o) {
+            Builder copiedBuilder =
+                    currencyCode(o.getCurrencyCode())
+                            .currencySymbol(o.getCurrencySymbol())
+                            .rate(o.getRate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The currency of the pricing model.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currencyCode")
+    PricingCurrencyEnum currencyCode;
+
+    /**
+     * The symbol of the currency
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currencySymbol")
+    String currencySymbol;
+
+    /**
+     * The pricing rate.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rate")
+    Double rate;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/LaunchEligibility.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/LaunchEligibility.java
@@ -53,12 +53,21 @@ public class LaunchEligibility {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("ineligibilityReason")
+        private IneligibilityReasonEnum ineligibilityReason;
+
+        public Builder ineligibilityReason(IneligibilityReasonEnum ineligibilityReason) {
+            this.ineligibilityReason = ineligibilityReason;
+            this.__explicitlySet__.add("ineligibilityReason");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public LaunchEligibility build() {
             LaunchEligibility __instance__ =
-                    new LaunchEligibility(imageId, isLaunchAllowed, meters);
+                    new LaunchEligibility(imageId, isLaunchAllowed, meters, ineligibilityReason);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -68,7 +77,8 @@ public class LaunchEligibility {
             Builder copiedBuilder =
                     imageId(o.getImageId())
                             .isLaunchAllowed(o.getIsLaunchAllowed())
-                            .meters(o.getMeters());
+                            .meters(o.getMeters())
+                            .ineligibilityReason(o.getIneligibilityReason());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -99,6 +109,12 @@ public class LaunchEligibility {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("meters")
     String meters;
+
+    /**
+     * Reason the account is ineligible to launch paid listings
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ineligibilityReason")
+    IneligibilityReasonEnum ineligibilityReason;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/Listing.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/Listing.java
@@ -222,6 +222,16 @@ public class Listing {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("compatibleArchitectures")
+        private java.util.List<CompatibleArchitectures> compatibleArchitectures;
+
+        public Builder compatibleArchitectures(
+                java.util.List<CompatibleArchitectures> compatibleArchitectures) {
+            this.compatibleArchitectures = compatibleArchitectures;
+            this.__explicitlySet__.add("compatibleArchitectures");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("regions")
         private java.util.List<Region> regions;
 
@@ -314,6 +324,7 @@ public class Listing {
                             documentationLinks,
                             icon,
                             banner,
+                            compatibleArchitectures,
                             regions,
                             packageType,
                             defaultPackageVersion,
@@ -350,6 +361,7 @@ public class Listing {
                             .documentationLinks(o.getDocumentationLinks())
                             .icon(o.getIcon())
                             .banner(o.getBanner())
+                            .compatibleArchitectures(o.getCompatibleArchitectures())
                             .regions(o.getRegions())
                             .packageType(o.getPackageType())
                             .defaultPackageVersion(o.getDefaultPackageVersion())
@@ -492,6 +504,56 @@ public class Listing {
 
     @com.fasterxml.jackson.annotation.JsonProperty("banner")
     UploadData banner;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum CompatibleArchitectures {
+        X86("X86"),
+        Arm("ARM"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, CompatibleArchitectures> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (CompatibleArchitectures v : CompatibleArchitectures.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        CompatibleArchitectures(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static CompatibleArchitectures create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'CompatibleArchitectures', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The list of compatible architectures supported by the listing
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compatibleArchitectures")
+    java.util.List<CompatibleArchitectures> compatibleArchitectures;
 
     /**
      * The regions where you can deploy the listing. (Some listings have restrictions that limit their deployment to United States regions only.)

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/ListingSummary.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/ListingSummary.java
@@ -96,6 +96,16 @@ public class ListingSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("compatibleArchitectures")
+        private java.util.List<CompatibleArchitectures> compatibleArchitectures;
+
+        public Builder compatibleArchitectures(
+                java.util.List<CompatibleArchitectures> compatibleArchitectures) {
+            this.compatibleArchitectures = compatibleArchitectures;
+            this.__explicitlySet__.add("compatibleArchitectures");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("regions")
         private java.util.List<Region> regions;
 
@@ -165,6 +175,7 @@ public class ListingSummary {
                             icon,
                             packageType,
                             pricingTypes,
+                            compatibleArchitectures,
                             regions,
                             isFeatured,
                             categories,
@@ -186,6 +197,7 @@ public class ListingSummary {
                             .icon(o.getIcon())
                             .packageType(o.getPackageType())
                             .pricingTypes(o.getPricingTypes())
+                            .compatibleArchitectures(o.getCompatibleArchitectures())
                             .regions(o.getRegions())
                             .isFeatured(o.getIsFeatured())
                             .categories(o.getCategories())
@@ -294,6 +306,56 @@ public class ListingSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pricingTypes")
     java.util.List<PricingTypes> pricingTypes;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum CompatibleArchitectures {
+        X86("X86"),
+        Arm("ARM"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, CompatibleArchitectures> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (CompatibleArchitectures v : CompatibleArchitectures.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        CompatibleArchitectures(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static CompatibleArchitectures create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'CompatibleArchitectures', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The list of compatible architectures supported by the listing
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compatibleArchitectures")
+    java.util.List<CompatibleArchitectures> compatibleArchitectures;
 
     /**
      * The regions where you can deploy the listing. (Some listings have restrictions that limit their deployment to United States regions only.)

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/PricingCurrencyEnum.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/PricingCurrencyEnum.java
@@ -11,6 +11,12 @@ package com.oracle.bmc.marketplace.model;
 @lombok.extern.slf4j.Slf4j
 public enum PricingCurrencyEnum {
     Usd("USD"),
+    Cad("CAD"),
+    Inr("INR"),
+    Gbp("GBP"),
+    Brl("BRL"),
+    Jpy("JPY"),
+    Omr("OMR"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/PricingModel.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/model/PricingModel.java
@@ -60,11 +60,21 @@ public class PricingModel {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("internationalMarketPrice")
+        private InternationalMarketPrice internationalMarketPrice;
+
+        public Builder internationalMarketPrice(InternationalMarketPrice internationalMarketPrice) {
+            this.internationalMarketPrice = internationalMarketPrice;
+            this.__explicitlySet__.add("internationalMarketPrice");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public PricingModel build() {
-            PricingModel __instance__ = new PricingModel(type, payGoStrategy, currency, rate);
+            PricingModel __instance__ =
+                    new PricingModel(type, payGoStrategy, currency, rate, internationalMarketPrice);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -75,7 +85,8 @@ public class PricingModel {
                     type(o.getType())
                             .payGoStrategy(o.getPayGoStrategy())
                             .currency(o.getCurrency())
-                            .rate(o.getRate());
+                            .rate(o.getRate())
+                            .internationalMarketPrice(o.getInternationalMarketPrice());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -112,6 +123,9 @@ public class PricingModel {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("rate")
     java.math.BigDecimal rate;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("internationalMarketPrice")
+    InternationalMarketPrice internationalMarketPrice;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/requests/ListListingsRequest.java
+++ b/bmc-marketplace/src/main/java/com/oracle/bmc/marketplace/requests/ListListingsRequest.java
@@ -30,7 +30,7 @@ public class ListListingsRequest extends com.oracle.bmc.requests.BmcRequest<java
     private String listingId;
 
     /**
-     * Image ID of the listing
+     * The image identifier of the listing.
      */
     private String imageId;
 

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ospgateway/pom.xml
+++ b/bmc-ospgateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ospgateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubbillingschedule/pom.xml
+++ b/bmc-osubbillingschedule/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osuborganizationsubscription/pom.xml
+++ b/bmc-osuborganizationsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubsubscription/pom.xml
+++ b/bmc-osubsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubusage/pom.xml
+++ b/bmc-osubusage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubusage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemanagerproxy/pom.xml
+++ b/bmc-servicemanagerproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-threatintelligence/pom.xml
+++ b/bmc-threatintelligence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-threatintelligence</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usage/pom.xml
+++ b/bmc-usage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-visualbuilder/pom.xml
+++ b/bmc-visualbuilder/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-visualbuilder</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.20.0</version>
+    <version>2.21.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.20.0</version>
+  <version>2.21.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for returning the number of network ports as part of listing shapes in the Compute service

- Support for Java runtime removal and custom logs in the Java Management service

- Support for new parameters for BGP admin state and enabling/disabling BFD in the Networking service

- Support for private OKE clusters and blue-green deployments in the DevOps service

- Support for international customers to consume and launch third-party paid listings in the Marketplace service

- Support for additional fields on entities, attributes, and folders in the Data Catalog service



### Breaking Changes

- Support for retries by default on operations in the Marketplace service