### PR TITLE
Releasing version 2.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.22.0 - 2022-04-05
+### Added
+- Fixed the lifecycle state values for target databases in the Data Safe service
+- Support for content length and content type response headers when downloading PDFs in the Account Management service
+- Support for creating Enterprise Manager-based zLinux host targets, creating alarms, and viewing top process analytics in the Operations Insights service
+- Support for diagnostic reboots on VM instances in the Compute service
+
+### Breaking Changes
+- The data type of property `lifecycleState` in request `ListTargetDatabasesRequest` was changed from `com.oracle.bmc.datasafe.model.LifecycleState` to `com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState` in the Data Safe service
+- The data type of property `lifecycleState` in model `TargetDatabase` was changed from `com.oracle.bmc.datasafe.model.LifecycleState` to `com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState` in the Data Safe service
+- The data type of property `lifecycleState` in model `TargetDatabaseSummary` was changed from `com.oracle.bmc.datasafe.model.LifecycleState` to `com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState` in the Data Safe service
+
 ## 2.21.0 - 2022-03-29
 ### Added
 - Support for returning the number of network ports as part of listing shapes in the Compute service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>4.5.7.Final</version>
+      <version>4.5.9.Final</version>
     </dependency>
 
     <dependency>
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -57,12 +57,12 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.16.1</version>
+      <version>3.19.3</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aispeech/pom.xml
+++ b/bmc-aispeech/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aispeech</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aivision/pom.xml
+++ b/bmc-aivision/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aivision</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-appmgmtcontrol/pom.xml
+++ b/bmc-appmgmtcontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,636 +19,636 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificates</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usage</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasetools</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ospgateway</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identitydataplane</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-visualbuilder</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubusage</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubsubscription</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dashboardservice</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-threatintelligence</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aivision</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aispeech</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataconnectivity</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificates/pom.xml
+++ b/bmc-certificates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificates</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificatesmanagement/pom.xml
+++ b/bmc-certificatesmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
@@ -789,6 +789,8 @@ public interface Compute extends AutoCloseable {
      * <p>
      *
      * <p>
+     * - **DIAGNOSTICREBOOT** - **This feature currently only supports virtual machines** Powers off the VM instance then rebuilds and powers it back on.
+     * <p>
      *
      * For more information about managing instance lifecycle states, see
      * [Stopping and Starting an Instance](https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/restartinginstance.htm).

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
@@ -973,6 +973,8 @@ public interface ComputeAsync extends AutoCloseable {
      * <p>
      *
      * <p>
+     * - **DIAGNOSTICREBOOT** - **This feature currently only supports virtual machines** Powers off the VM instance then rebuilds and powers it back on.
+     * <p>
      *
      * For more information about managing instance lifecycle states, see
      * [Stopping and Starting an Instance](https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/restartinginstance.htm).

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolume.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolume.java
@@ -353,7 +353,7 @@ public class BootVolume {
     Boolean isHydrated;
 
     /**
-     * The number of volume performance units (VPUs) that will be applied to this boot volume per GB,
+     * The number of volume performance units (VPUs) that will be applied to this volume per GB,
      * representing the Block Volume service's elastic performance options.
      * See [Block Volume Performance Levels](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
      * <p>
@@ -362,10 +362,8 @@ public class BootVolume {
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
-     *
-     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
-     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
+     * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")
@@ -464,15 +462,14 @@ public class BootVolume {
     String kmsKeyId;
 
     /**
-     * Specifies whether the auto-tune performance is enabled for this boot volume. This field is deprecated.
-     * Use the {@code DetachedVolumeAutotunePolicy} instead to enable the volume for detached autotune.
+     * Specifies whether the auto-tune performance is enabled for this boot volume.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
     Boolean isAutoTuneEnabled;
 
     /**
-     * The number of Volume Performance Units per GB that this boot volume is effectively tuned to.
+     * The number of Volume Performance Units per GB that this volume is effectively tuned to when it's idle.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("autoTunedVpusPerGB")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateBootVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateBootVolumeDetails.java
@@ -258,13 +258,11 @@ public class CreateBootVolumeDetails {
      * <p>
      * Allowed values:
      * <p>
-     * {@code 10}: Represents the Balanced option.
+     * {@code 10}: Represents Balanced option.
      * <p>
-     * {@code 20}: Represents the Higher Performance option.
-     *
-     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
-     *
-     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
+     * {@code 20}: Represents Higher Performance option.
+     * <p>
+     * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")
@@ -274,8 +272,7 @@ public class CreateBootVolumeDetails {
     BootVolumeSourceDetails sourceDetails;
 
     /**
-     * Specifies whether the auto-tune performance is enabled for this boot volume. This field is deprecated.
-     * Use the {@code DetachedVolumeAutotunePolicy} instead to enable the volume for detached autotune.
+     * Specifies whether the auto-tune performance is enabled for this boot volume.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVcnDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVcnDetails.java
@@ -217,7 +217,6 @@ public class CreateVcnDetails {
     /**
      * Whether IPv6 is enabled for the VCN. Default is {@code false}.
      * If enabled, Oracle will assign the VCN a IPv6 /56 CIDR block.
-     * You may skip having Oracle allocate the VCN a IPv6 /56 CIDR block by setting isOracleGuaAllocationEnabled to {@code false}.
      * For important details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: {@code true}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeDetails.java
@@ -276,15 +276,11 @@ public class CreateVolumeDetails {
      * <p>
      * Allowed values:
      * <p>
-     * {@code 0}: Represents Lower Cost option.
-     * <p>
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
-     *
-     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
-     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
+     * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")
@@ -317,8 +313,7 @@ public class CreateVolumeDetails {
     String volumeBackupId;
 
     /**
-     * Specifies whether the auto-tune performance is enabled for this volume. This field is deprecated.
-     * Use the {@code DetachedVolumeAutotunePolicy} instead to enable the volume for detached autotune.
+     * Specifies whether the auto-tune performance is enabled for this boot volume.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.core.model;
 
 /**
- * No match criteria is applied.
+ * All routes are imported or exported.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationCreateVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationCreateVolumeDetails.java
@@ -226,17 +226,15 @@ public class InstanceConfigurationCreateVolumeDetails {
     /**
      * The number of volume performance units (VPUs) that will be applied to this volume per GB,
      * representing the Block Volume service's elastic performance options.
-     * See [Block Volume Elastic Performance](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
+     * See [Block Volume Performance Levels](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
      * <p>
      * Allowed values:
-     * <p>
-     * {@code 0}: Represents Lower Cost option.
      * <p>
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
      * <p>
-     * For performance autotune enabled volumes, It would be the Default(Minimum) VPUs/GB.
+     * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/PublicIpPool.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/PublicIpPool.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.core.model;
 
 /**
- * A public IP pool is a set of public IP addresses represented as one or more IPv4 CIDR blocks. Resources like load balancers and compute instances can be allocated public IP addresses from a public IP pool.
+ * A public IP pool is a set of public IP addresses represented as one or more IPv4 CIDR blocks.      Resources like load balancers and compute instances can be allocated public IP addresses from a public IP pool.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -141,6 +142,7 @@ public class PublicIpPool {
 
     /**
      * The CIDR blocks added to this pool. This could be all or a portion of a BYOIP CIDR block.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("cidrBlocks")
     java.util.List<String> cidrBlocks;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeDetails.java
@@ -175,18 +175,15 @@ public class UpdateBootVolumeDetails {
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
-     *
-     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
-     * For performance autotune enabled volumes, It would be the Default(Minimum) VPUs/GB.
+     * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")
     Long vpusPerGB;
 
     /**
-     * Specifies whether the auto-tune performance is enabled for this boot volume. This field is deprecated.
-     * Use the {@code DetachedVolumeAutotunePolicy} instead to enable the volume for detached autotune.
+     * Specifies whether the auto-tune performance is enabled for this boot volume.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeDetails.java
@@ -166,15 +166,11 @@ public class UpdateVolumeDetails {
      * <p>
      * Allowed values:
      * <p>
-     * {@code 0}: Represents Lower Cost option.
-     * <p>
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
-     *
-     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
-     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
+     * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")
@@ -187,8 +183,7 @@ public class UpdateVolumeDetails {
     Long sizeInGBs;
 
     /**
-     * Specifies whether the auto-tune performance is enabled for this volume. This field is deprecated.
-     * Use the {@code DetachedVolumeAutotunePolicy} instead to enable the volume for detached autotune.
+     * Specifies whether the auto-tune performance is enabled for this boot volume.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkCreateDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkCreateDetails.java
@@ -113,8 +113,8 @@ public class VcnDrgAttachmentNetworkCreateDetails extends DrgAttachmentNetworkCr
     String routeTableId;
 
     /**
-     * Indicates whether the VCN CIDR(s) or the individual Subnet CIDR(s) are imported from the attachment.
-     * Routes from the VCN Ingress Route Table are always imported.
+     * Indicates whether the VCN CIDRs or the individual subnet CIDRs are imported from the attachment.
+     * Routes from the VCN ingress route table are always imported.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnRouteType")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkDetails.java
@@ -108,8 +108,8 @@ public class VcnDrgAttachmentNetworkDetails extends DrgAttachmentNetworkDetails 
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")
     String routeTableId;
     /**
-     * Indicates whether the VCN CIDR(s) or the individual Subnet CIDR(s) are imported from the attachment.
-     * Routes from the VCN Ingress Route Table are always imported.
+     * Indicates whether the VCN CIDRs or the individual subnet CIDRs are imported from the attachment.
+     * Routes from the VCN ingress route table are always imported.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -156,8 +156,8 @@ public class VcnDrgAttachmentNetworkDetails extends DrgAttachmentNetworkDetails 
         }
     };
     /**
-     * Indicates whether the VCN CIDR(s) or the individual Subnet CIDR(s) are imported from the attachment.
-     * Routes from the VCN Ingress Route Table are always imported.
+     * Indicates whether the VCN CIDRs or the individual subnet CIDRs are imported from the attachment.
+     * Routes from the VCN ingress route table are always imported.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnRouteType")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkUpdateDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkUpdateDetails.java
@@ -98,8 +98,8 @@ public class VcnDrgAttachmentNetworkUpdateDetails extends DrgAttachmentNetworkUp
     String routeTableId;
 
     /**
-     * Indicates whether the VCN CIDR(s) or the individual Subnet CIDR(s) are imported from the attachment.
-     * Routes from the VCN Ingress Route Table are always imported.
+     * Indicates whether the VCN CIDRs or the individual subnet CIDRs are imported from the attachment.
+     * Routes from the VCN ingress route table are always imported.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnRouteType")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Volume.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Volume.java
@@ -404,15 +404,11 @@ public class Volume {
      * <p>
      * Allowed values:
      * <p>
-     * {@code 0}: Represents Lower Cost option.
-     * <p>
      * {@code 10}: Represents Balanced option.
      * <p>
      * {@code 20}: Represents Higher Performance option.
-     *
-     *   * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      * <p>
-     * For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
+     * {@code 30}-{@code 120}: Represents the Ultra High Performance option.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")
@@ -448,15 +444,14 @@ public class Volume {
     String volumeGroupId;
 
     /**
-     * Specifies whether the auto-tune performance is enabled for this volume. This field is deprecated.
-     * Use the {@code DetachedVolumeAutotunePolicy} instead to enable the volume for detached autotune.
+     * Specifies whether the auto-tune performance is enabled for this boot volume.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
     Boolean isAutoTuneEnabled;
 
     /**
-     * The number of Volume Performance Units per GB that this volume is effectively tuned to.
+     * The number of Volume Performance Units per GB that this volume is effectively tuned to when it's idle.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("autoTunedVpusPerGB")

--- a/bmc-dashboardservice/pom.xml
+++ b/bmc-dashboardservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dashboardservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasetools/pom.xml
+++ b/bmc-databasetools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasetools</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataconnectivity/pom.xml
+++ b/bmc-dataconnectivity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataconnectivity</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeWaiters.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeWaiters.java
@@ -1650,7 +1650,9 @@ public class DataSafeWaiters {
                                         response.getSecurityAssessment().getLifecycleState());
                             }
                         },
-                        false),
+                        targetStatesSet.contains(
+                                com.oracle.bmc.datasafe.model.SecurityAssessmentLifecycleState
+                                        .Deleted)),
                 request);
     }
 
@@ -2193,7 +2195,7 @@ public class DataSafeWaiters {
     public com.oracle.bmc.waiter.Waiter<GetTargetDatabaseRequest, GetTargetDatabaseResponse>
             forTargetDatabase(
                     GetTargetDatabaseRequest request,
-                    com.oracle.bmc.datasafe.model.LifecycleState... targetStates) {
+                    com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState... targetStates) {
         org.apache.commons.lang3.Validate.notEmpty(
                 targetStates, "At least one targetState must be provided");
         org.apache.commons.lang3.Validate.noNullElements(
@@ -2215,7 +2217,7 @@ public class DataSafeWaiters {
     public com.oracle.bmc.waiter.Waiter<GetTargetDatabaseRequest, GetTargetDatabaseResponse>
             forTargetDatabase(
                     GetTargetDatabaseRequest request,
-                    com.oracle.bmc.datasafe.model.LifecycleState targetState,
+                    com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState targetState,
                     com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
                     com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
         org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
@@ -2240,7 +2242,7 @@ public class DataSafeWaiters {
                     GetTargetDatabaseRequest request,
                     com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
                     com.oracle.bmc.waiter.DelayStrategy delayStrategy,
-                    com.oracle.bmc.datasafe.model.LifecycleState... targetStates) {
+                    com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState... targetStates) {
         org.apache.commons.lang3.Validate.notEmpty(
                 targetStates, "At least one targetState must be provided");
         org.apache.commons.lang3.Validate.noNullElements(
@@ -2257,9 +2259,10 @@ public class DataSafeWaiters {
             forTargetDatabase(
                     com.oracle.bmc.waiter.BmcGenericWaiter waiter,
                     final GetTargetDatabaseRequest request,
-                    final com.oracle.bmc.datasafe.model.LifecycleState... targetStates) {
-        final java.util.Set<com.oracle.bmc.datasafe.model.LifecycleState> targetStatesSet =
-                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+                    final com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
 
         return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
                 executorService,
@@ -2281,7 +2284,8 @@ public class DataSafeWaiters {
                             }
                         },
                         targetStatesSet.contains(
-                                com.oracle.bmc.datasafe.model.LifecycleState.Deleted)),
+                                com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState
+                                        .Deleted)),
                 request);
     }
 
@@ -2383,7 +2387,9 @@ public class DataSafeWaiters {
                                         response.getUserAssessment().getLifecycleState());
                             }
                         },
-                        false),
+                        targetStatesSet.contains(
+                                com.oracle.bmc.datasafe.model.UserAssessmentLifecycleState
+                                        .Deleted)),
                 request);
     }
 

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/AuditArchiveRetrievalLifecycleState.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/AuditArchiveRetrievalLifecycleState.java
@@ -16,6 +16,7 @@ public enum AuditArchiveRetrievalLifecycleState {
     Failed("FAILED"),
     Deleting("DELETING"),
     Deleted("DELETED"),
+    Updating("UPDATING"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/SecurityAssessmentLifecycleState.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/SecurityAssessmentLifecycleState.java
@@ -14,6 +14,7 @@ public enum SecurityAssessmentLifecycleState {
     Succeeded("SUCCEEDED"),
     Updating("UPDATING"),
     Deleting("DELETING"),
+    Deleted("DELETED"),
     Failed("FAILED"),
 
     /**

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/TargetDatabase.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/TargetDatabase.java
@@ -106,9 +106,9 @@ public class TargetDatabase {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-        private LifecycleState lifecycleState;
+        private TargetDatabaseLifecycleState lifecycleState;
 
-        public Builder lifecycleState(LifecycleState lifecycleState) {
+        public Builder lifecycleState(TargetDatabaseLifecycleState lifecycleState) {
             this.lifecycleState = lifecycleState;
             this.__explicitlySet__.add("lifecycleState");
             return this;
@@ -273,7 +273,7 @@ public class TargetDatabase {
      * The current state of the target database in Data Safe.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-    LifecycleState lifecycleState;
+    TargetDatabaseLifecycleState lifecycleState;
 
     /**
      * Details about the current state of the target database in Data Safe.

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/TargetDatabaseLifecycleState.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/TargetDatabaseLifecycleState.java
@@ -17,6 +17,7 @@ package com.oracle.bmc.datasafe.model;
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.extern.slf4j.Slf4j
 public enum TargetDatabaseLifecycleState {
     Creating("CREATING"),
     Updating("UPDATING"),
@@ -26,7 +27,12 @@ public enum TargetDatabaseLifecycleState {
     Deleted("DELETED"),
     NeedsAttention("NEEDS_ATTENTION"),
     Failed("FAILED"),
-    ;
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
 
     private final String value;
     private static java.util.Map<String, TargetDatabaseLifecycleState> map;
@@ -34,7 +40,9 @@ public enum TargetDatabaseLifecycleState {
     static {
         map = new java.util.HashMap<>();
         for (TargetDatabaseLifecycleState v : TargetDatabaseLifecycleState.values()) {
-            map.put(v.getValue(), v);
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
         }
     }
 
@@ -52,6 +60,9 @@ public enum TargetDatabaseLifecycleState {
         if (map.containsKey(key)) {
             return map.get(key);
         }
-        throw new IllegalArgumentException("Invalid TargetDatabaseLifecycleState: " + key);
+        LOG.warn(
+                "Received unknown value '{}' for enum 'TargetDatabaseLifecycleState', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
     }
 }

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/TargetDatabaseSummary.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/TargetDatabaseSummary.java
@@ -90,9 +90,9 @@ public class TargetDatabaseSummary {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-        private LifecycleState lifecycleState;
+        private TargetDatabaseLifecycleState lifecycleState;
 
-        public Builder lifecycleState(LifecycleState lifecycleState) {
+        public Builder lifecycleState(TargetDatabaseLifecycleState lifecycleState) {
             this.lifecycleState = lifecycleState;
             this.__explicitlySet__.add("lifecycleState");
             return this;
@@ -231,7 +231,7 @@ public class TargetDatabaseSummary {
      * The current state of the target database in Data Safe.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-    LifecycleState lifecycleState;
+    TargetDatabaseLifecycleState lifecycleState;
 
     /**
      * Details about the current state of the target database in Data Safe.

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/UserAssessmentLifecycleState.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/UserAssessmentLifecycleState.java
@@ -14,6 +14,7 @@ public enum UserAssessmentLifecycleState {
     Succeeded("SUCCEEDED"),
     Updating("UPDATING"),
     Deleting("DELETING"),
+    Deleted("DELETED"),
     Failed("FAILED"),
 
     /**

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequestResource.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequestResource.java
@@ -110,6 +110,7 @@ public class WorkRequestResource {
         Updated("UPDATED"),
         Deleted("DELETED"),
         InProgress("IN_PROGRESS"),
+        Failed("FAILED"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListTargetDatabasesRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListTargetDatabasesRequest.java
@@ -43,7 +43,7 @@ public class ListTargetDatabasesRequest extends com.oracle.bmc.requests.BmcReque
     /**
      * A filter to return the target databases that matches the current state of the target database.
      */
-    private com.oracle.bmc.datasafe.model.LifecycleState lifecycleState;
+    private com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState lifecycleState;
 
     /**
      * A filter to return target databases that match the database type of the target database.

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListWorkRequestsRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListWorkRequestsRequest.java
@@ -31,19 +31,20 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
 
     /**
      * The field used for sorting. Only one sorting order (sortOrder) can be specified.
-     * The default order for STARTTIME and FINISHTIME is descending.
+     * The default order is descending.
      *
      */
     private SortBy sortBy;
 
     /**
      * The field used for sorting. Only one sorting order (sortOrder) can be specified.
-     * The default order for STARTTIME and FINISHTIME is descending.
+     * The default order is descending.
      *
      **/
     public enum SortBy {
         Starttime("STARTTIME"),
         Finishtime("FINISHTIME"),
+        Acceptedtime("ACCEPTEDTIME"),
         ;
 
         private final String value;

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/Identity.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/Identity.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.identity.requests.*;
 import com.oracle.bmc.identity.responses.*;
 
 /**
- * APIs for managing users, groups, compartments, and policies.
+ * APIs for managing users, groups, compartments, policies, and identity domains.
  * This service client uses CircuitBreakerUtils.DEFAULT_CIRCUIT_BREAKER for all the operations by default if no circuit breaker configuration is defined by the user.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
@@ -47,23 +47,13 @@ public interface Identity extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * If the domain's {@code lifecycleState} is INACTIVE,
-     * 1. Set the {@code lifecycleDetails} to ACTIVATING and asynchronously starts enabling
-     *    the domain and return 202 ACCEPTED.
-     *     1.1 Sets the domain status to ENABLED and set specified domain's
-     *         {@code lifecycleState} to ACTIVE and set the {@code lifecycleDetails} to null.
+     * (For tenancies that support identity domains) Activates a deactivated identity domain. You can only activate identity domains that your user account is not a part of.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status. Deactivate a domain can be done using HTTP POST
-     * /domains/{domainId}/actions/deactivate.
+     * After you send the request, the `lifecycleDetails` of the identity domain is set to ACTIVATING. When the operation completes, the
+     * `lifecycleDetails` is set to null and the `lifecycleState` of the identity domain is set to ACTIVE.
      * <p>
-     * - If the domain's {@code lifecycleState} is ACTIVE, returns 202 ACCEPTED with no action
-     *   taken on service side.
-     * - If domain is of {@code type} DEFAULT or DEFAULT_LIGHTWEIGHT or domain's {@code lifecycleState} is not INACTIVE,
-     *   returns 400 BAD REQUEST.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If the authenticated user is part of the domain to be activated, returns 400 BAD REQUEST
-     * - If error occurs while activating domain, returns 500 INTERNAL SERVER ERROR.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -123,7 +113,7 @@ public interface Identity extends AutoCloseable {
     /**
      * Deletes multiple resources in the compartment. All resources must be in the same compartment. You must have the appropriate
      * permissions to delete the resources in the request. This API can only be invoked from the tenancy's
-     * [home region](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingregions.htm#Home). This operation creates a
+     * [home region](https://docs.cloud.oracle.com/Content/Identity/regions/managingregions.htm#Home). This operation creates a
      * {@link WorkRequest}. Use the {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest}
      * API to monitor the status of the bulk action.
      *
@@ -198,7 +188,7 @@ public interface Identity extends AutoCloseable {
 
     /**
      * Moves multiple resources from one compartment to another. All resources must be in the same compartment.
-     * This API can only be invoked from the tenancy's [home region](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingregions.htm#Home).
+     * This API can only be invoked from the tenancy's [home region](https://docs.cloud.oracle.com/Content/Identity/regions/managingregions.htm#Home).
      * To move resources, you must have the appropriate permissions to move the resource in both the source and target
      * compartments. This operation creates a {@link WorkRequest}.
      * Use the {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} API to monitor the status of the bulk action.
@@ -246,18 +236,10 @@ public interface Identity extends AutoCloseable {
             CascadeDeleteTagNamespaceRequest request);
 
     /**
-     * Change the containing compartment for a domain.
+     * (For tenancies that support identity domains) Moves the identity domain to a different compartment in the tenancy.
      * <p>
-     * This is an asynchronous call where the Domain's compartment is changed and is updated with the new compartment information.
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
-     * <p>
-     * The compartment change is complete when accessed via domain URL and
-     * also returns new compartment OCID.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If Domain {@code type} is DEFAULT or DEFAULT_LIGHTWEIGHT, return 400 BAD Request
-     * - If Domain is not active or being updated, returns 400 BAD REQUEST.
-     * - If error occurs while changing compartment for domain, return 500 INTERNAL SERVER ERROR.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -270,21 +252,15 @@ public interface Identity extends AutoCloseable {
     ChangeDomainCompartmentResponse changeDomainCompartment(ChangeDomainCompartmentRequest request);
 
     /**
-     * If the domain's {@code lifecycleState} is ACTIVE, validates the requested {@code licenseType} update
-     * is allowed and
-     * 1. Set the {@code lifecycleDetails} to UPDATING
-     * 2. Asynchronously starts updating the domain and return 202 ACCEPTED.
-     *     2.1 Successfully updates specified domain's {@code licenseType}.
-     * 3. On completion set the {@code lifecycleDetails} to null.
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
+     * (For tenancies that support identity domains) Changes the license type of the given identity domain. The identity domain's
+     * `lifecycleState` must be set to ACTIVE and the requested `licenseType` must be allowed. To retrieve the allowed `licenseType` for
+     * the identity domain, use {@link #listAllowedDomainLicenseTypes(ListAllowedDomainLicenseTypesRequest) listAllowedDomainLicenseTypes}.
      * <p>
-     * - If license type update is successful, return 202 ACCEPTED
-     * - If requested {@code licenseType} validation fails, returns 400 Bad request.
-     * - If Domain is not active or being updated, returns 400 BAD REQUEST.
-     * - If Domain {@code type} is DEFAULT or DEFAULT_LIGHTWEIGHT, return 400 BAD Request
-     * - If the domain doesn't exists, returns 404 NOT FOUND
-     * - If any internal error occurs, returns 500 INTERNAL SERVER ERROR.
+     * After you send your request, the `lifecycleDetails` of this identity domain is set to UPDATING. When the update of the identity
+     * domain completes, then the `lifecycleDetails` is set to null.
+     * <p>
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -300,7 +276,7 @@ public interface Identity extends AutoCloseable {
      * Moves the specified tag namespace to the specified compartment within the same tenancy.
      * <p>
      * To move the tag namespace, you must have the manage tag-namespaces permission on both compartments.
-     * For more information about IAM policies, see [Details for IAM](https://docs.cloud.oracle.com/Content/Identity/Reference/iampolicyreference.htm).
+     * For more information about IAM policies, see [Details for IAM](https://docs.cloud.oracle.com/Content/Identity/policyreference/iampolicyreference.htm).
      * <p>
      * Moving a tag namespace moves all the tag key definitions contained in the tag namespace.
      *
@@ -317,7 +293,7 @@ public interface Identity extends AutoCloseable {
 
     /**
      * Creates a new auth token for the specified user. For information about what auth tokens are for, see
-     * [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingcredentials.htm).
+     * [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/access/managing-user-credentials.htm).
      * <p>
      * You must specify a *description* for the auth token (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with
@@ -349,7 +325,7 @@ public interface Identity extends AutoCloseable {
      * You must also specify a *name* for the compartment, which must be unique across all compartments in
      * your tenancy. You can use this name or the OCID when writing policies that apply
      * to the compartment. For more information about policies, see
-     * [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm).
+     * [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm).
      * <p>
      * You must also specify a *description* for the compartment (although it can be an empty string). It does
      * not have to be unique, and you can change it anytime with
@@ -371,7 +347,7 @@ public interface Identity extends AutoCloseable {
     /**
      * Creates a new secret key for the specified user. Secret keys are used for authentication with the Object Storage Service's Amazon S3
      * compatible API. The secret key consists of an Access Key/Secret Key pair. For information, see
-     * [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingcredentials.htm).
+     * [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/access/managing-user-credentials.htm).
      * <p>
      * You must specify a *description* for the secret key (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with
@@ -405,22 +381,14 @@ public interface Identity extends AutoCloseable {
     CreateDbCredentialResponse createDbCredential(CreateDbCredentialRequest request);
 
     /**
-     * Creates a new domain in the tenancy with domain home in {@code homeRegion}. This is an asynchronous call - where, at start,
-     * {@code lifecycleState} of this domain is set to CREATING and {@code lifecycleDetails} to UPDATING. On domain creation completion
-     * this Domain's {@code lifecycleState} will be set to ACTIVE and {@code lifecycleDetails} to null.
+     * (For tenancies that support identity domains) Creates a new identity domain in the tenancy with the identity domain home in `homeRegion`.
+     * After you send your request, the temporary `lifecycleState` of this identity domain is set to CREATING and `lifecycleDetails` to UPDATING.
+     * When creation of the identity domain completes, this identity domain's `lifecycleState` is set to ACTIVE and `lifecycleDetails` to null.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      * <p>
-     * After creating a `Domain`, make sure its `lifecycleState` changes from CREATING to ACTIVE
-     * before using it.
-     * If the domain's {@code displayName} already exists, returns 400 BAD REQUEST.
-     * If any one of admin related fields are provided and one of the following 3 fields
-     * - {@code adminEmail}, {@code adminLastName} and {@code adminUserName} - is not provided,
-     * returns 400 BAD REQUEST.
-     * - If {@code isNotificationBypassed} is NOT provided when admin information is provided,
-     * returns 400 BAD REQUEST.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * After creating an `identity domain`, first make sure its `lifecycleState` changes from CREATING to ACTIVE before you use it.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -444,7 +412,7 @@ public interface Identity extends AutoCloseable {
      * You must also specify a *name* for the dynamic group, which must be unique across all dynamic groups in your
      * tenancy, and cannot be changed. Note that this name has to be also unique across all groups in your tenancy.
      * You can use this name or the OCID when writing policies that apply to the dynamic group. For more information
-     * about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm).
+     * about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm).
      * <p>
      * You must also specify a *description* for the dynamic group (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with {@link #updateDynamicGroup(UpdateDynamicGroupRequest) updateDynamicGroup}.
@@ -473,7 +441,7 @@ public interface Identity extends AutoCloseable {
      * <p>
      * You must also specify a *name* for the group, which must be unique across all groups in your tenancy and
      * cannot be changed. You can use this name or the OCID when writing policies that apply to the group. For more
-     * information about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm).
+     * information about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm).
      * <p>
      * You must also specify a *description* for the group (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with {@link #updateGroup(UpdateGroupRequest) updateGroup}.
@@ -568,7 +536,7 @@ public interface Identity extends AutoCloseable {
      * You must also specify a *name* for the network source, which must be unique across all network sources in your
      * tenancy, and cannot be changed.
      * You can use this name or the OCID when writing policies that apply to the network source. For more information
-     * about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm).
+     * about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm).
      * <p>
      * You must also specify a *description* for the network source (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with {@link #updateNetworkSource(UpdateNetworkSourceRequest) updateNetworkSource}.
@@ -605,13 +573,17 @@ public interface Identity extends AutoCloseable {
 
     /**
      * Creates a new Console one-time password for the specified user. For more information about user
-     * credentials, see [User Credentials](https://docs.cloud.oracle.com/Content/Identity/Concepts/usercredentials.htm).
+     * credentials, see [User Credentials](https://docs.cloud.oracle.com/Content/Identity/usercred/usercredentials.htm).
      * <p>
      * Use this operation after creating a new user, or if a user forgets their password. The new one-time
      * password is returned to you in the response, and you must securely deliver it to the user. They'll
      * be prompted to change this password the next time they sign in to the Console. If they don't change
      * it within 7 days, the password will expire and you'll need to create a new one-time password for the
      * user.
+     * <p>
+     * (For tenancies that support identity domains) Resetting a user's password generates a reset password email
+     * with a link that the user must follow to reset their password. If the user does not reset their password before the
+     * link expires, you'll need to reset the user's password again.
      * <p>
      **Note:** The user's Console login is the unique name you specified when you created the user
      * (see {@link #createUser(CreateUserRequest) createUser}).
@@ -628,7 +600,7 @@ public interface Identity extends AutoCloseable {
 
     /**
      * Creates a new policy in the specified compartment (either the tenancy or another of your compartments).
-     * If you're new to policies, see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+     * If you're new to policies, see [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
      * <p>
      * You must specify a *name* for the policy, which must be unique across all policies in your tenancy
      * and cannot be changed.
@@ -637,8 +609,8 @@ public interface Identity extends AutoCloseable {
      * have to be unique, and you can change it anytime with {@link #updatePolicy(UpdatePolicyRequest) updatePolicy}.
      * <p>
      * You must specify one or more policy statements in the statements array. For information about writing
-     * policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm) and
-     * [Common Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/commonpolicies.htm).
+     * policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm) and
+     * [Common Policies](https://docs.cloud.oracle.com/Content/Identity/policiescommon/commonpolicies.htm).
      * <p>
      * After you send your request, the new object's `lifecycleState` will temporarily be CREATING. Before using the
      * object, first make sure its `lifecycleState` has changed to ACTIVE.
@@ -791,7 +763,7 @@ public interface Identity extends AutoCloseable {
 
     /**
      * Creates a new user in your tenancy. For conceptual information about users, your tenancy, and other
-     * IAM Service components, see [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * IAM Service components, see [Overview of IAM](https://docs.cloud.oracle.com/Content/Identity/getstarted/identity-domains.htm).
      * <p>
      * You must specify your tenancy's OCID as the compartment ID in the request object (remember that the
      * tenancy is simply the root compartment). Notice that IAM resources (users, groups, compartments, and
@@ -837,24 +809,15 @@ public interface Identity extends AutoCloseable {
     CreateUserResponse createUser(CreateUserRequest request);
 
     /**
-     * If the domain's {@code lifecycleState} is ACTIVE and no active Apps are present in domain,
-     * 1. Set the {@code lifecycleDetails} to DEACTIVATING and asynchronously starts disabling
-     *    the domain and return 202 ACCEPTED.
-     *     1.1 Sets the domain status to DISABLED and set specified domain's
-     *         {@code lifecycleState} to INACTIVE and set the {@code lifecycleDetails} to null.
+     * (For tenancies that support identity domains) Deactivates the specified identity domain. Identity domains must be in an ACTIVE
+     * `lifecycleState` and have no active apps present in the domain or underlying Identity Cloud Service stripe. You cannot deactivate
+     * the default identity domain.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status. Activate a domain can be done using HTTP POST
-     * /domains/{domainId}/actions/activate.
+     * After you send your request, the `lifecycleDetails` of this identity domain is set to DEACTIVATING. When the operation completes,
+     * then the `lifecycleDetails` is set to null and the `lifecycleState` is set to INACTIVE.
      * <p>
-     * - If the domain's {@code lifecycleState} is INACTIVE, returns 202 ACCEPTED with no action
-     *   taken on service side.
-     * - If domain is of {@code type} DEFAULT or DEFAULT_LIGHTWEIGHT or domain's {@code lifecycleState}
-     *   is not ACTIVE, returns 400 BAD REQUEST.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If any active Apps in domain, returns 400 BAD REQUEST.
-     * - If the authenticated user is part of the domain to be activated, returns 400 BAD REQUEST
-     * - If error occurs while deactivating domain, returns 500 INTERNAL SERVER ERROR.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -937,23 +900,13 @@ public interface Identity extends AutoCloseable {
     DeleteDbCredentialResponse deleteDbCredential(DeleteDbCredentialRequest request);
 
     /**
-     * Soft Deletes a domain.
-     * <p>
-     * This is an asynchronous API, where, if the domain's {@code lifecycleState} is INACTIVE and
-     * no active Apps are present in underlying stripe,
-     *   1. Sets the specified domain's {@code lifecycleState} to DELETING.
-     *   2. Domains marked as DELETING will be cleaned up by a periodic task unless customer request it to be undo via ticket.
-     *   3. Work request is created and returned as opc-work-request-id along with 202 ACCEPTED.
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
-     * <p>
-     * - If the domain's {@code lifecycleState} is DELETING, returns 202 Accepted as a deletion
-     *   is already in progress for this domain.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If domain is of {@code type} DEFAULT or DEFAULT_LIGHTWEIGHT, returns 400 BAD REQUEST.
-     * - If any active Apps in domain, returns 400 BAD REQUEST.
-     * - If the authenticated user is part of the domain to be deleted, returns 400 BAD REQUEST.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * (For tenancies that support identity domains) Deletes an identity domain. The identity domain must have no active apps present in
+     * the underlying IDCS stripe. You must also deactivate the identity domain, rendering the `lifecycleState` of the identity domain INACTIVE.
+     * Furthermore, as the authenticated user performing the operation, you cannot be a member of the identity domain you are deleting.
+     * Lastly, you cannot delete the default identity domain. A tenancy must always have at least the default identity domain.
+     *
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1036,7 +989,7 @@ public interface Identity extends AutoCloseable {
     DeleteMfaTotpDeviceResponse deleteMfaTotpDevice(DeleteMfaTotpDeviceRequest request);
 
     /**
-     * Deletes the specified network source
+     * Deletes the specified network source.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1180,19 +1133,16 @@ public interface Identity extends AutoCloseable {
     DeleteUserResponse deleteUser(DeleteUserRequest request);
 
     /**
-     * Replicate domain to a new region. This is an asynchronous call - where, at start,
-     * {@code state} of this domain in replica region is set to ENABLING_REPLICATION.
-     * On domain replication completion the {@code state} will be set to REPLICATION_ENABLED.
+     * (For tenancies that support identity domains) Replicates the identity domain to a new region (provided that the region is the
+     * tenancy home region or other region that the tenancy subscribes to). You can only replicate identity domains that are in an ACTIVE
+     * `lifecycleState` and not currently updating or already replicating. You also can only trigger the replication of secondary identity domains.
+     * The default identity domain is automatically replicated to all regions that the tenancy subscribes to.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
+     * After you send the request, the `state` of the identity domain in the replica region is set to ENABLING_REPLICATION. When the operation
+     * completes, the `state` is set to REPLICATION_ENABLED.
      * <p>
-     * If the replica region's {@code state} is already ENABLING_REPLICATION or REPLICATION_ENABLED,
-     * returns 409 CONFLICT.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If home region is same as replication region, return 400 BAD REQUEST.
-     * - If Domain is not active or being updated, returns 400 BAD REQUEST.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1253,10 +1203,7 @@ public interface Identity extends AutoCloseable {
     GetCompartmentResponse getCompartment(GetCompartmentRequest request);
 
     /**
-     * Get the specified domain's information.
-     * <p>
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If any internal error occurs, returns 500 INTERNAL SERVER ERROR.
+     * (For tenancies that support identity domains) Gets the specified identity domain's information.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1299,11 +1246,7 @@ public interface Identity extends AutoCloseable {
     GetGroupResponse getGroup(GetGroupRequest request);
 
     /**
-     * Gets details on a specified IAM work request. For asynchronous operations in Identity and Access Management service, opc-work-request-id header values contains
-     * iam work request id that can be provided in this API to track the current status of the operation.
-     * <p>
-     * - If workrequest exists, returns 202 ACCEPTED
-     * - If workrequest does not exist, returns 404 NOT FOUND
+     * Gets the details of a specified IAM work request. The workRequestID is returned in the opc-workrequest-id header for any asynchronous operation in the Identity and Access Management service.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1528,13 +1471,11 @@ public interface Identity extends AutoCloseable {
     ImportStandardTagsResponse importStandardTags(ImportStandardTagsRequest request);
 
     /**
-     * List the allowed domain license types supported by OCI
-     * If {@code currentLicenseTypeName} provided, returns allowed license types a domain with the specified license type name can migrate to.
-     * If {@code name} is provided, it filters and returns resources that match the given license type name.
-     * Otherwise, returns all valid license types that are currently supported.
+     * (For tenancies that support identity domains) Lists the license types for identity domains supported by Oracle Cloud Infrastructure.
+     * (License types are also referred to as domain types.)
      * <p>
-     * - If license type details are retrieved sucessfully, return 202 ACCEPTED.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * If `currentLicenseTypeName` is provided, then the request returns license types that the identity domain with the specified license
+     * type name can change to. Otherwise, the request returns all valid license types currently supported.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1660,7 +1601,7 @@ public interface Identity extends AutoCloseable {
 
     /**
      * Lists all the tags enabled for cost-tracking in the specified tenancy. For information about
-     * cost-tracking tags, see [Using Cost-tracking Tags](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#costs).
+     * cost-tracking tags, see [Using Cost-tracking Tags](https://docs.cloud.oracle.com/Content/Tagging/Tasks/usingcosttrackingtags.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1700,8 +1641,7 @@ public interface Identity extends AutoCloseable {
     ListDbCredentialsResponse listDbCredentials(ListDbCredentialsRequest request);
 
     /**
-     * List all domains that are homed or have a replica region in current region.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * (For tenancies that support identity domains) Lists all identity domains within a tenancy.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1759,11 +1699,7 @@ public interface Identity extends AutoCloseable {
     ListGroupsResponse listGroups(ListGroupsRequest request);
 
     /**
-     * Gets error details for a specified IAM work request. For asynchronous operations in Identity and Access Management service, opc-work-request-id header values contains
-     * iam work request id that can be provided in this API to track the current status of the operation.
-     * <p>
-     * - If workrequest exists, returns 202 ACCEPTED
-     * - If workrequest does not exist, returns 404 NOT FOUND
+     * Gets error details for a specified IAM work request. The workRequestID is returned in the opc-workrequest-id header for any asynchronous operation in the Identity and Access Management service.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1777,11 +1713,7 @@ public interface Identity extends AutoCloseable {
             ListIamWorkRequestErrorsRequest request);
 
     /**
-     * Gets logs for a specified IAM work request. For asynchronous operations in Identity and Access Management service, opc-work-request-id header values contains
-     * iam work request id that can be provided in this API to track the current status of the operation.
-     * <p>
-     * - If workrequest exists, returns 202 ACCEPTED
-     * - If workrequest does not exist, returns 404 NOT FOUND
+     * Gets logs for a specified IAM work request. The workRequestID is returned in the opc-workrequest-id header for any asynchronous operation in the Identity and Access Management service.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1794,10 +1726,7 @@ public interface Identity extends AutoCloseable {
     ListIamWorkRequestLogsResponse listIamWorkRequestLogs(ListIamWorkRequestLogsRequest request);
 
     /**
-     * List the IAM work requests in compartment
-     * <p>
-     * - If IAM workrequest  details are retrieved sucessfully, return 202 ACCEPTED.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * Lists the IAM work requests in compartment. The workRequestID is returned in the opc-workrequest-id header for any asynchronous operation in the Identity and Access Management service.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -2125,7 +2054,7 @@ public interface Identity extends AutoCloseable {
      **IMPORTANT**: After you move a compartment to a new parent compartment, the access policies of
      * the new parent take effect and the policies of the previous parent no longer apply. Ensure that you
      * are aware of the implications for the compartment contents before you move it. For more
-     * information, see [Moving a Compartment](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingcompartments.htm#MoveCompartment).
+     * information, see [Moving a Compartment](https://docs.cloud.oracle.com/Content/Identity/compartments/managingcompartments.htm#MoveCompartment).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -2189,7 +2118,7 @@ public interface Identity extends AutoCloseable {
     UpdateAuthTokenResponse updateAuthToken(UpdateAuthTokenRequest request);
 
     /**
-     * Updates authentication policy for the specified tenancy
+     * Updates authentication policy for the specified tenancy.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -2228,18 +2157,10 @@ public interface Identity extends AutoCloseable {
     UpdateCustomerSecretKeyResponse updateCustomerSecretKey(UpdateCustomerSecretKeyRequest request);
 
     /**
-     * Updates domain information and associated stripe. This is an asynchronous call where
-     * the associated stripe and domain are updated.
+     * (For tenancies that support identity domains) Updates identity domain information and the associated Identity Cloud Service (IDCS) stripe.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
-     * <p>
-     * - If the {@code displayName} is not unique within the tenancy, returns 400 BAD REQUEST.
-     * - If any field other than {@code description} is requested to be updated for DEFAULT domain,
-     * returns 400 BAD REQUEST.
-     * - If Domain is not active or being updated, returns 400 BAD REQUEST.
-     * - If Domain {@code type} is DEFAULT or DEFAULT_LIGHTWEIGHT, return 400 BAD Request
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -2307,6 +2228,7 @@ public interface Identity extends AutoCloseable {
 
     /**
      * Updates the specified network source.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -2421,7 +2343,7 @@ public interface Identity extends AutoCloseable {
      * namespace (changing `isRetired` from 'true' to 'false') does not reactivate tag definitions.
      * To reactivate the tag definitions, you must reactivate each one individually *after* you reactivate the namespace,
      * using {@link #updateTag(UpdateTagRequest) updateTag}. For more information about retiring tag namespaces, see
-     * [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
+     * [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm#retiringkeys).
      * <p>
      * You can't add a namespace with the same name as a retired namespace in the same tenancy.
      *

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsync.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsync.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.identity.requests.*;
 import com.oracle.bmc.identity.responses.*;
 
 /**
- * APIs for managing users, groups, compartments, and policies.
+ * APIs for managing users, groups, compartments, policies, and identity domains.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
 public interface IdentityAsync extends AutoCloseable {
@@ -46,23 +46,13 @@ public interface IdentityAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * If the domain's {@code lifecycleState} is INACTIVE,
-     * 1. Set the {@code lifecycleDetails} to ACTIVATING and asynchronously starts enabling
-     *    the domain and return 202 ACCEPTED.
-     *     1.1 Sets the domain status to ENABLED and set specified domain's
-     *         {@code lifecycleState} to ACTIVE and set the {@code lifecycleDetails} to null.
+     * (For tenancies that support identity domains) Activates a deactivated identity domain. You can only activate identity domains that your user account is not a part of.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status. Deactivate a domain can be done using HTTP POST
-     * /domains/{domainId}/actions/deactivate.
+     * After you send the request, the `lifecycleDetails` of the identity domain is set to ACTIVATING. When the operation completes, the
+     * `lifecycleDetails` is set to null and the `lifecycleState` of the identity domain is set to ACTIVE.
      * <p>
-     * - If the domain's {@code lifecycleState} is ACTIVE, returns 202 ACCEPTED with no action
-     *   taken on service side.
-     * - If domain is of {@code type} DEFAULT or DEFAULT_LIGHTWEIGHT or domain's {@code lifecycleState} is not INACTIVE,
-     *   returns 400 BAD REQUEST.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If the authenticated user is part of the domain to be activated, returns 400 BAD REQUEST
-     * - If error occurs while activating domain, returns 500 INTERNAL SERVER ERROR.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      *
      * @param request The request object containing the details to send
@@ -136,7 +126,7 @@ public interface IdentityAsync extends AutoCloseable {
     /**
      * Deletes multiple resources in the compartment. All resources must be in the same compartment. You must have the appropriate
      * permissions to delete the resources in the request. This API can only be invoked from the tenancy's
-     * [home region](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingregions.htm#Home). This operation creates a
+     * [home region](https://docs.cloud.oracle.com/Content/Identity/regions/managingregions.htm#Home). This operation creates a
      * {@link WorkRequest}. Use the {@link #getWorkRequest(GetWorkRequestRequest, Consumer, Consumer) getWorkRequest}
      * API to monitor the status of the bulk action.
      *
@@ -221,7 +211,7 @@ public interface IdentityAsync extends AutoCloseable {
 
     /**
      * Moves multiple resources from one compartment to another. All resources must be in the same compartment.
-     * This API can only be invoked from the tenancy's [home region](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingregions.htm#Home).
+     * This API can only be invoked from the tenancy's [home region](https://docs.cloud.oracle.com/Content/Identity/regions/managingregions.htm#Home).
      * To move resources, you must have the appropriate permissions to move the resource in both the source and target
      * compartments. This operation creates a {@link WorkRequest}.
      * Use the {@link #getWorkRequest(GetWorkRequestRequest, Consumer, Consumer) getWorkRequest} API to monitor the status of the bulk action.
@@ -276,18 +266,10 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Change the containing compartment for a domain.
+     * (For tenancies that support identity domains) Moves the identity domain to a different compartment in the tenancy.
      * <p>
-     * This is an asynchronous call where the Domain's compartment is changed and is updated with the new compartment information.
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
-     * <p>
-     * The compartment change is complete when accessed via domain URL and
-     * also returns new compartment OCID.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If Domain {@code type} is DEFAULT or DEFAULT_LIGHTWEIGHT, return 400 BAD Request
-     * - If Domain is not active or being updated, returns 400 BAD REQUEST.
-     * - If error occurs while changing compartment for domain, return 500 INTERNAL SERVER ERROR.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      *
      * @param request The request object containing the details to send
@@ -304,21 +286,15 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * If the domain's {@code lifecycleState} is ACTIVE, validates the requested {@code licenseType} update
-     * is allowed and
-     * 1. Set the {@code lifecycleDetails} to UPDATING
-     * 2. Asynchronously starts updating the domain and return 202 ACCEPTED.
-     *     2.1 Successfully updates specified domain's {@code licenseType}.
-     * 3. On completion set the {@code lifecycleDetails} to null.
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
+     * (For tenancies that support identity domains) Changes the license type of the given identity domain. The identity domain's
+     * `lifecycleState` must be set to ACTIVE and the requested `licenseType` must be allowed. To retrieve the allowed `licenseType` for
+     * the identity domain, use {@link #listAllowedDomainLicenseTypes(ListAllowedDomainLicenseTypesRequest, Consumer, Consumer) listAllowedDomainLicenseTypes}.
      * <p>
-     * - If license type update is successful, return 202 ACCEPTED
-     * - If requested {@code licenseType} validation fails, returns 400 Bad request.
-     * - If Domain is not active or being updated, returns 400 BAD REQUEST.
-     * - If Domain {@code type} is DEFAULT or DEFAULT_LIGHTWEIGHT, return 400 BAD Request
-     * - If the domain doesn't exists, returns 404 NOT FOUND
-     * - If any internal error occurs, returns 500 INTERNAL SERVER ERROR.
+     * After you send your request, the `lifecycleDetails` of this identity domain is set to UPDATING. When the update of the identity
+     * domain completes, then the `lifecycleDetails` is set to null.
+     * <p>
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      *
      * @param request The request object containing the details to send
@@ -338,7 +314,7 @@ public interface IdentityAsync extends AutoCloseable {
      * Moves the specified tag namespace to the specified compartment within the same tenancy.
      * <p>
      * To move the tag namespace, you must have the manage tag-namespaces permission on both compartments.
-     * For more information about IAM policies, see [Details for IAM](https://docs.cloud.oracle.com/Content/Identity/Reference/iampolicyreference.htm).
+     * For more information about IAM policies, see [Details for IAM](https://docs.cloud.oracle.com/Content/Identity/policyreference/iampolicyreference.htm).
      * <p>
      * Moving a tag namespace moves all the tag key definitions contained in the tag namespace.
      *
@@ -360,7 +336,7 @@ public interface IdentityAsync extends AutoCloseable {
 
     /**
      * Creates a new auth token for the specified user. For information about what auth tokens are for, see
-     * [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingcredentials.htm).
+     * [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/access/managing-user-credentials.htm).
      * <p>
      * You must specify a *description* for the auth token (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with
@@ -395,7 +371,7 @@ public interface IdentityAsync extends AutoCloseable {
      * You must also specify a *name* for the compartment, which must be unique across all compartments in
      * your tenancy. You can use this name or the OCID when writing policies that apply
      * to the compartment. For more information about policies, see
-     * [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm).
+     * [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm).
      * <p>
      * You must also specify a *description* for the compartment (although it can be an empty string). It does
      * not have to be unique, and you can change it anytime with
@@ -421,7 +397,7 @@ public interface IdentityAsync extends AutoCloseable {
     /**
      * Creates a new secret key for the specified user. Secret keys are used for authentication with the Object Storage Service's Amazon S3
      * compatible API. The secret key consists of an Access Key/Secret Key pair. For information, see
-     * [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingcredentials.htm).
+     * [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/access/managing-user-credentials.htm).
      * <p>
      * You must specify a *description* for the secret key (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with
@@ -463,22 +439,14 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Creates a new domain in the tenancy with domain home in {@code homeRegion}. This is an asynchronous call - where, at start,
-     * {@code lifecycleState} of this domain is set to CREATING and {@code lifecycleDetails} to UPDATING. On domain creation completion
-     * this Domain's {@code lifecycleState} will be set to ACTIVE and {@code lifecycleDetails} to null.
+     * (For tenancies that support identity domains) Creates a new identity domain in the tenancy with the identity domain home in `homeRegion`.
+     * After you send your request, the temporary `lifecycleState` of this identity domain is set to CREATING and `lifecycleDetails` to UPDATING.
+     * When creation of the identity domain completes, this identity domain's `lifecycleState` is set to ACTIVE and `lifecycleDetails` to null.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      * <p>
-     * After creating a `Domain`, make sure its `lifecycleState` changes from CREATING to ACTIVE
-     * before using it.
-     * If the domain's {@code displayName} already exists, returns 400 BAD REQUEST.
-     * If any one of admin related fields are provided and one of the following 3 fields
-     * - {@code adminEmail}, {@code adminLastName} and {@code adminUserName} - is not provided,
-     * returns 400 BAD REQUEST.
-     * - If {@code isNotificationBypassed} is NOT provided when admin information is provided,
-     * returns 400 BAD REQUEST.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * After creating an `identity domain`, first make sure its `lifecycleState` changes from CREATING to ACTIVE before you use it.
      *
      *
      * @param request The request object containing the details to send
@@ -505,7 +473,7 @@ public interface IdentityAsync extends AutoCloseable {
      * You must also specify a *name* for the dynamic group, which must be unique across all dynamic groups in your
      * tenancy, and cannot be changed. Note that this name has to be also unique across all groups in your tenancy.
      * You can use this name or the OCID when writing policies that apply to the dynamic group. For more information
-     * about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm).
+     * about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm).
      * <p>
      * You must also specify a *description* for the dynamic group (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with {@link #updateDynamicGroup(UpdateDynamicGroupRequest, Consumer, Consumer) updateDynamicGroup}.
@@ -538,7 +506,7 @@ public interface IdentityAsync extends AutoCloseable {
      * <p>
      * You must also specify a *name* for the group, which must be unique across all groups in your tenancy and
      * cannot be changed. You can use this name or the OCID when writing policies that apply to the group. For more
-     * information about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm).
+     * information about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm).
      * <p>
      * You must also specify a *description* for the group (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with {@link #updateGroup(UpdateGroupRequest, Consumer, Consumer) updateGroup}.
@@ -647,7 +615,7 @@ public interface IdentityAsync extends AutoCloseable {
      * You must also specify a *name* for the network source, which must be unique across all network sources in your
      * tenancy, and cannot be changed.
      * You can use this name or the OCID when writing policies that apply to the network source. For more information
-     * about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm).
+     * about policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm).
      * <p>
      * You must also specify a *description* for the network source (although it can be an empty string). It does not
      * have to be unique, and you can change it anytime with {@link #updateNetworkSource(UpdateNetworkSourceRequest, Consumer, Consumer) updateNetworkSource}.
@@ -691,13 +659,17 @@ public interface IdentityAsync extends AutoCloseable {
 
     /**
      * Creates a new Console one-time password for the specified user. For more information about user
-     * credentials, see [User Credentials](https://docs.cloud.oracle.com/Content/Identity/Concepts/usercredentials.htm).
+     * credentials, see [User Credentials](https://docs.cloud.oracle.com/Content/Identity/usercred/usercredentials.htm).
      * <p>
      * Use this operation after creating a new user, or if a user forgets their password. The new one-time
      * password is returned to you in the response, and you must securely deliver it to the user. They'll
      * be prompted to change this password the next time they sign in to the Console. If they don't change
      * it within 7 days, the password will expire and you'll need to create a new one-time password for the
      * user.
+     * <p>
+     * (For tenancies that support identity domains) Resetting a user's password generates a reset password email
+     * with a link that the user must follow to reset their password. If the user does not reset their password before the
+     * link expires, you'll need to reset the user's password again.
      * <p>
      **Note:** The user's Console login is the unique name you specified when you created the user
      * (see {@link #createUser(CreateUserRequest, Consumer, Consumer) createUser}).
@@ -718,7 +690,7 @@ public interface IdentityAsync extends AutoCloseable {
 
     /**
      * Creates a new policy in the specified compartment (either the tenancy or another of your compartments).
-     * If you're new to policies, see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+     * If you're new to policies, see [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
      * <p>
      * You must specify a *name* for the policy, which must be unique across all policies in your tenancy
      * and cannot be changed.
@@ -727,8 +699,8 @@ public interface IdentityAsync extends AutoCloseable {
      * have to be unique, and you can change it anytime with {@link #updatePolicy(UpdatePolicyRequest, Consumer, Consumer) updatePolicy}.
      * <p>
      * You must specify one or more policy statements in the statements array. For information about writing
-     * policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm) and
-     * [Common Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/commonpolicies.htm).
+     * policies, see [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm) and
+     * [Common Policies](https://docs.cloud.oracle.com/Content/Identity/policiescommon/commonpolicies.htm).
      * <p>
      * After you send your request, the new object's `lifecycleState` will temporarily be CREATING. Before using the
      * object, first make sure its `lifecycleState` has changed to ACTIVE.
@@ -904,7 +876,7 @@ public interface IdentityAsync extends AutoCloseable {
 
     /**
      * Creates a new user in your tenancy. For conceptual information about users, your tenancy, and other
-     * IAM Service components, see [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * IAM Service components, see [Overview of IAM](https://docs.cloud.oracle.com/Content/Identity/getstarted/identity-domains.htm).
      * <p>
      * You must specify your tenancy's OCID as the compartment ID in the request object (remember that the
      * tenancy is simply the root compartment). Notice that IAM resources (users, groups, compartments, and
@@ -952,24 +924,15 @@ public interface IdentityAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<CreateUserRequest, CreateUserResponse> handler);
 
     /**
-     * If the domain's {@code lifecycleState} is ACTIVE and no active Apps are present in domain,
-     * 1. Set the {@code lifecycleDetails} to DEACTIVATING and asynchronously starts disabling
-     *    the domain and return 202 ACCEPTED.
-     *     1.1 Sets the domain status to DISABLED and set specified domain's
-     *         {@code lifecycleState} to INACTIVE and set the {@code lifecycleDetails} to null.
+     * (For tenancies that support identity domains) Deactivates the specified identity domain. Identity domains must be in an ACTIVE
+     * `lifecycleState` and have no active apps present in the domain or underlying Identity Cloud Service stripe. You cannot deactivate
+     * the default identity domain.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status. Activate a domain can be done using HTTP POST
-     * /domains/{domainId}/actions/activate.
+     * After you send your request, the `lifecycleDetails` of this identity domain is set to DEACTIVATING. When the operation completes,
+     * then the `lifecycleDetails` is set to null and the `lifecycleState` is set to INACTIVE.
      * <p>
-     * - If the domain's {@code lifecycleState} is INACTIVE, returns 202 ACCEPTED with no action
-     *   taken on service side.
-     * - If domain is of {@code type} DEFAULT or DEFAULT_LIGHTWEIGHT or domain's {@code lifecycleState}
-     *   is not ACTIVE, returns 400 BAD REQUEST.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If any active Apps in domain, returns 400 BAD REQUEST.
-     * - If the authenticated user is part of the domain to be activated, returns 400 BAD REQUEST
-     * - If error occurs while deactivating domain, returns 500 INTERNAL SERVER ERROR.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      *
      * @param request The request object containing the details to send
@@ -1073,23 +1036,13 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Soft Deletes a domain.
-     * <p>
-     * This is an asynchronous API, where, if the domain's {@code lifecycleState} is INACTIVE and
-     * no active Apps are present in underlying stripe,
-     *   1. Sets the specified domain's {@code lifecycleState} to DELETING.
-     *   2. Domains marked as DELETING will be cleaned up by a periodic task unless customer request it to be undo via ticket.
-     *   3. Work request is created and returned as opc-work-request-id along with 202 ACCEPTED.
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
-     * <p>
-     * - If the domain's {@code lifecycleState} is DELETING, returns 202 Accepted as a deletion
-     *   is already in progress for this domain.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If domain is of {@code type} DEFAULT or DEFAULT_LIGHTWEIGHT, returns 400 BAD REQUEST.
-     * - If any active Apps in domain, returns 400 BAD REQUEST.
-     * - If the authenticated user is part of the domain to be deleted, returns 400 BAD REQUEST.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * (For tenancies that support identity domains) Deletes an identity domain. The identity domain must have no active apps present in
+     * the underlying IDCS stripe. You must also deactivate the identity domain, rendering the `lifecycleState` of the identity domain INACTIVE.
+     * Furthermore, as the authenticated user performing the operation, you cannot be a member of the identity domain you are deleting.
+     * Lastly, you cannot delete the default identity domain. A tenancy must always have at least the default identity domain.
+     *
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      *
      * @param request The request object containing the details to send
@@ -1193,7 +1146,7 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes the specified network source
+     * Deletes the specified network source.
      *
      *
      * @param request The request object containing the details to send
@@ -1366,19 +1319,16 @@ public interface IdentityAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<DeleteUserRequest, DeleteUserResponse> handler);
 
     /**
-     * Replicate domain to a new region. This is an asynchronous call - where, at start,
-     * {@code state} of this domain in replica region is set to ENABLING_REPLICATION.
-     * On domain replication completion the {@code state} will be set to REPLICATION_ENABLED.
+     * (For tenancies that support identity domains) Replicates the identity domain to a new region (provided that the region is the
+     * tenancy home region or other region that the tenancy subscribes to). You can only replicate identity domains that are in an ACTIVE
+     * `lifecycleState` and not currently updating or already replicating. You also can only trigger the replication of secondary identity domains.
+     * The default identity domain is automatically replicated to all regions that the tenancy subscribes to.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
+     * After you send the request, the `state` of the identity domain in the replica region is set to ENABLING_REPLICATION. When the operation
+     * completes, the `state` is set to REPLICATION_ENABLED.
      * <p>
-     * If the replica region's {@code state} is already ENABLING_REPLICATION or REPLICATION_ENABLED,
-     * returns 409 CONFLICT.
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If home region is same as replication region, return 400 BAD REQUEST.
-     * - If Domain is not active or being updated, returns 400 BAD REQUEST.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      *
      * @param request The request object containing the details to send
@@ -1452,10 +1402,7 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Get the specified domain's information.
-     * <p>
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
-     * - If any internal error occurs, returns 500 INTERNAL SERVER ERROR.
+     * (For tenancies that support identity domains) Gets the specified identity domain's information.
      *
      *
      * @param request The request object containing the details to send
@@ -1505,11 +1452,7 @@ public interface IdentityAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetGroupRequest, GetGroupResponse> handler);
 
     /**
-     * Gets details on a specified IAM work request. For asynchronous operations in Identity and Access Management service, opc-work-request-id header values contains
-     * iam work request id that can be provided in this API to track the current status of the operation.
-     * <p>
-     * - If workrequest exists, returns 202 ACCEPTED
-     * - If workrequest does not exist, returns 404 NOT FOUND
+     * Gets the details of a specified IAM work request. The workRequestID is returned in the opc-workrequest-id header for any asynchronous operation in the Identity and Access Management service.
      *
      *
      * @param request The request object containing the details to send
@@ -1789,13 +1732,11 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * List the allowed domain license types supported by OCI
-     * If {@code currentLicenseTypeName} provided, returns allowed license types a domain with the specified license type name can migrate to.
-     * If {@code name} is provided, it filters and returns resources that match the given license type name.
-     * Otherwise, returns all valid license types that are currently supported.
+     * (For tenancies that support identity domains) Lists the license types for identity domains supported by Oracle Cloud Infrastructure.
+     * (License types are also referred to as domain types.)
      * <p>
-     * - If license type details are retrieved sucessfully, return 202 ACCEPTED.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * If `currentLicenseTypeName` is provided, then the request returns license types that the identity domain with the specified license
+     * type name can change to. Otherwise, the request returns all valid license types currently supported.
      *
      *
      * @param request The request object containing the details to send
@@ -1946,7 +1887,7 @@ public interface IdentityAsync extends AutoCloseable {
 
     /**
      * Lists all the tags enabled for cost-tracking in the specified tenancy. For information about
-     * cost-tracking tags, see [Using Cost-tracking Tags](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#costs).
+     * cost-tracking tags, see [Using Cost-tracking Tags](https://docs.cloud.oracle.com/Content/Tagging/Tasks/usingcosttrackingtags.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -1998,8 +1939,7 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * List all domains that are homed or have a replica region in current region.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * (For tenancies that support identity domains) Lists all identity domains within a tenancy.
      *
      *
      * @param request The request object containing the details to send
@@ -2068,11 +2008,7 @@ public interface IdentityAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListGroupsRequest, ListGroupsResponse> handler);
 
     /**
-     * Gets error details for a specified IAM work request. For asynchronous operations in Identity and Access Management service, opc-work-request-id header values contains
-     * iam work request id that can be provided in this API to track the current status of the operation.
-     * <p>
-     * - If workrequest exists, returns 202 ACCEPTED
-     * - If workrequest does not exist, returns 404 NOT FOUND
+     * Gets error details for a specified IAM work request. The workRequestID is returned in the opc-workrequest-id header for any asynchronous operation in the Identity and Access Management service.
      *
      *
      * @param request The request object containing the details to send
@@ -2089,11 +2025,7 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets logs for a specified IAM work request. For asynchronous operations in Identity and Access Management service, opc-work-request-id header values contains
-     * iam work request id that can be provided in this API to track the current status of the operation.
-     * <p>
-     * - If workrequest exists, returns 202 ACCEPTED
-     * - If workrequest does not exist, returns 404 NOT FOUND
+     * Gets logs for a specified IAM work request. The workRequestID is returned in the opc-workrequest-id header for any asynchronous operation in the Identity and Access Management service.
      *
      *
      * @param request The request object containing the details to send
@@ -2110,10 +2042,7 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * List the IAM work requests in compartment
-     * <p>
-     * - If IAM workrequest  details are retrieved sucessfully, return 202 ACCEPTED.
-     * - If any internal error occurs, return 500 INTERNAL SERVER ERROR.
+     * Lists the IAM work requests in compartment. The workRequestID is returned in the opc-workrequest-id header for any asynchronous operation in the Identity and Access Management service.
      *
      *
      * @param request The request object containing the details to send
@@ -2515,7 +2444,7 @@ public interface IdentityAsync extends AutoCloseable {
      **IMPORTANT**: After you move a compartment to a new parent compartment, the access policies of
      * the new parent take effect and the policies of the previous parent no longer apply. Ensure that you
      * are aware of the implications for the compartment contents before you move it. For more
-     * information, see [Moving a Compartment](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingcompartments.htm#MoveCompartment).
+     * information, see [Moving a Compartment](https://docs.cloud.oracle.com/Content/Identity/compartments/managingcompartments.htm#MoveCompartment).
      *
      *
      * @param request The request object containing the details to send
@@ -2597,7 +2526,7 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Updates authentication policy for the specified tenancy
+     * Updates authentication policy for the specified tenancy.
      *
      *
      * @param request The request object containing the details to send
@@ -2647,18 +2576,10 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Updates domain information and associated stripe. This is an asynchronous call where
-     * the associated stripe and domain are updated.
+     * (For tenancies that support identity domains) Updates identity domain information and the associated Identity Cloud Service (IDCS) stripe.
      * <p>
-     * To track progress, HTTP GET on /iamWorkRequests/{iamWorkRequestsId} endpoint will provide
-     * the async operation's status.
-     * <p>
-     * - If the {@code displayName} is not unique within the tenancy, returns 400 BAD REQUEST.
-     * - If any field other than {@code description} is requested to be updated for DEFAULT domain,
-     * returns 400 BAD REQUEST.
-     * - If Domain is not active or being updated, returns 400 BAD REQUEST.
-     * - If Domain {@code type} is DEFAULT or DEFAULT_LIGHTWEIGHT, return 400 BAD Request
-     * - If the domain doesn't exists, returns 404 NOT FOUND.
+     * To track the progress of the request, submitting an HTTP GET on the /iamWorkRequests/{iamWorkRequestsId} endpoint retrieves
+     * the operation's status.
      *
      *
      * @param request The request object containing the details to send
@@ -2743,6 +2664,7 @@ public interface IdentityAsync extends AutoCloseable {
 
     /**
      * Updates the specified network source.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -2880,7 +2802,7 @@ public interface IdentityAsync extends AutoCloseable {
      * namespace (changing `isRetired` from 'true' to 'false') does not reactivate tag definitions.
      * To reactivate the tag definitions, you must reactivate each one individually *after* you reactivate the namespace,
      * using {@link #updateTag(UpdateTagRequest, Consumer, Consumer) updateTag}. For more information about retiring tag namespaces, see
-     * [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
+     * [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm#retiringkeys).
      * <p>
      * You can't add a namespace with the same name as a retired namespace in the same tenancy.
      *

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AllowedDomainLicenseTypeSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AllowedDomainLicenseTypeSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * The 'AllowedDomainLicenseTypeSummary' object contains information about the 'Domain License type'.
+ * (For tenancies that support identity domains) The 'AllowedDomainLicenseTypeSummary' object contains information about the license type of the identity domain.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AuthToken.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AuthToken.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  **Note:** The token is always an Oracle-generated string; you can't change it to a string of your choice.
  * <p>
- * For more information, see [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingcredentials.htm).
+ * For more information, see [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/access/managing-user-credentials.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -170,6 +170,9 @@ public class AuthToken {
 
     /**
      * The description you assign to the auth token. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AuthenticationPolicy.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AuthenticationPolicy.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Authentication policy, currently set for the given compartment
+ * Authentication policy, currently set for the given compartment.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BaseTagDefinitionValidator.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BaseTagDefinitionValidator.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.identity.model;
 /**
  * Validates a definedTag value. Each validator performs validation steps in addition to the standard
  * validation for definedTag values. For more information, see
- * [Limits on Tags](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Limits).
+ * [Limits on Tags](https://docs.cloud.oracle.com/Content/Tagging/Concepts/taggingoverview.htm#limits).
  * <p>
  * If you define a validator after a value has been set for a defined tag, then any updates that
  * attempt to change the value must pass the additional validation defined by the current rule.

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ChangeDomainCompartmentDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ChangeDomainCompartmentDetails.java
@@ -63,7 +63,7 @@ public class ChangeDomainCompartmentDetails {
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the destination compartment
-     * into which to move the domain.
+     * into which to move the identity domain.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ChangeDomainLicenseTypeDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ChangeDomainLicenseTypeDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Update domain license type
+ * (For tenancies that support identity domains) Details for updating the license type of the identity domain.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -62,7 +62,7 @@ public class ChangeDomainLicenseTypeDetails {
     }
 
     /**
-     * The License type of Domain
+     * The license type of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("licenseType")
     String licenseType;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ChangeTasDomainLicenseTypeDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ChangeTasDomainLicenseTypeDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Update domain license type
+ * (For tenancies that support identity domains) Update the identity domain license type.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -62,7 +62,7 @@ public class ChangeTasDomainLicenseTypeDetails {
     }
 
     /**
-     * The License type of Domain
+     * The license type of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("licenseType")
     String licenseType;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Compartment.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Compartment.java
@@ -10,7 +10,7 @@ package com.oracle.bmc.identity.model;
  * of measuring usage and billing, access (through the use of IAM Service policies), and isolation (separating the
  * resources for one project or business unit from another). A common approach is to create a compartment for each
  * major part of your organization. For more information, see
- * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm) and also
+ * [Overview of IAM](https://docs.cloud.oracle.com//Content/Identity/getstarted/identity-domains.htm) and also
  * [Setting Up Your Tenancy](https://docs.cloud.oracle.com/Content/GSG/Concepts/settinguptenancy.htm).
  * <p>
  * To place a resource in a compartment, simply specify the compartment ID in the "Create" request object when
@@ -20,7 +20,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access,
- * see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * see [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
  * <p>
  **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
  * using the API.

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateAuthTokenDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateAuthTokenDetails.java
@@ -62,6 +62,8 @@ public class CreateAuthTokenDetails {
 
     /**
      * The description you assign to the auth token during creation. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateDbCredentialDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateDbCredentialDetails.java
@@ -79,6 +79,8 @@ public class CreateDbCredentialDetails {
 
     /**
      * The description you assign to the DB credentials during creation.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateDomainDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateDomainDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Create a domain details
+ * (For tenancies that support identity domains) Details for creating an identity domain.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -208,19 +208,19 @@ public class CreateDomainDetails {
     }
 
     /**
-     * The OCID of the Compartment where domain is created
+     * The OCID of the compartment where the identity domain is created.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The mutable display name of the domain.
+     * The mutable display name of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Domain entity description
+     * The identity domain description. You can have an empty description.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
@@ -236,54 +236,52 @@ public class CreateDomainDetails {
     String homeRegion;
 
     /**
-     * The License type of Domain
+     * The license type of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("licenseType")
     String licenseType;
 
     /**
-     * Indicates whether domain is hidden on login screen or not.
+     * Indicates whether the identity domain is hidden on the sign-in screen or not.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isHiddenOnLogin")
     Boolean isHiddenOnLogin;
 
     /**
-     * The admin first name
+     * The administrator's first name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("adminFirstName")
     String adminFirstName;
 
     /**
-     * The admin last name
+     * The administrator's last name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("adminLastName")
     String adminLastName;
 
     /**
-     * The admin user name
+     * The administrator's user name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("adminUserName")
     String adminUserName;
 
     /**
-     * The admin email address
+     * The administrator's email address.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("adminEmail")
     String adminEmail;
 
     /**
-     * Indicates if admin user created in IDCS stripe would like to receive notification like welcome email
-     * or not.
-     * Required field only if admin information is provided, otherwise optional.
+     * Indicates whether or not the administrator user created in the IDCS stripe would like to receive notifications like a welcome email.
+     * This field is required only if admin information is provided. This field is otherwise optional.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isNotificationBypassed")
     Boolean isNotificationBypassed;
 
     /**
-     * Optional field to indicate whether users in the domain are required to have a primary email address or not
-     * Defaults to true
+     * Optional field to indicate whether users in the identity domain are required to have a primary email address or not. The default is true.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPrimaryEmailRequired")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateDynamicGroupDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateDynamicGroupDetails.java
@@ -135,7 +135,7 @@ public class CreateDynamicGroupDetails {
 
     /**
      * The matching rule to dynamically match an instance certificate to this dynamic group.
-     * For rule syntax, see [Managing Dynamic Groups](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+     * For rule syntax, see [Managing Dynamic Groups](https://docs.cloud.oracle.com/Content/Identity/dynamicgroups/managingdynamicgroups.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("matchingRule")
@@ -143,6 +143,9 @@ public class CreateDynamicGroupDetails {
 
     /**
      * The description you assign to the group during creation. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateGroupDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateGroupDetails.java
@@ -120,6 +120,9 @@ public class CreateGroupDetails {
 
     /**
      * The description you assign to the group during creation. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateNetworkSourceDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateNetworkSourceDetails.java
@@ -6,6 +6,7 @@ package com.oracle.bmc.identity.model;
 
 /**
  * Properties for creating a network source object.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreatePolicyDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreatePolicyDetails.java
@@ -146,8 +146,8 @@ public class CreatePolicyDetails {
 
     /**
      * An array of policy statements written in the policy language. See
-     * [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm) and
-     * [Common Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/commonpolicies.htm).
+     * [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm) and
+     * [Common Policies](https://docs.cloud.oracle.com/Content/Identity/policiescommon/commonpolicies.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("statements")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateSmtpCredentialDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateSmtpCredentialDetails.java
@@ -62,6 +62,8 @@ public class CreateSmtpCredentialDetails {
 
     /**
      * The description you assign to the SMTP credentials during creation. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateSwiftPasswordDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateSwiftPasswordDetails.java
@@ -62,6 +62,8 @@ public class CreateSwiftPasswordDetails {
 
     /**
      * The description you assign to the Swift password during creation. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateUserDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateUserDetails.java
@@ -130,6 +130,9 @@ public class CreateUserDetails {
 
     /**
      * The description you assign to the user during creation. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CustomerSecretKey.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CustomerSecretKey.java
@@ -11,7 +11,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  **Note:** The secret key is always an Oracle-generated string; you can't change it to a string of your choice.
  * <p>
- * For more information, see [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingcredentials.htm).
+ * For more information, see [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/access/managing-user-credentials.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DbCredentialSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DbCredentialSummary.java
@@ -130,6 +130,9 @@ public class DbCredentialSummary {
 
     /**
      * The description you assign to the DB credential. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Domain.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Domain.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Properties for a Domain
+ * (For tenancies that support identity domains) Properties for an identity domain. An identity domain is used to manage users and groups, integration standards, external identities, and secure application integration through Oracle Single Sign-on (SSO) configuration.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -228,43 +229,43 @@ public class Domain {
     }
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The OCID of the compartment containing the domain.
+     * The OCID of the compartment containing the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The mutable display name of the domain
+     * The mutable display name of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * The domain descripition
+     * The identity domain description. You can have an empty description.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * Region agnostic domain URL.
+     * Region-agnostic identity domain URL.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("url")
     String url;
 
     /**
-     * Region specific domain URL.
+     * Region-specific identity domain URL.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("homeRegionUrl")
     String homeRegionUrl;
 
     /**
-     * The home region for the domain.
+     * The home region for the identity domain.
      * See [Regions and Availability Domains](https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm)
      * for the full list of supported region names.
      * <p>
@@ -275,7 +276,7 @@ public class Domain {
     String homeRegion;
 
     /**
-     * The regions domain is replication to.
+     * The regions where replicas of the identity domain exist.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("replicaRegions")
     java.util.List<ReplicatedRegionDetails> replicaRegions;
@@ -333,20 +334,20 @@ public class Domain {
     Type type;
 
     /**
-     * The License type of Domain
+     * The license type of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("licenseType")
     String licenseType;
 
     /**
-     * Indicates whether domain is hidden on login screen or not.
+     * Indicates whether the identity domain is hidden on the sign-in screen or not.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isHiddenOnLogin")
     Boolean isHiddenOnLogin;
 
     /**
-     * Date and time the domain was created, in the format defined by RFC3339.
+     * Date and time the identity domain was created, in the format defined by RFC3339.
      * <p>
      * Example: {@code 2016-08-25T21:10:29.600Z}
      *
@@ -409,7 +410,7 @@ public class Domain {
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
     /**
-     * Any additional details about the current state of the Domain.
+     * Any additional details about the current state of the identity domain.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -457,7 +458,7 @@ public class Domain {
         }
     };
     /**
-     * Any additional details about the current state of the Domain.
+     * Any additional details about the current state of the identity domain.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DomainReplication.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DomainReplication.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Domain replication states.
+ * (For tenancies that support identity domains) Identity domain replication states.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -84,19 +84,19 @@ public class DomainReplication {
     }
 
     /**
-     * Version number indicating the value of kievTxnId, starting from which, the domain replication events need to be returned.
+     * The version number indicating the value of kievTxnId, starting from which the identity domain replication events need to be returned.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("opcWaterMark")
     java.math.BigDecimal opcWaterMark;
 
     /**
-     * Custom value defining the order of records with same kievTxnId
+     * A custom value defining the order of records with the same kievTxnId.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("txnSeqNumber")
     java.math.BigDecimal txnSeqNumber;
 
     /**
-     * The domain's replication state
+     * The identity domain's replication state.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("domainReplicationStates")
     java.util.List<DomainReplicationStates> domainReplicationStates;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DomainReplicationStates.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DomainReplicationStates.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Domain replication replication log for all domains for a given region
+ * (For tenancies that support identity domains) The identity domain replication log for all identity domains for a given region.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -83,12 +83,12 @@ public class DomainReplicationStates {
     }
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("domainId")
     String domainId;
     /**
-     * The IDCS replicated region state
+     * The IDCS-replicated region state.
      *
      **/
     public enum State {
@@ -127,14 +127,14 @@ public class DomainReplicationStates {
         }
     };
     /**
-     * The IDCS replicated region state
+     * The IDCS-replicated region state.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("state")
     State state;
 
     /**
-     * The replica region for domain.
+     * The replica region for the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("replicaRegion")
     String replicaRegion;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DomainSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DomainSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * As the name suggests, a {@code DomainSummary} object contains information about a {@code Domain}.
+ * (For tenancies that support identity domains) As the name suggests, a {@code DomainSummary} object contains information about a {@code Domain}.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -229,54 +229,54 @@ public class DomainSummary {
     }
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The OCID of the comparment containing the domain.
+     * The OCID of the compartment containing the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The mutable display name of the domain
+     * The mutable display name of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * The domain descripition
+     * The identity domain description. You can have an empty description.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * Region agnostic domain URL.
+     * Region-agnostic identity domain URL.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("url")
     String url;
 
     /**
-     * Region specific domain URL.
+     * Region-specific identity domain URL.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("homeRegionUrl")
     String homeRegionUrl;
 
     /**
-     * The home region for the domain.
+     * The home region for the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
     String homeRegion;
 
     /**
-     * The regions domain is replicated to.
+     * The regions where replicas of the identity domain exist.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("replicaRegions")
     java.util.List<ReplicatedRegionDetails> replicaRegions;
     /**
-     * The type of the domain.
+     * The type of the identity domain.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -322,27 +322,27 @@ public class DomainSummary {
         }
     };
     /**
-     * The type of the domain.
+     * The type of the identity domain.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     Type type;
 
     /**
-     * The License type of Domain
+     * The license type of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("licenseType")
     String licenseType;
 
     /**
-     * Indicates whether domain is hidden on login screen or not.
+     * Indicates whether the identity domain is hidden on the sign-in screen or not.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isHiddenOnLogin")
     Boolean isHiddenOnLogin;
 
     /**
-     * Date and time the domain was created, in the format defined by RFC3339.
+     * Date and time the identity domain was created, in the format defined by RFC3339.
      * <p>
      * Example: {@code 2016-08-25T21:10:29.600Z}
      *
@@ -405,7 +405,7 @@ public class DomainSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
     /**
-     * Any additional details about the current state of the Domain.
+     * Any additional details about the current state of the identity domain.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -453,7 +453,7 @@ public class DomainSummary {
         }
     };
     /**
-     * Any additional details about the current state of the Domain.
+     * Any additional details about the current state of the identity domain.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DynamicGroup.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/DynamicGroup.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  * This works like regular user/group membership. But in that case, the membership is a static relationship, whereas
  * in a dynamic group, the membership of an instance certificate to a dynamic group is determined during runtime.
- * For more information, see [Managing Dynamic Groups](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+ * For more information, see [Managing Dynamic Groups](https://docs.cloud.oracle.com/Content/Identity/dynamicgroups/managingdynamicgroups.htm).
  * <p>
  **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using
  * the API.
@@ -195,13 +195,16 @@ public class DynamicGroup {
 
     /**
      * The description you assign to the group. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
      * A rule string that defines which instance certificates will be matched.
-     * For syntax, see [Managing Dynamic Groups](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+     * For syntax, see [Managing Dynamic Groups](https://docs.cloud.oracle.com/Content/Identity/dynamicgroups/managingdynamicgroups.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("matchingRule")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/EnableReplicationToRegionDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/EnableReplicationToRegionDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Domain replication request packet
+ * (For tenancies that support identity domains) Identity domain replication request packet.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -62,7 +62,7 @@ public class EnableReplicationToRegionDetails {
     }
 
     /**
-     * A region for which domain replication is requested for.
+     * A region to which you want identity domain replication to occur.
      * See [Regions and Availability Domains](https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm)
      * for the full list of supported region names.
      * <p>

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Group.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Group.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.identity.model;
 /**
  * A collection of users who all need the same type of access to a particular set of resources or compartment.
  * For conceptual information about groups and other IAM Service components, see
- * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+ * [Overview of IAM](https://docs.cloud.oracle.com/Content/Identity/getstarted/identity-domains.htm).
  * <p>
  * If you're federating with an identity provider (IdP), you need to create mappings between the groups
  * defined in the IdP and groups you define in the IAM service. For more information, see
@@ -17,7 +17,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access,
- * see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * see [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
  * <p>
  **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
  * using the API.
@@ -188,6 +188,9 @@ public class Group {
 
     /**
      * The description you assign to the group. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequest.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * A IAM work request object that allows users to track Asynchronous API status.
+ * (For tenancies that support identity domains) An IAM work request object that allows users to track the status of asynchronous API requests.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -212,7 +213,7 @@ public class IamWorkRequest {
     @com.fasterxml.jackson.annotation.JsonProperty("operationType")
     OperationType operationType;
     /**
-     * Status of the work request
+     * The status of the work request.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Status {
@@ -262,7 +263,7 @@ public class IamWorkRequest {
         }
     };
     /**
-     * Status of the work request
+     * The status of the work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("status")
     Status status;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequestErrorSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequestErrorSummary.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * An error encountered while executing an operation that is tracked by a IAM work request.
+ * (For tenancies that support identity domains) An error encountered while executing an operation that is tracked by a IAM work request.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequestLogSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequestLogSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * The log entity for a IAM work request.
+ * (For tenancies that support identity domains) The log entity for a IAM work request.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequestResource.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequestResource.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * A IAM work request resource entry
+ * (For tenancies that support identity domains) A IAM work request resource entry.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequestSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IamWorkRequestSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * The IAM work request summary. Tracks the status of the asynchronous operations.
+ * (For tenancies that support identity domains) The IAM work request summary. Tracks the status of asynchronous operations.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -215,7 +215,7 @@ public class IamWorkRequestSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("operationType")
     OperationType operationType;
     /**
-     * Status of the work request
+     * The status of the work request.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Status {
@@ -265,7 +265,7 @@ public class IamWorkRequestSummary {
         }
     };
     /**
-     * Status of the work request
+     * The status of the work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("status")
     Status status;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IdentityProvider.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IdentityProvider.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access,
- * see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * see [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
  * <p>
  **Warning:** Oracle recommends that you avoid using any confidential information when you supply string
  * values using the API.

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/MfaTotpDevice.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/MfaTotpDevice.java
@@ -10,7 +10,7 @@ package com.oracle.bmc.identity.model;
  * Console. To enable multi-factor authentication, the user must register a mobile device with a TOTP authenticator app
  * installed. The registration process creates the {@code MfaTotpDevice} object. The registration process requires
  * interaction with the Console and cannot be completed programmatically. For more information, see
- * [Managing Multi-Factor Authentication](https://docs.cloud.oracle.com/Content/Identity/Tasks/usingmfa.htm).
+ * [Managing Multi-Factor Authentication](https://docs.cloud.oracle.com/Content/Identity/mfa/understand-multi-factor-authentication.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/NetworkPolicy.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/NetworkPolicy.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Network policy, Consists of a list of Network Source ids.
+ * Network policy, which consists of a list of network source IDs.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Policy.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Policy.java
@@ -7,8 +7,8 @@ package com.oracle.bmc.identity.model;
 /**
  * A document that specifies the type of access a group has to the resources in a compartment. For information about
  * policies and other IAM Service components, see
- * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). If you're new to policies, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Overview of IAM](https://docs.cloud.oracle.com/Content/Identity/getstarted/identity-domains.htm). If you're new to policies, see
+ * [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
  * <p>
  * The word "policy" is used by people in different ways:
  * <p>

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Region.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Region.java
@@ -11,7 +11,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access,
- * see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * see [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/RegionSubscription.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/RegionSubscription.java
@@ -6,11 +6,11 @@ package com.oracle.bmc.identity.model;
 
 /**
  * An object that represents your tenancy's access to a particular region (i.e., a subscription), the status of that
- * access, and whether that region is the home region. For more information, see [Managing Regions](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingregions.htm).
+ * access, and whether that region is the home region. For more information, see [Managing Regions](https://docs.cloud.oracle.com/Content/Identity/regions/managingregions.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access,
- * see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * see [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ReplicatedRegionDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ReplicatedRegionDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Properties for a region where a domain is replicated too.
+ * (For tenancies that support identity domains) Properties for a region where a replica for the identity domain exists.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -88,12 +88,12 @@ public class ReplicatedRegionDetails {
     String region;
 
     /**
-     * Region agnostic domain URL.
+     * Region-agnostic identity domain URL.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("url")
     String url;
     /**
-     * The IDCS replicated region state
+     * The IDCS-replicated region state.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -143,7 +143,7 @@ public class ReplicatedRegionDetails {
         }
     };
     /**
-     * The IDCS replicated region state
+     * The IDCS-replicated region state.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("state")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/SmtpCredential.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/SmtpCredential.java
@@ -12,7 +12,7 @@ package com.oracle.bmc.identity.model;
  **Note:** The credential set is always an Oracle-generated SMTP user name and password pair;
  * you cannot designate the SMTP user name or the SMTP password.
  * <p>
- * For more information, see [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingcredentials.htm#SMTP).
+ * For more information, see [Managing User Credentials](https://docs.cloud.oracle.com/Content/Identity/access/managing-user-credentials.htm#SMTP).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -185,6 +185,9 @@ public class SmtpCredential {
 
     /**
      * The description you assign to the SMTP credential. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/SmtpCredentialSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/SmtpCredentialSummary.java
@@ -164,6 +164,9 @@ public class SmtpCredentialSummary {
 
     /**
      * The description you assign to the SMTP credential. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Tag.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Tag.java
@@ -261,7 +261,7 @@ public class Tag {
 
     /**
      * Indicates whether the tag is retired.
-     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
+     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm#retiringkeys).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isRetired")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/TagDefault.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/TagDefault.java
@@ -12,7 +12,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  * Tag defaults are inherited by child compartments. This means that if you set a tag default on the root compartment
  * for a tenancy, all resources that are created in the tenancy are tagged. For more information about
- * using tag defaults, see [Managing Tag Defaults](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingtagdefaults.htm).
+ * using tag defaults, see [Managing Tag Defaults](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagdefaults.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator.

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/TagNamespace.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/TagNamespace.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.identity.model;
 
 /**
  * A managed container for defined tags. A tag namespace is unique in a tenancy. For more information,
- * see [Managing Tags and Tag Namespaces](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm).
+ * see [Managing Tags and Tag Namespaces](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm).
  * <p>
  **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
  * using the API.
@@ -200,7 +200,7 @@ public class TagNamespace {
 
     /**
      * Whether the tag namespace is retired.
-     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
+     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm#retiringkeys).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isRetired")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/TagNamespaceSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/TagNamespaceSummary.java
@@ -198,7 +198,7 @@ public class TagNamespaceSummary {
 
     /**
      * Whether the tag namespace is retired.
-     * For more information, see [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
+     * For more information, see [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm#retiringkeys).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isRetired")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/TagSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/TagSummary.java
@@ -208,7 +208,7 @@ public class TagSummary {
 
     /**
      * Whether the tag is retired.
-     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
+     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm#retiringkeys).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isRetired")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Tenancy.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Tenancy.java
@@ -12,7 +12,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access,
- * see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * see [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UIPassword.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UIPassword.java
@@ -8,7 +8,7 @@ package com.oracle.bmc.identity.model;
  * A text password that enables a user to sign in to the Console, the user interface for interacting with Oracle
  * Cloud Infrastructure.
  * <p>
- * For more information about user credentials, see [User Credentials](https://docs.cloud.oracle.com/Content/Identity/Concepts/usercredentials.htm).
+ * For more information about user credentials, see [User Credentials](https://docs.cloud.oracle.com/Content/Identity/usercred/usercredentials.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateAuthTokenDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateAuthTokenDetails.java
@@ -62,6 +62,9 @@ public class UpdateAuthTokenDetails {
 
     /**
      * The description you assign to the auth token. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateCustomerSecretKeyDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateCustomerSecretKeyDetails.java
@@ -63,6 +63,9 @@ public class UpdateCustomerSecretKeyDetails {
 
     /**
      * The description you assign to the secret key. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateDomainDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateDomainDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Update domain details
+ * (For tenancies that support identity domains) Update identity domain details.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -105,19 +105,19 @@ public class UpdateDomainDetails {
     }
 
     /**
-     * The domain description
+     * The identity domain description. You can have an empty description.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * The mutable display name of the domain
+     * The mutable display name of the identity domain.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Indicates whether domain is hidden on login screen or not.
+     * Indicates whether the identity domain is hidden on the sign-in screen or not.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isHiddenOnLogin")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateDynamicGroupDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateDynamicGroupDetails.java
@@ -96,13 +96,16 @@ public class UpdateDynamicGroupDetails {
 
     /**
      * The description you assign to the dynamic group. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
      * The matching rule to dynamically match an instance certificate to this dynamic group.
-     * For rule syntax, see [Managing Dynamic Groups](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+     * For rule syntax, see [Managing Dynamic Groups](https://docs.cloud.oracle.com/Content/Identity/dynamicgroups/managingdynamicgroups.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("matchingRule")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateGroupDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateGroupDetails.java
@@ -85,6 +85,9 @@ public class UpdateGroupDetails {
 
     /**
      * The description you assign to the group. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdatePolicyDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdatePolicyDetails.java
@@ -112,8 +112,8 @@ public class UpdatePolicyDetails {
 
     /**
      * An array of policy statements written in the policy language. See
-     * [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm) and
-     * [Common Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/commonpolicies.htm).
+     * [How Policies Work](https://docs.cloud.oracle.com/Content/Identity/policieshow/how-policies-work.htm) and
+     * [Common Policies](https://docs.cloud.oracle.com/Content/Identity/policiescommon/commonpolicies.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("statements")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateSmtpCredentialDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateSmtpCredentialDetails.java
@@ -62,6 +62,9 @@ public class UpdateSmtpCredentialDetails {
 
     /**
      * The description you assign to the SMTP credential. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateSwiftPasswordDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateSwiftPasswordDetails.java
@@ -62,6 +62,9 @@ public class UpdateSwiftPasswordDetails {
 
     /**
      * The description you assign to the Swift password. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateTagDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateTagDetails.java
@@ -125,7 +125,7 @@ public class UpdateTagDetails {
 
     /**
      * Whether the tag is retired.
-     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
+     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm#retiringkeys).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isRetired")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateTagNamespaceDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateTagNamespaceDetails.java
@@ -102,7 +102,7 @@ public class UpdateTagNamespaceDetails {
 
     /**
      * Whether the tag namespace is retired.
-     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
+     * See [Retiring Key Definitions and Namespace Definitions](https://docs.cloud.oracle.com/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm#retiringkeys).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isRetired")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateUserDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateUserDetails.java
@@ -106,6 +106,9 @@ public class UpdateUserDetails {
 
     /**
      * The description you assign to the user. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/User.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/User.java
@@ -10,9 +10,9 @@ package com.oracle.bmc.identity.model;
  * have one or more IAM Service credentials ({@link ApiKey},
  * {@link UIPassword}, {@link SwiftPassword} and
  * {@link AuthToken}).
- * For more information, see [User Credentials](https://docs.cloud.oracle.com/Content/Identity/Concepts/usercredentials.htm)). End users of your
- * application are not typically IAM Service users. For conceptual information about users and other IAM Service
- * components, see [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+ * For more information, see [User Credentials](https://docs.cloud.oracle.com/Content/Identity/usercred/usercredentials.htm)). End users of your
+ * application are not typically IAM Service users, but for tenancies that have identity domains, they might be.
+ * For conceptual information about users and other IAM Service components, see [Overview of IAM](https://docs.cloud.oracle.com/Content/Identity/getstarted/identity-domains.htm).
  * <p>
  * These users are created directly within the Oracle Cloud Infrastructure system, via the IAM service.
  * They are different from *federated users*, who authenticate themselves to the Oracle Cloud Infrastructure
@@ -21,7 +21,7 @@ package com.oracle.bmc.identity.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access,
- * see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * see [Get Started with Policies](https://docs.cloud.oracle.com/Content/Identity/policiesgs/get-started-with-policies.htm).
  * <p>
  **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
  * using the API.
@@ -291,6 +291,9 @@ public class User {
 
     /**
      * The description you assign to the user. Does not have to be unique, and it's changeable.
+     * <p>
+     * (For tenancies that support identity domains) You can have an empty description.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
@@ -298,6 +301,8 @@ public class User {
     /**
      * The email address you assign to the user.
      * The email address must be unique across all users in the tenancy.
+     * <p>
+     * (For tenancies that support identity domains) The email address is required unless the requirement is disabled at the tenancy level.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("email")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ActivateDomainRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ActivateDomainRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.identity.model.*;
 public class ActivateDomainRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      */
     private String domainId;
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ChangeDomainCompartmentRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ChangeDomainCompartmentRequest.java
@@ -22,12 +22,12 @@ public class ChangeDomainCompartmentRequest
                 com.oracle.bmc.identity.model.ChangeDomainCompartmentDetails> {
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      */
     private String domainId;
 
     /**
-     * the request object for moving compartment of a domain
+     * The request object for moving the identity domain to a different compartment.
      */
     private com.oracle.bmc.identity.model.ChangeDomainCompartmentDetails
             changeDomainCompartmentDetails;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ChangeDomainLicenseTypeRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ChangeDomainLicenseTypeRequest.java
@@ -22,12 +22,12 @@ public class ChangeDomainLicenseTypeRequest
                 com.oracle.bmc.identity.model.ChangeDomainLicenseTypeDetails> {
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      */
     private String domainId;
 
     /**
-     * the request object for domain license type update
+     * The request object for an update to the license type of the identity domain.
      */
     private com.oracle.bmc.identity.model.ChangeDomainLicenseTypeDetails
             changeDomainLicenseTypeDetails;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/CreateDomainRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/CreateDomainRequest.java
@@ -22,7 +22,7 @@ public class CreateDomainRequest
                 com.oracle.bmc.identity.model.CreateDomainDetails> {
 
     /**
-     * The request object for creating a new domain
+     * The request object for creating a new identity domain.
      */
     private com.oracle.bmc.identity.model.CreateDomainDetails createDomainDetails;
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/DeactivateDomainRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/DeactivateDomainRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.identity.model.*;
 public class DeactivateDomainRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      */
     private String domainId;
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/DeleteCustomerSecretKeyRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/DeleteCustomerSecretKeyRequest.java
@@ -26,7 +26,7 @@ public class DeleteCustomerSecretKeyRequest
     private String userId;
 
     /**
-     * The OCID of the secret key.
+     * The access token of the secret key.
      */
     private String customerSecretKeyId;
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/DeleteDomainRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/DeleteDomainRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.identity.model.*;
 public class DeleteDomainRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      */
     private String domainId;
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/EnableReplicationToRegionRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/EnableReplicationToRegionRequest.java
@@ -22,12 +22,12 @@ public class EnableReplicationToRegionRequest
                 com.oracle.bmc.identity.model.EnableReplicationToRegionDetails> {
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      */
     private String domainId;
 
     /**
-     * the request object for region we are replicating domain region
+     * The request object for replicating the identity domain to another region.
      */
     private com.oracle.bmc.identity.model.EnableReplicationToRegionDetails
             enableReplicationToRegionDetails;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/GetDomainRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/GetDomainRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.identity.model.*;
 public class GetDomainRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      */
     private String domainId;
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListAllowedDomainLicenseTypesRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListAllowedDomainLicenseTypesRequest.java
@@ -21,7 +21,7 @@ public class ListAllowedDomainLicenseTypesRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The domain license type
+     * The license type of the identity domain.
      */
     private String currentLicenseTypeName;
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListDomainsRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListDomainsRequest.java
@@ -26,32 +26,32 @@ public class ListDomainsRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String compartmentId;
 
     /**
-     * The mutable display name of the domain
+     * The mutable display name of the identity domain.
      */
     private String displayName;
 
     /**
-     * The region agnostic domain URL
+     * The region-agnostic identity domain URL.
      */
     private String url;
 
     /**
-     * The region specific domain URL
+     * The region-specific identity domain URL.
      */
     private String homeRegionUrl;
 
     /**
-     * The domain type
+     * The identity domain type.
      */
     private String type;
 
     /**
-     * The domain license type
+     * The license type of the identity domain.
      */
     private String licenseType;
 
     /**
-     * Indicate if the domain is visible at login screen or not
+     * Indicates whether or not the identity domain is visible at the sign-in screen.
      */
     private Boolean isHiddenOnLogin;
 
@@ -181,7 +181,7 @@ public class ListDomainsRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String opcRequestId;
 
     /**
-     * A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+     * A filter to only return resources that match the given lifecycle state. The state value is case-insensitive.
      *
      */
     private com.oracle.bmc.identity.model.Domain.LifecycleState lifecycleState;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListFaultDomainsRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListFaultDomainsRequest.java
@@ -26,7 +26,7 @@ public class ListFaultDomainsRequest extends com.oracle.bmc.requests.BmcRequest<
     private String compartmentId;
 
     /**
-     * The name of the availibilityDomain.
+     * The name of the availabilityDomain.
      *
      */
     private String availabilityDomain;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/UpdateCustomerSecretKeyRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/UpdateCustomerSecretKeyRequest.java
@@ -27,7 +27,7 @@ public class UpdateCustomerSecretKeyRequest
     private String userId;
 
     /**
-     * The OCID of the secret key.
+     * The access token of the secret key.
      */
     private String customerSecretKeyId;
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/UpdateDomainRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/UpdateDomainRequest.java
@@ -22,12 +22,12 @@ public class UpdateDomainRequest
                 com.oracle.bmc.identity.model.UpdateDomainDetails> {
 
     /**
-     * The OCID of the domain
+     * The OCID of the identity domain.
      */
     private String domainId;
 
     /**
-     * Request object for updating the Domain.
+     * Request object for updating the identity domain.
      */
     private com.oracle.bmc.identity.model.UpdateDomainDetails updateDomainDetails;
 

--- a/bmc-identitydataplane/pom.xml
+++ b/bmc-identitydataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-identitydataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsights.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsights.java
@@ -1359,6 +1359,22 @@ public interface OperationsInsights extends AutoCloseable {
                     SummarizeHostInsightResourceUtilizationInsightRequest request);
 
     /**
+     * Returns response with aggregated time series data (timeIntervalstart, timeIntervalEnd, commandArgs, usageData) for top processes.
+     * Data is aggregated for the time period specified and proceses are sorted descendent by the proces metric specified (CPU, MEMORY, VIRTUAL_MEMORY).
+     * HostInsight Id and Process metric must be specified
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/SummarizeHostInsightTopProcessesUsageTrendExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeHostInsightTopProcessesUsageTrend API.
+     */
+    SummarizeHostInsightTopProcessesUsageTrendResponse summarizeHostInsightTopProcessesUsageTrend(
+            SummarizeHostInsightTopProcessesUsageTrendRequest request);
+
+    /**
      * Gets the details of resources used by an Operations Insights Warehouse.
      * There is only expected to be 1 warehouse per tenant. The warehouse is expected to be in the root compartment.
      *

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsAsync.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsAsync.java
@@ -1733,6 +1733,27 @@ public interface OperationsInsightsAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Returns response with aggregated time series data (timeIntervalstart, timeIntervalEnd, commandArgs, usageData) for top processes.
+     * Data is aggregated for the time period specified and proceses are sorted descendent by the proces metric specified (CPU, MEMORY, VIRTUAL_MEMORY).
+     * HostInsight Id and Process metric must be specified
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeHostInsightTopProcessesUsageTrendResponse>
+            summarizeHostInsightTopProcessesUsageTrend(
+                    SummarizeHostInsightTopProcessesUsageTrendRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    SummarizeHostInsightTopProcessesUsageTrendRequest,
+                                    SummarizeHostInsightTopProcessesUsageTrendResponse>
+                            handler);
+
+    /**
      * Gets the details of resources used by an Operations Insights Warehouse.
      * There is only expected to be 1 warehouse per tenant. The warehouse is expected to be in the root compartment.
      *

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsAsyncClient.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsAsyncClient.java
@@ -4585,6 +4585,55 @@ public class OperationsInsightsAsyncClient implements OperationsInsightsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<SummarizeHostInsightTopProcessesUsageTrendResponse>
+            summarizeHostInsightTopProcessesUsageTrend(
+                    SummarizeHostInsightTopProcessesUsageTrendRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    SummarizeHostInsightTopProcessesUsageTrendRequest,
+                                    SummarizeHostInsightTopProcessesUsageTrendResponse>
+                            handler) {
+        LOG.trace("Called async summarizeHostInsightTopProcessesUsageTrend");
+        final SummarizeHostInsightTopProcessesUsageTrendRequest interceptedRequest =
+                SummarizeHostInsightTopProcessesUsageTrendConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeHostInsightTopProcessesUsageTrendConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        SummarizeHostInsightTopProcessesUsageTrendResponse>
+                transformer = SummarizeHostInsightTopProcessesUsageTrendConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeHostInsightTopProcessesUsageTrendRequest,
+                        SummarizeHostInsightTopProcessesUsageTrendResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeHostInsightTopProcessesUsageTrendRequest,
+                                SummarizeHostInsightTopProcessesUsageTrendResponse>,
+                        java.util.concurrent.Future<
+                                SummarizeHostInsightTopProcessesUsageTrendResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeHostInsightTopProcessesUsageTrendRequest,
+                    SummarizeHostInsightTopProcessesUsageTrendResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<SummarizeOperationsInsightsWarehouseResourceUsageResponse>
             summarizeOperationsInsightsWarehouseResourceUsage(
                     SummarizeOperationsInsightsWarehouseResourceUsageRequest request,

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsClient.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/OperationsInsightsClient.java
@@ -3490,6 +3490,40 @@ public class OperationsInsightsClient implements OperationsInsights {
     }
 
     @Override
+    public SummarizeHostInsightTopProcessesUsageTrendResponse
+            summarizeHostInsightTopProcessesUsageTrend(
+                    SummarizeHostInsightTopProcessesUsageTrendRequest request) {
+        LOG.trace("Called summarizeHostInsightTopProcessesUsageTrend");
+        final SummarizeHostInsightTopProcessesUsageTrendRequest interceptedRequest =
+                SummarizeHostInsightTopProcessesUsageTrendConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeHostInsightTopProcessesUsageTrendConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        SummarizeHostInsightTopProcessesUsageTrendResponse>
+                transformer = SummarizeHostInsightTopProcessesUsageTrendConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public SummarizeOperationsInsightsWarehouseResourceUsageResponse
             summarizeOperationsInsightsWarehouseResourceUsage(
                     SummarizeOperationsInsightsWarehouseResourceUsageRequest request) {

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/SummarizeHostInsightTopProcessesUsageTrendConverter.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/internal/http/SummarizeHostInsightTopProcessesUsageTrendConverter.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.opsi.model.*;
+import com.oracle.bmc.opsi.requests.*;
+import com.oracle.bmc.opsi.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeHostInsightTopProcessesUsageTrendConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.opsi.requests.SummarizeHostInsightTopProcessesUsageTrendRequest
+            interceptRequest(
+                    com.oracle.bmc.opsi.requests.SummarizeHostInsightTopProcessesUsageTrendRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.opsi.requests.SummarizeHostInsightTopProcessesUsageTrendRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+        Validate.notNull(request.getId(), "id is required");
+        Validate.notNull(request.getResourceMetric(), "resourceMetric is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200630")
+                        .path("hostInsights")
+                        .path("topProcessesUsageTrend");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        target =
+                target.queryParam(
+                        "id",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getId()));
+
+        target =
+                target.queryParam(
+                        "resourceMetric",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getResourceMetric()));
+
+        if (request.getAnalysisTimeInterval() != null) {
+            target =
+                    target.queryParam(
+                            "analysisTimeInterval",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getAnalysisTimeInterval()));
+        }
+
+        if (request.getTimeIntervalStart() != null) {
+            target =
+                    target.queryParam(
+                            "timeIntervalStart",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeIntervalStart()));
+        }
+
+        if (request.getTimeIntervalEnd() != null) {
+            target =
+                    target.queryParam(
+                            "timeIntervalEnd",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeIntervalEnd()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.opsi.responses
+                            .SummarizeHostInsightTopProcessesUsageTrendResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.opsi.responses
+                                .SummarizeHostInsightTopProcessesUsageTrendResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.opsi.responses
+                                        .SummarizeHostInsightTopProcessesUsageTrendResponse>() {
+                            @Override
+                            public com.oracle.bmc.opsi.responses
+                                            .SummarizeHostInsightTopProcessesUsageTrendResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.opsi.responses.SummarizeHostInsightTopProcessesUsageTrendResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.opsi.model
+                                                                .SummarizeHostInsightsTopProcessesUsageTrendCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.opsi.model
+                                                                        .SummarizeHostInsightsTopProcessesUsageTrendCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.opsi.model
+                                                        .SummarizeHostInsightsTopProcessesUsageTrendCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.opsi.responses
+                                                .SummarizeHostInsightTopProcessesUsageTrendResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.opsi.responses
+                                                        .SummarizeHostInsightTopProcessesUsageTrendResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.summarizeHostInsightsTopProcessesUsageTrendCollection(
+                                        response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.opsi.responses
+                                                .SummarizeHostInsightTopProcessesUsageTrendResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EmManagedExternalHostInsight.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EmManagedExternalHostInsight.java
@@ -417,7 +417,7 @@ public class EmManagedExternalHostInsight extends HostInsight {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -425,6 +425,7 @@ public class EmManagedExternalHostInsight extends HostInsight {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -467,7 +468,7 @@ public class EmManagedExternalHostInsight extends HostInsight {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("platformType")

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EmManagedExternalHostInsightSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/EmManagedExternalHostInsightSummary.java
@@ -391,7 +391,7 @@ public class EmManagedExternalHostInsightSummary extends HostInsightSummary {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -399,6 +399,7 @@ public class EmManagedExternalHostInsightSummary extends HostInsightSummary {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -441,7 +442,7 @@ public class EmManagedExternalHostInsightSummary extends HostInsightSummary {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("platformType")

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostConfigurationSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostConfigurationSummary.java
@@ -60,7 +60,7 @@ public class HostConfigurationSummary {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -68,6 +68,7 @@ public class HostConfigurationSummary {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -110,7 +111,7 @@ public class HostConfigurationSummary {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("platformType")

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostDetails.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostDetails.java
@@ -142,7 +142,7 @@ public class HostDetails {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -150,6 +150,7 @@ public class HostDetails {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -192,7 +193,7 @@ public class HostDetails {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("platformType")

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostImportableAgentEntitySummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostImportableAgentEntitySummary.java
@@ -118,7 +118,7 @@ public class HostImportableAgentEntitySummary extends ImportableAgentEntitySumma
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -126,6 +126,7 @@ public class HostImportableAgentEntitySummary extends ImportableAgentEntitySumma
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -168,7 +169,7 @@ public class HostImportableAgentEntitySummary extends ImportableAgentEntitySumma
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("platformType")

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostPerformanceMetricGroup.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostPerformanceMetricGroup.java
@@ -34,6 +34,10 @@ package com.oracle.bmc.opsi.model;
         name = "HOST_MEMORY_USAGE"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = HostTopProcesses.class,
+        name = "HOST_TOP_PROCESSES"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = HostCpuUsage.class,
         name = "HOST_CPU_USAGE"
     ),
@@ -61,6 +65,7 @@ public class HostPerformanceMetricGroup {
         HostCpuUsage("HOST_CPU_USAGE"),
         HostMemoryUsage("HOST_MEMORY_USAGE"),
         HostNetworkActivitySummary("HOST_NETWORK_ACTIVITY_SUMMARY"),
+        HostTopProcesses("HOST_TOP_PROCESSES"),
         ;
 
         private final String value;

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostTopProcesses.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/HostTopProcesses.java
@@ -1,0 +1,271 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Top Processes metric for the host
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = HostTopProcesses.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "metricName"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class HostTopProcesses extends HostPerformanceMetricGroup {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCollected")
+        private java.util.Date timeCollected;
+
+        public Builder timeCollected(java.util.Date timeCollected) {
+            this.timeCollected = timeCollected;
+            this.__explicitlySet__.add("timeCollected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pid")
+        private java.math.BigDecimal pid;
+
+        public Builder pid(java.math.BigDecimal pid) {
+            this.pid = pid;
+            this.__explicitlySet__.add("pid");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("userName")
+        private String userName;
+
+        public Builder userName(String userName) {
+            this.userName = userName;
+            this.__explicitlySet__.add("userName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memoryUtilizationPercent")
+        private Double memoryUtilizationPercent;
+
+        public Builder memoryUtilizationPercent(Double memoryUtilizationPercent) {
+            this.memoryUtilizationPercent = memoryUtilizationPercent;
+            this.__explicitlySet__.add("memoryUtilizationPercent");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuUtilizationPercent")
+        private Double cpuUtilizationPercent;
+
+        public Builder cpuUtilizationPercent(Double cpuUtilizationPercent) {
+            this.cpuUtilizationPercent = cpuUtilizationPercent;
+            this.__explicitlySet__.add("cpuUtilizationPercent");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuUsageInSeconds")
+        private Double cpuUsageInSeconds;
+
+        public Builder cpuUsageInSeconds(Double cpuUsageInSeconds) {
+            this.cpuUsageInSeconds = cpuUsageInSeconds;
+            this.__explicitlySet__.add("cpuUsageInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("command")
+        private String command;
+
+        public Builder command(String command) {
+            this.command = command;
+            this.__explicitlySet__.add("command");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("virtualMemoryInMBs")
+        private Double virtualMemoryInMBs;
+
+        public Builder virtualMemoryInMBs(Double virtualMemoryInMBs) {
+            this.virtualMemoryInMBs = virtualMemoryInMBs;
+            this.__explicitlySet__.add("virtualMemoryInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("physicalMemoryInMBs")
+        private Double physicalMemoryInMBs;
+
+        public Builder physicalMemoryInMBs(Double physicalMemoryInMBs) {
+            this.physicalMemoryInMBs = physicalMemoryInMBs;
+            this.__explicitlySet__.add("physicalMemoryInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("startTime")
+        private java.util.Date startTime;
+
+        public Builder startTime(java.util.Date startTime) {
+            this.startTime = startTime;
+            this.__explicitlySet__.add("startTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("totalProcesses")
+        private java.math.BigDecimal totalProcesses;
+
+        public Builder totalProcesses(java.math.BigDecimal totalProcesses) {
+            this.totalProcesses = totalProcesses;
+            this.__explicitlySet__.add("totalProcesses");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public HostTopProcesses build() {
+            HostTopProcesses __instance__ =
+                    new HostTopProcesses(
+                            timeCollected,
+                            pid,
+                            userName,
+                            memoryUtilizationPercent,
+                            cpuUtilizationPercent,
+                            cpuUsageInSeconds,
+                            command,
+                            virtualMemoryInMBs,
+                            physicalMemoryInMBs,
+                            startTime,
+                            totalProcesses);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(HostTopProcesses o) {
+            Builder copiedBuilder =
+                    timeCollected(o.getTimeCollected())
+                            .pid(o.getPid())
+                            .userName(o.getUserName())
+                            .memoryUtilizationPercent(o.getMemoryUtilizationPercent())
+                            .cpuUtilizationPercent(o.getCpuUtilizationPercent())
+                            .cpuUsageInSeconds(o.getCpuUsageInSeconds())
+                            .command(o.getCommand())
+                            .virtualMemoryInMBs(o.getVirtualMemoryInMBs())
+                            .physicalMemoryInMBs(o.getPhysicalMemoryInMBs())
+                            .startTime(o.getStartTime())
+                            .totalProcesses(o.getTotalProcesses());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public HostTopProcesses(
+            java.util.Date timeCollected,
+            java.math.BigDecimal pid,
+            String userName,
+            Double memoryUtilizationPercent,
+            Double cpuUtilizationPercent,
+            Double cpuUsageInSeconds,
+            String command,
+            Double virtualMemoryInMBs,
+            Double physicalMemoryInMBs,
+            java.util.Date startTime,
+            java.math.BigDecimal totalProcesses) {
+        super(timeCollected);
+        this.pid = pid;
+        this.userName = userName;
+        this.memoryUtilizationPercent = memoryUtilizationPercent;
+        this.cpuUtilizationPercent = cpuUtilizationPercent;
+        this.cpuUsageInSeconds = cpuUsageInSeconds;
+        this.command = command;
+        this.virtualMemoryInMBs = virtualMemoryInMBs;
+        this.physicalMemoryInMBs = physicalMemoryInMBs;
+        this.startTime = startTime;
+        this.totalProcesses = totalProcesses;
+    }
+
+    /**
+     * process id
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("pid")
+    java.math.BigDecimal pid;
+
+    /**
+     * User that started the process
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("userName")
+    String userName;
+
+    /**
+     * Memory utilization percentage
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memoryUtilizationPercent")
+    Double memoryUtilizationPercent;
+
+    /**
+     * CPU utilization percentage
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuUtilizationPercent")
+    Double cpuUtilizationPercent;
+
+    /**
+     * CPU usage in seconds
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuUsageInSeconds")
+    Double cpuUsageInSeconds;
+
+    /**
+     * Command line executed for the process
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("command")
+    String command;
+
+    /**
+     * Virtual memory in megabytes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("virtualMemoryInMBs")
+    Double virtualMemoryInMBs;
+
+    /**
+     * Physical memory in megabytes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("physicalMemoryInMBs")
+    Double physicalMemoryInMBs;
+
+    /**
+     * Process Start Time
+     * Example: {@code "2020-03-31T00:00:00.000Z"}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("startTime")
+    java.util.Date startTime;
+
+    /**
+     * Number of processes running at the time of collection
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalProcesses")
+    java.math.BigDecimal totalProcesses;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/MacsManagedExternalHostInsight.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/MacsManagedExternalHostInsight.java
@@ -312,7 +312,7 @@ public class MacsManagedExternalHostInsight extends HostInsight {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -320,6 +320,7 @@ public class MacsManagedExternalHostInsight extends HostInsight {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -362,7 +363,7 @@ public class MacsManagedExternalHostInsight extends HostInsight {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("platformType")

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/MacsManagedExternalHostInsightSummary.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/MacsManagedExternalHostInsightSummary.java
@@ -280,7 +280,7 @@ public class MacsManagedExternalHostInsightSummary extends HostInsightSummary {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -288,6 +288,7 @@ public class MacsManagedExternalHostInsightSummary extends HostInsightSummary {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -330,7 +331,7 @@ public class MacsManagedExternalHostInsightSummary extends HostInsightSummary {
     /**
      * Platform type.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("platformType")

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/SummarizeHostInsightsTopProcessesUsageTrendCollection.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/SummarizeHostInsightsTopProcessesUsageTrendCollection.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Top level response object.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = SummarizeHostInsightsTopProcessesUsageTrendCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SummarizeHostInsightsTopProcessesUsageTrendCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timeIntervalStart")
+        private java.util.Date timeIntervalStart;
+
+        public Builder timeIntervalStart(java.util.Date timeIntervalStart) {
+            this.timeIntervalStart = timeIntervalStart;
+            this.__explicitlySet__.add("timeIntervalStart");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeIntervalEnd")
+        private java.util.Date timeIntervalEnd;
+
+        public Builder timeIntervalEnd(java.util.Date timeIntervalEnd) {
+            this.timeIntervalEnd = timeIntervalEnd;
+            this.__explicitlySet__.add("timeIntervalEnd");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<TopProcessesUsageTrendAggregation> items;
+
+        public Builder items(java.util.List<TopProcessesUsageTrendAggregation> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SummarizeHostInsightsTopProcessesUsageTrendCollection build() {
+            SummarizeHostInsightsTopProcessesUsageTrendCollection __instance__ =
+                    new SummarizeHostInsightsTopProcessesUsageTrendCollection(
+                            timeIntervalStart, timeIntervalEnd, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SummarizeHostInsightsTopProcessesUsageTrendCollection o) {
+            Builder copiedBuilder =
+                    timeIntervalStart(o.getTimeIntervalStart())
+                            .timeIntervalEnd(o.getTimeIntervalEnd())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The start timestamp that was passed into the request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeIntervalStart")
+    java.util.Date timeIntervalStart;
+
+    /**
+     * The end timestamp that was passed into the request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeIntervalEnd")
+    java.util.Date timeIntervalEnd;
+
+    /**
+     * Collection of Usage Data with time stamps for top processes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<TopProcessesUsageTrendAggregation> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/TopProcessesUsageTrend.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/TopProcessesUsageTrend.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Aggregated data for top processes
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TopProcessesUsageTrend.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TopProcessesUsageTrend {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("endTimestamp")
+        private java.util.Date endTimestamp;
+
+        public Builder endTimestamp(java.util.Date endTimestamp) {
+            this.endTimestamp = endTimestamp;
+            this.__explicitlySet__.add("endTimestamp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuUsage")
+        private Double cpuUsage;
+
+        public Builder cpuUsage(Double cpuUsage) {
+            this.cpuUsage = cpuUsage;
+            this.__explicitlySet__.add("cpuUsage");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuUtilization")
+        private Double cpuUtilization;
+
+        public Builder cpuUtilization(Double cpuUtilization) {
+            this.cpuUtilization = cpuUtilization;
+            this.__explicitlySet__.add("cpuUtilization");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memoryUtilization")
+        private Double memoryUtilization;
+
+        public Builder memoryUtilization(Double memoryUtilization) {
+            this.memoryUtilization = memoryUtilization;
+            this.__explicitlySet__.add("memoryUtilization");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("virtualMemoryInMBs")
+        private Double virtualMemoryInMBs;
+
+        public Builder virtualMemoryInMBs(Double virtualMemoryInMBs) {
+            this.virtualMemoryInMBs = virtualMemoryInMBs;
+            this.__explicitlySet__.add("virtualMemoryInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("physicalMemoryInMBs")
+        private Double physicalMemoryInMBs;
+
+        public Builder physicalMemoryInMBs(Double physicalMemoryInMBs) {
+            this.physicalMemoryInMBs = physicalMemoryInMBs;
+            this.__explicitlySet__.add("physicalMemoryInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxProcessCount")
+        private Integer maxProcessCount;
+
+        public Builder maxProcessCount(Integer maxProcessCount) {
+            this.maxProcessCount = maxProcessCount;
+            this.__explicitlySet__.add("maxProcessCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TopProcessesUsageTrend build() {
+            TopProcessesUsageTrend __instance__ =
+                    new TopProcessesUsageTrend(
+                            endTimestamp,
+                            cpuUsage,
+                            cpuUtilization,
+                            memoryUtilization,
+                            virtualMemoryInMBs,
+                            physicalMemoryInMBs,
+                            maxProcessCount);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TopProcessesUsageTrend o) {
+            Builder copiedBuilder =
+                    endTimestamp(o.getEndTimestamp())
+                            .cpuUsage(o.getCpuUsage())
+                            .cpuUtilization(o.getCpuUtilization())
+                            .memoryUtilization(o.getMemoryUtilization())
+                            .virtualMemoryInMBs(o.getVirtualMemoryInMBs())
+                            .physicalMemoryInMBs(o.getPhysicalMemoryInMBs())
+                            .maxProcessCount(o.getMaxProcessCount());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The timestamp in which the current sampling period ends in RFC 3339 format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("endTimestamp")
+    java.util.Date endTimestamp;
+
+    /**
+     * Process CPU usage.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuUsage")
+    Double cpuUsage;
+
+    /**
+     * Process CPU utilization percentage
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuUtilization")
+    Double cpuUtilization;
+
+    /**
+     * Process memory utilization percentage
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memoryUtilization")
+    Double memoryUtilization;
+
+    /**
+     * Process virtual memory in Megabytes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("virtualMemoryInMBs")
+    Double virtualMemoryInMBs;
+
+    /**
+     * Procress physical memory in Megabytes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("physicalMemoryInMBs")
+    Double physicalMemoryInMBs;
+
+    /**
+     * Maximum number of processes running at time of collection
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxProcessCount")
+    Integer maxProcessCount;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/TopProcessesUsageTrendAggregation.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/model/TopProcessesUsageTrendAggregation.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.model;
+
+/**
+ * Usage data per host top process
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TopProcessesUsageTrendAggregation.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TopProcessesUsageTrendAggregation {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("command")
+        private String command;
+
+        public Builder command(String command) {
+            this.command = command;
+            this.__explicitlySet__.add("command");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("usageData")
+        private java.util.List<TopProcessesUsageTrend> usageData;
+
+        public Builder usageData(java.util.List<TopProcessesUsageTrend> usageData) {
+            this.usageData = usageData;
+            this.__explicitlySet__.add("usageData");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TopProcessesUsageTrendAggregation build() {
+            TopProcessesUsageTrendAggregation __instance__ =
+                    new TopProcessesUsageTrendAggregation(command, usageData);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TopProcessesUsageTrendAggregation o) {
+            Builder copiedBuilder = command(o.getCommand()).usageData(o.getUsageData());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Command line and arguments used to launch process
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("command")
+    String command;
+
+    /**
+     * List of usage data samples for a top process
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("usageData")
+    java.util.List<TopProcessesUsageTrend> usageData;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListHostConfigurationsRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListHostConfigurationsRequest.java
@@ -45,7 +45,7 @@ public class ListHostConfigurationsRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      */
     private java.util.List<PlatformType> platformType;
@@ -53,13 +53,14 @@ public class ListHostConfigurationsRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     public enum PlatformType {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
         ;
 
         private final String value;
@@ -259,7 +260,7 @@ public class ListHostConfigurationsRequest
         /**
          * Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */
@@ -271,7 +272,7 @@ public class ListHostConfigurationsRequest
         /**
          * Singular setter. Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListHostInsightsRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListHostInsightsRequest.java
@@ -50,7 +50,7 @@ public class ListHostInsightsRequest extends com.oracle.bmc.requests.BmcRequest<
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      */
     private java.util.List<PlatformType> platformType;
@@ -58,13 +58,14 @@ public class ListHostInsightsRequest extends com.oracle.bmc.requests.BmcRequest<
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     public enum PlatformType {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
         ;
 
         private final String value;
@@ -279,7 +280,7 @@ public class ListHostInsightsRequest extends com.oracle.bmc.requests.BmcRequest<
         /**
          * Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */
@@ -291,7 +292,7 @@ public class ListHostInsightsRequest extends com.oracle.bmc.requests.BmcRequest<
         /**
          * Singular setter. Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListHostedEntitiesRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/ListHostedEntitiesRequest.java
@@ -61,7 +61,7 @@ public class ListHostedEntitiesRequest extends com.oracle.bmc.requests.BmcReques
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      */
     private java.util.List<PlatformType> platformType;
@@ -69,13 +69,14 @@ public class ListHostedEntitiesRequest extends com.oracle.bmc.requests.BmcReques
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     public enum PlatformType {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
         ;
 
         private final String value;
@@ -196,7 +197,7 @@ public class ListHostedEntitiesRequest extends com.oracle.bmc.requests.BmcReques
         /**
          * Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */
@@ -208,7 +209,7 @@ public class ListHostedEntitiesRequest extends com.oracle.bmc.requests.BmcReques
         /**
          * Singular setter. Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceCapacityTrendRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceCapacityTrendRequest.java
@@ -63,7 +63,7 @@ public class SummarizeHostInsightResourceCapacityTrendRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      */
     private java.util.List<PlatformType> platformType;
@@ -71,13 +71,14 @@ public class SummarizeHostInsightResourceCapacityTrendRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     public enum PlatformType {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
         ;
 
         private final String value;
@@ -289,7 +290,7 @@ public class SummarizeHostInsightResourceCapacityTrendRequest
         /**
          * Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */
@@ -301,7 +302,7 @@ public class SummarizeHostInsightResourceCapacityTrendRequest
         /**
          * Singular setter. Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceForecastTrendRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceForecastTrendRequest.java
@@ -63,7 +63,7 @@ public class SummarizeHostInsightResourceForecastTrendRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      */
     private java.util.List<PlatformType> platformType;
@@ -71,13 +71,14 @@ public class SummarizeHostInsightResourceForecastTrendRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     public enum PlatformType {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
         ;
 
         private final String value;
@@ -348,7 +349,7 @@ public class SummarizeHostInsightResourceForecastTrendRequest
         /**
          * Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */
@@ -360,7 +361,7 @@ public class SummarizeHostInsightResourceForecastTrendRequest
         /**
          * Singular setter. Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceStatisticsRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceStatisticsRequest.java
@@ -63,7 +63,7 @@ public class SummarizeHostInsightResourceStatisticsRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      */
     private java.util.List<PlatformType> platformType;
@@ -71,13 +71,14 @@ public class SummarizeHostInsightResourceStatisticsRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     public enum PlatformType {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
         ;
 
         private final String value;
@@ -270,7 +271,7 @@ public class SummarizeHostInsightResourceStatisticsRequest
         /**
          * Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */
@@ -282,7 +283,7 @@ public class SummarizeHostInsightResourceStatisticsRequest
         /**
          * Singular setter. Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceUsageRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceUsageRequest.java
@@ -63,7 +63,7 @@ public class SummarizeHostInsightResourceUsageRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      */
     private java.util.List<PlatformType> platformType;
@@ -71,13 +71,14 @@ public class SummarizeHostInsightResourceUsageRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     public enum PlatformType {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
         ;
 
         private final String value;
@@ -195,7 +196,7 @@ public class SummarizeHostInsightResourceUsageRequest
         /**
          * Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */
@@ -207,7 +208,7 @@ public class SummarizeHostInsightResourceUsageRequest
         /**
          * Singular setter. Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceUsageTrendRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceUsageTrendRequest.java
@@ -63,7 +63,7 @@ public class SummarizeHostInsightResourceUsageTrendRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      */
     private java.util.List<PlatformType> platformType;
@@ -71,13 +71,14 @@ public class SummarizeHostInsightResourceUsageTrendRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     public enum PlatformType {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
         ;
 
         private final String value;
@@ -238,7 +239,7 @@ public class SummarizeHostInsightResourceUsageTrendRequest
         /**
          * Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */
@@ -250,7 +251,7 @@ public class SummarizeHostInsightResourceUsageTrendRequest
         /**
          * Singular setter. Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceUtilizationInsightRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightResourceUtilizationInsightRequest.java
@@ -63,7 +63,7 @@ public class SummarizeHostInsightResourceUtilizationInsightRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      */
     private java.util.List<PlatformType> platformType;
@@ -71,13 +71,14 @@ public class SummarizeHostInsightResourceUtilizationInsightRequest
     /**
      * Filter by one or more platform types.
      * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+     * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
      *
      **/
     public enum PlatformType {
         Linux("LINUX"),
         Solaris("SOLARIS"),
         Sunos("SUNOS"),
+        Zlinux("ZLINUX"),
         ;
 
         private final String value;
@@ -195,7 +196,7 @@ public class SummarizeHostInsightResourceUtilizationInsightRequest
         /**
          * Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */
@@ -207,7 +208,7 @@ public class SummarizeHostInsightResourceUtilizationInsightRequest
         /**
          * Singular setter. Filter by one or more platform types.
          * Supported platformType(s) for MACS-managed external host insight: [LINUX].
-         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS].
+         * Supported platformType(s) for EM-managed external host insight: [LINUX, SOLARIS, SUNOS, ZLINUX].
          *
          * @return this builder instance
          */

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightTopProcessesUsageTrendRequest.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/requests/SummarizeHostInsightTopProcessesUsageTrendRequest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.requests;
+
+import com.oracle.bmc.opsi.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/opsi/SummarizeHostInsightTopProcessesUsageTrendExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeHostInsightTopProcessesUsageTrendRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeHostInsightTopProcessesUsageTrendRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * Required [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the host insight resource.
+     *
+     */
+    private String id;
+
+    /**
+     * Host top processes resource metric sort options.
+     * Supported values are CPU, MEMORY, VIIRTUAL_MEMORY.
+     *
+     */
+    private String resourceMetric;
+
+    /**
+     * Specify time period in ISO 8601 format with respect to current time.
+     * Default is last 30 days represented by P30D.
+     * If timeInterval is specified, then timeIntervalStart and timeIntervalEnd will be ignored.
+     * Examples  P90D (last 90 days), P4W (last 4 weeks), P2M (last 2 months), P1Y (last 12 months), . Maximum value allowed is 25 months prior to current time (P25M).
+     *
+     */
+    private String analysisTimeInterval;
+
+    /**
+     * Analysis start time in UTC in ISO 8601 format(inclusive).
+     * Example 2019-10-30T00:00:00Z (yyyy-MM-ddThh:mm:ssZ).
+     * The minimum allowed value is 2 years prior to the current day.
+     * timeIntervalStart and timeIntervalEnd parameters are used together.
+     * If analysisTimeInterval is specified, this parameter is ignored.
+     *
+     */
+    private java.util.Date timeIntervalStart;
+
+    /**
+     * Analysis end time in UTC in ISO 8601 format(exclusive).
+     * Example 2019-10-30T00:00:00Z (yyyy-MM-ddThh:mm:ssZ).
+     * timeIntervalStart and timeIntervalEnd are used together.
+     * If timeIntervalEnd is not specified, current time is used as timeIntervalEnd.
+     *
+     */
+    private java.util.Date timeIntervalEnd;
+
+    /**
+     * For list pagination. The value of the {@code opc-next-page} response header from
+     * the previous "List" call. For important details about how pagination works,
+     * see [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to
+     * return in a paginated "List" call.
+     * For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     * Example: {@code 50}
+     *
+     */
+    private Integer limit;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeHostInsightTopProcessesUsageTrendRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeHostInsightTopProcessesUsageTrendRequest o) {
+            compartmentId(o.getCompartmentId());
+            id(o.getId());
+            resourceMetric(o.getResourceMetric());
+            analysisTimeInterval(o.getAnalysisTimeInterval());
+            timeIntervalStart(o.getTimeIntervalStart());
+            timeIntervalEnd(o.getTimeIntervalEnd());
+            page(o.getPage());
+            limit(o.getLimit());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeHostInsightTopProcessesUsageTrendRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeHostInsightTopProcessesUsageTrendRequest
+         */
+        public SummarizeHostInsightTopProcessesUsageTrendRequest build() {
+            SummarizeHostInsightTopProcessesUsageTrendRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/SummarizeHostInsightTopProcessesUsageTrendResponse.java
+++ b/bmc-opsi/src/main/java/com/oracle/bmc/opsi/responses/SummarizeHostInsightTopProcessesUsageTrendResponse.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.opsi.responses;
+
+import com.oracle.bmc.opsi.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeHostInsightTopProcessesUsageTrendResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the {@code page} parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned SummarizeHostInsightsTopProcessesUsageTrendCollection instance.
+     */
+    private com.oracle.bmc.opsi.model.SummarizeHostInsightsTopProcessesUsageTrendCollection
+            summarizeHostInsightsTopProcessesUsageTrendCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "summarizeHostInsightsTopProcessesUsageTrendCollection"
+    })
+    private SummarizeHostInsightTopProcessesUsageTrendResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            com.oracle.bmc.opsi.model.SummarizeHostInsightsTopProcessesUsageTrendCollection
+                    summarizeHostInsightsTopProcessesUsageTrendCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.summarizeHostInsightsTopProcessesUsageTrendCollection =
+                summarizeHostInsightsTopProcessesUsageTrendCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeHostInsightTopProcessesUsageTrendResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            summarizeHostInsightsTopProcessesUsageTrendCollection(
+                    o.getSummarizeHostInsightsTopProcessesUsageTrendCollection());
+
+            return this;
+        }
+
+        public SummarizeHostInsightTopProcessesUsageTrendResponse build() {
+            return new SummarizeHostInsightTopProcessesUsageTrendResponse(
+                    __httpStatusCode__,
+                    opcRequestId,
+                    opcNextPage,
+                    summarizeHostInsightsTopProcessesUsageTrendCollection);
+        }
+    }
+}

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ospgateway/pom.xml
+++ b/bmc-ospgateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ospgateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/internal/http/DownloadPdfContentConverter.java
+++ b/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/internal/http/DownloadPdfContentConverter.java
@@ -129,6 +129,30 @@ public class DownloadPdfContentConverter {
                                                     String.class));
                                 }
 
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        contentTypeHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Content-Type");
+                                if (contentTypeHeader.isPresent()) {
+                                    builder.contentType(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Content-Type",
+                                                    contentTypeHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        contentLengthHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Content-Length");
+                                if (contentLengthHeader.isPresent()) {
+                                    builder.contentLength(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Content-Length",
+                                                    contentLengthHeader.get().get(0),
+                                                    Integer.class));
+                                }
+
                                 com.oracle.bmc.ospgateway.responses.DownloadPdfContentResponse
                                         responseWrapper = builder.build();
 

--- a/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/CreditCardPaymentDetail.java
+++ b/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/CreditCardPaymentDetail.java
@@ -59,12 +59,55 @@ public class CreditCardPaymentDetail extends PaymentDetail {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("nameOnCard")
+        private String nameOnCard;
+
+        public Builder nameOnCard(String nameOnCard) {
+            this.nameOnCard = nameOnCard;
+            this.__explicitlySet__.add("nameOnCard");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creditCardType")
+        private CreditCardType creditCardType;
+
+        public Builder creditCardType(CreditCardType creditCardType) {
+            this.creditCardType = creditCardType;
+            this.__explicitlySet__.add("creditCardType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lastDigits")
+        private String lastDigits;
+
+        public Builder lastDigits(String lastDigits) {
+            this.lastDigits = lastDigits;
+            this.__explicitlySet__.add("lastDigits");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeExpiration")
+        private java.util.Date timeExpiration;
+
+        public Builder timeExpiration(java.util.Date timeExpiration) {
+            this.timeExpiration = timeExpiration;
+            this.__explicitlySet__.add("timeExpiration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreditCardPaymentDetail build() {
             CreditCardPaymentDetail __instance__ =
-                    new CreditCardPaymentDetail(timePaidOn, paidBy, amountPaid);
+                    new CreditCardPaymentDetail(
+                            timePaidOn,
+                            paidBy,
+                            amountPaid,
+                            nameOnCard,
+                            creditCardType,
+                            lastDigits,
+                            timeExpiration);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -74,7 +117,11 @@ public class CreditCardPaymentDetail extends PaymentDetail {
             Builder copiedBuilder =
                     timePaidOn(o.getTimePaidOn())
                             .paidBy(o.getPaidBy())
-                            .amountPaid(o.getAmountPaid());
+                            .amountPaid(o.getAmountPaid())
+                            .nameOnCard(o.getNameOnCard())
+                            .creditCardType(o.getCreditCardType())
+                            .lastDigits(o.getLastDigits())
+                            .timeExpiration(o.getTimeExpiration());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -90,9 +137,93 @@ public class CreditCardPaymentDetail extends PaymentDetail {
 
     @Deprecated
     public CreditCardPaymentDetail(
-            java.util.Date timePaidOn, String paidBy, java.math.BigDecimal amountPaid) {
+            java.util.Date timePaidOn,
+            String paidBy,
+            java.math.BigDecimal amountPaid,
+            String nameOnCard,
+            CreditCardType creditCardType,
+            String lastDigits,
+            java.util.Date timeExpiration) {
         super(timePaidOn, paidBy, amountPaid);
+        this.nameOnCard = nameOnCard;
+        this.creditCardType = creditCardType;
+        this.lastDigits = lastDigits;
+        this.timeExpiration = timeExpiration;
     }
+
+    /**
+     * Name on the credit card
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nameOnCard")
+    String nameOnCard;
+    /**
+     * Credit card type
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum CreditCardType {
+        Visa("VISA"),
+        Amex("AMEX"),
+        Mastercard("MASTERCARD"),
+        Discover("DISCOVER"),
+        Jcb("JCB"),
+        Diner("DINER"),
+        Elo("ELO"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, CreditCardType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (CreditCardType v : CreditCardType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        CreditCardType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static CreditCardType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'CreditCardType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Credit card type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("creditCardType")
+    CreditCardType creditCardType;
+
+    /**
+     * Last four digits of the card
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastDigits")
+    String lastDigits;
+
+    /**
+     * Expired date of the credit card
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeExpiration")
+    java.util.Date timeExpiration;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/CreditCardPaymentOption.java
+++ b/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/CreditCardPaymentOption.java
@@ -50,12 +50,54 @@ public class CreditCardPaymentOption extends PaymentOption {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("creditCardType")
+        private CreditCardType creditCardType;
+
+        public Builder creditCardType(CreditCardType creditCardType) {
+            this.creditCardType = creditCardType;
+            this.__explicitlySet__.add("creditCardType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lastDigits")
+        private String lastDigits;
+
+        public Builder lastDigits(String lastDigits) {
+            this.lastDigits = lastDigits;
+            this.__explicitlySet__.add("lastDigits");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nameOnCard")
+        private String nameOnCard;
+
+        public Builder nameOnCard(String nameOnCard) {
+            this.nameOnCard = nameOnCard;
+            this.__explicitlySet__.add("nameOnCard");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeExpiration")
+        private java.util.Date timeExpiration;
+
+        public Builder timeExpiration(java.util.Date timeExpiration) {
+            this.timeExpiration = timeExpiration;
+            this.__explicitlySet__.add("timeExpiration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreditCardPaymentOption build() {
             CreditCardPaymentOption __instance__ =
-                    new CreditCardPaymentOption(walletInstrumentId, walletTransactionId);
+                    new CreditCardPaymentOption(
+                            walletInstrumentId,
+                            walletTransactionId,
+                            creditCardType,
+                            lastDigits,
+                            nameOnCard,
+                            timeExpiration);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -64,7 +106,11 @@ public class CreditCardPaymentOption extends PaymentOption {
         public Builder copy(CreditCardPaymentOption o) {
             Builder copiedBuilder =
                     walletInstrumentId(o.getWalletInstrumentId())
-                            .walletTransactionId(o.getWalletTransactionId());
+                            .walletTransactionId(o.getWalletTransactionId())
+                            .creditCardType(o.getCreditCardType())
+                            .lastDigits(o.getLastDigits())
+                            .nameOnCard(o.getNameOnCard())
+                            .timeExpiration(o.getTimeExpiration());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -79,9 +125,43 @@ public class CreditCardPaymentOption extends PaymentOption {
     }
 
     @Deprecated
-    public CreditCardPaymentOption(String walletInstrumentId, String walletTransactionId) {
+    public CreditCardPaymentOption(
+            String walletInstrumentId,
+            String walletTransactionId,
+            CreditCardType creditCardType,
+            String lastDigits,
+            String nameOnCard,
+            java.util.Date timeExpiration) {
         super(walletInstrumentId, walletTransactionId);
+        this.creditCardType = creditCardType;
+        this.lastDigits = lastDigits;
+        this.nameOnCard = nameOnCard;
+        this.timeExpiration = timeExpiration;
     }
+
+    /**
+     * Credit card type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("creditCardType")
+    CreditCardType creditCardType;
+
+    /**
+     * Last four digits of the card.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastDigits")
+    String lastDigits;
+
+    /**
+     * Name on the credit card.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nameOnCard")
+    String nameOnCard;
+
+    /**
+     * Expired date of the credit card.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeExpiration")
+    java.util.Date timeExpiration;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/CreditCardType.java
+++ b/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/CreditCardType.java
@@ -8,6 +8,7 @@ package com.oracle.bmc.ospgateway.model;
  * Credit card type.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191001")
+@lombok.extern.slf4j.Slf4j
 public enum CreditCardType {
     Visa("VISA"),
     Amex("AMEX"),
@@ -16,7 +17,12 @@ public enum CreditCardType {
     Jcb("JCB"),
     Diner("DINER"),
     Elo("ELO"),
-    ;
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
 
     private final String value;
     private static java.util.Map<String, CreditCardType> map;
@@ -24,7 +30,9 @@ public enum CreditCardType {
     static {
         map = new java.util.HashMap<>();
         for (CreditCardType v : CreditCardType.values()) {
-            map.put(v.getValue(), v);
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
         }
     }
 
@@ -42,6 +50,9 @@ public enum CreditCardType {
         if (map.containsKey(key)) {
             return map.get(key);
         }
-        throw new IllegalArgumentException("Invalid CreditCardType: " + key);
+        LOG.warn(
+                "Received unknown value '{}' for enum 'CreditCardType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
     }
 }

--- a/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/OtherPaymentDetail.java
+++ b/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/OtherPaymentDetail.java
@@ -59,12 +59,65 @@ public class OtherPaymentDetail extends PaymentDetail {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("echeckRouting")
+        private String echeckRouting;
+
+        public Builder echeckRouting(String echeckRouting) {
+            this.echeckRouting = echeckRouting;
+            this.__explicitlySet__.add("echeckRouting");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nameOnCard")
+        private String nameOnCard;
+
+        public Builder nameOnCard(String nameOnCard) {
+            this.nameOnCard = nameOnCard;
+            this.__explicitlySet__.add("nameOnCard");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creditCardType")
+        private CreditCardType creditCardType;
+
+        public Builder creditCardType(CreditCardType creditCardType) {
+            this.creditCardType = creditCardType;
+            this.__explicitlySet__.add("creditCardType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lastDigits")
+        private String lastDigits;
+
+        public Builder lastDigits(String lastDigits) {
+            this.lastDigits = lastDigits;
+            this.__explicitlySet__.add("lastDigits");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeExpiration")
+        private java.util.Date timeExpiration;
+
+        public Builder timeExpiration(java.util.Date timeExpiration) {
+            this.timeExpiration = timeExpiration;
+            this.__explicitlySet__.add("timeExpiration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public OtherPaymentDetail build() {
             OtherPaymentDetail __instance__ =
-                    new OtherPaymentDetail(timePaidOn, paidBy, amountPaid);
+                    new OtherPaymentDetail(
+                            timePaidOn,
+                            paidBy,
+                            amountPaid,
+                            echeckRouting,
+                            nameOnCard,
+                            creditCardType,
+                            lastDigits,
+                            timeExpiration);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -74,7 +127,12 @@ public class OtherPaymentDetail extends PaymentDetail {
             Builder copiedBuilder =
                     timePaidOn(o.getTimePaidOn())
                             .paidBy(o.getPaidBy())
-                            .amountPaid(o.getAmountPaid());
+                            .amountPaid(o.getAmountPaid())
+                            .echeckRouting(o.getEcheckRouting())
+                            .nameOnCard(o.getNameOnCard())
+                            .creditCardType(o.getCreditCardType())
+                            .lastDigits(o.getLastDigits())
+                            .timeExpiration(o.getTimeExpiration());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -90,9 +148,101 @@ public class OtherPaymentDetail extends PaymentDetail {
 
     @Deprecated
     public OtherPaymentDetail(
-            java.util.Date timePaidOn, String paidBy, java.math.BigDecimal amountPaid) {
+            java.util.Date timePaidOn,
+            String paidBy,
+            java.math.BigDecimal amountPaid,
+            String echeckRouting,
+            String nameOnCard,
+            CreditCardType creditCardType,
+            String lastDigits,
+            java.util.Date timeExpiration) {
         super(timePaidOn, paidBy, amountPaid);
+        this.echeckRouting = echeckRouting;
+        this.nameOnCard = nameOnCard;
+        this.creditCardType = creditCardType;
+        this.lastDigits = lastDigits;
+        this.timeExpiration = timeExpiration;
     }
+
+    /**
+     * Last four routing digits of the card
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("echeckRouting")
+    String echeckRouting;
+
+    /**
+     * Name on the echeck card
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nameOnCard")
+    String nameOnCard;
+    /**
+     * Echeck card type
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum CreditCardType {
+        Visa("VISA"),
+        Amex("AMEX"),
+        Mastercard("MASTERCARD"),
+        Discover("DISCOVER"),
+        Jcb("JCB"),
+        Diner("DINER"),
+        Elo("ELO"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, CreditCardType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (CreditCardType v : CreditCardType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        CreditCardType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static CreditCardType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'CreditCardType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Echeck card type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("creditCardType")
+    CreditCardType creditCardType;
+
+    /**
+     * Last four digits of the card
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastDigits")
+    String lastDigits;
+
+    /**
+     * Expired date of the echeck card
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeExpiration")
+    java.util.Date timeExpiration;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/PaypalPaymentDetail.java
+++ b/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/PaypalPaymentDetail.java
@@ -59,12 +59,31 @@ public class PaypalPaymentDetail extends PaymentDetail {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("paypalId")
+        private String paypalId;
+
+        public Builder paypalId(String paypalId) {
+            this.paypalId = paypalId;
+            this.__explicitlySet__.add("paypalId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("paypalReference")
+        private String paypalReference;
+
+        public Builder paypalReference(String paypalReference) {
+            this.paypalReference = paypalReference;
+            this.__explicitlySet__.add("paypalReference");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public PaypalPaymentDetail build() {
             PaypalPaymentDetail __instance__ =
-                    new PaypalPaymentDetail(timePaidOn, paidBy, amountPaid);
+                    new PaypalPaymentDetail(
+                            timePaidOn, paidBy, amountPaid, paypalId, paypalReference);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -74,7 +93,9 @@ public class PaypalPaymentDetail extends PaymentDetail {
             Builder copiedBuilder =
                     timePaidOn(o.getTimePaidOn())
                             .paidBy(o.getPaidBy())
-                            .amountPaid(o.getAmountPaid());
+                            .amountPaid(o.getAmountPaid())
+                            .paypalId(o.getPaypalId())
+                            .paypalReference(o.getPaypalReference());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -90,9 +111,27 @@ public class PaypalPaymentDetail extends PaymentDetail {
 
     @Deprecated
     public PaypalPaymentDetail(
-            java.util.Date timePaidOn, String paidBy, java.math.BigDecimal amountPaid) {
+            java.util.Date timePaidOn,
+            String paidBy,
+            java.math.BigDecimal amountPaid,
+            String paypalId,
+            String paypalReference) {
         super(timePaidOn, paidBy, amountPaid);
+        this.paypalId = paypalId;
+        this.paypalReference = paypalReference;
     }
+
+    /**
+     * The id (email address) of the paypal payment
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("paypalId")
+    String paypalId;
+
+    /**
+     * paypal payment reference
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("paypalReference")
+    String paypalReference;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/PaypalPaymentOption.java
+++ b/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/model/PaypalPaymentOption.java
@@ -50,12 +50,54 @@ public class PaypalPaymentOption extends PaymentOption {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("emailAddress")
+        private String emailAddress;
+
+        public Builder emailAddress(String emailAddress) {
+            this.emailAddress = emailAddress;
+            this.__explicitlySet__.add("emailAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("firstName")
+        private String firstName;
+
+        public Builder firstName(String firstName) {
+            this.firstName = firstName;
+            this.__explicitlySet__.add("firstName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lastName")
+        private String lastName;
+
+        public Builder lastName(String lastName) {
+            this.lastName = lastName;
+            this.__explicitlySet__.add("lastName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("extBillingAgreementId")
+        private String extBillingAgreementId;
+
+        public Builder extBillingAgreementId(String extBillingAgreementId) {
+            this.extBillingAgreementId = extBillingAgreementId;
+            this.__explicitlySet__.add("extBillingAgreementId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public PaypalPaymentOption build() {
             PaypalPaymentOption __instance__ =
-                    new PaypalPaymentOption(walletInstrumentId, walletTransactionId);
+                    new PaypalPaymentOption(
+                            walletInstrumentId,
+                            walletTransactionId,
+                            emailAddress,
+                            firstName,
+                            lastName,
+                            extBillingAgreementId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -64,7 +106,11 @@ public class PaypalPaymentOption extends PaymentOption {
         public Builder copy(PaypalPaymentOption o) {
             Builder copiedBuilder =
                     walletInstrumentId(o.getWalletInstrumentId())
-                            .walletTransactionId(o.getWalletTransactionId());
+                            .walletTransactionId(o.getWalletTransactionId())
+                            .emailAddress(o.getEmailAddress())
+                            .firstName(o.getFirstName())
+                            .lastName(o.getLastName())
+                            .extBillingAgreementId(o.getExtBillingAgreementId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -79,9 +125,43 @@ public class PaypalPaymentOption extends PaymentOption {
     }
 
     @Deprecated
-    public PaypalPaymentOption(String walletInstrumentId, String walletTransactionId) {
+    public PaypalPaymentOption(
+            String walletInstrumentId,
+            String walletTransactionId,
+            String emailAddress,
+            String firstName,
+            String lastName,
+            String extBillingAgreementId) {
         super(walletInstrumentId, walletTransactionId);
+        this.emailAddress = emailAddress;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.extBillingAgreementId = extBillingAgreementId;
     }
+
+    /**
+     * The email address of the paypal user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("emailAddress")
+    String emailAddress;
+
+    /**
+     * First name of the paypal user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("firstName")
+    String firstName;
+
+    /**
+     * Last name of the paypal user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastName")
+    String lastName;
+
+    /**
+     * Agreement id for the paypal account.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("extBillingAgreementId")
+    String extBillingAgreementId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/responses/DownloadPdfContentResponse.java
+++ b/bmc-ospgateway/src/main/java/com/oracle/bmc/ospgateway/responses/DownloadPdfContentResponse.java
@@ -25,6 +25,16 @@ public class DownloadPdfContentResponse extends com.oracle.bmc.responses.BmcResp
     private String contentDisposition;
 
     /**
+     * Set the content type to download
+     */
+    private String contentType;
+
+    /**
+     * Set the content length to download
+     */
+    private Integer contentLength;
+
+    /**
      * The returned java.io.InputStream instance.
      */
     private java.io.InputStream inputStream;
@@ -33,16 +43,22 @@ public class DownloadPdfContentResponse extends com.oracle.bmc.responses.BmcResp
         "__httpStatusCode__",
         "opcRequestId",
         "contentDisposition",
+        "contentType",
+        "contentLength",
         "inputStream"
     })
     private DownloadPdfContentResponse(
             int __httpStatusCode__,
             String opcRequestId,
             String contentDisposition,
+            String contentType,
+            Integer contentLength,
             java.io.InputStream inputStream) {
         super(__httpStatusCode__);
         this.opcRequestId = opcRequestId;
         this.contentDisposition = contentDisposition;
+        this.contentType = contentType;
+        this.contentLength = contentLength;
         this.inputStream = inputStream;
     }
 
@@ -62,6 +78,8 @@ public class DownloadPdfContentResponse extends com.oracle.bmc.responses.BmcResp
             __httpStatusCode__(o.get__httpStatusCode__());
             opcRequestId(o.getOpcRequestId());
             contentDisposition(o.getContentDisposition());
+            contentType(o.getContentType());
+            contentLength(o.getContentLength());
             inputStream(o.getInputStream());
 
             return this;
@@ -69,7 +87,12 @@ public class DownloadPdfContentResponse extends com.oracle.bmc.responses.BmcResp
 
         public DownloadPdfContentResponse build() {
             return new DownloadPdfContentResponse(
-                    __httpStatusCode__, opcRequestId, contentDisposition, inputStream);
+                    __httpStatusCode__,
+                    opcRequestId,
+                    contentDisposition,
+                    contentType,
+                    contentLength,
+                    inputStream);
         }
     }
 }

--- a/bmc-osubbillingschedule/pom.xml
+++ b/bmc-osubbillingschedule/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osuborganizationsubscription/pom.xml
+++ b/bmc-osuborganizationsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubsubscription/pom.xml
+++ b/bmc-osubsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubusage/pom.xml
+++ b/bmc-osubusage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubusage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemanagerproxy/pom.xml
+++ b/bmc-servicemanagerproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-threatintelligence/pom.xml
+++ b/bmc-threatintelligence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-threatintelligence</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usage/pom.xml
+++ b/bmc-usage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-visualbuilder/pom.xml
+++ b/bmc-visualbuilder/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-visualbuilder</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.21.0</version>
+    <version>2.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.21.0</version>
+  <version>2.22.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>
@@ -34,22 +34,22 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jackson.version>2.12.0</jackson.version>
-    <jersey.version>2.34</jersey.version>
+    <jackson.version>2.13.1</jackson.version>
+    <jersey.version>2.35</jersey.version>
     <apache-httpcomponents.version>4.5.13</apache-httpcomponents.version>
     <guava.version>31.0.1-jre</guava.version>
     <junit.version>4.13.2</junit.version>
     <lombok.version>1.18.20</lombok.version>
     <lombok.maven.version>1.18.20.0</lombok.maven.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <slf4j.version>1.7.29</slf4j.version>
+    <slf4j.version>1.7.33</slf4j.version>
     <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-lang3.version>3.8.1</commons-lang3.version>
     <commons-io.version>2.8.0</commons-io.version>
     <!-- Update resilience4jVersion and io.vavr.version together -->
-    <resilience4jVersion>1.2.0</resilience4jVersion>
-    <io.vavr.version>0.10.2</io.vavr.version>
+    <resilience4jVersion>1.7.1</resilience4jVersion>
+    <io.vavr.version>0.10.4</io.vavr.version>
     <maven-shade-plugin.version>3.1.1</maven-shade-plugin.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
### Added

- Fixed the lifecycle state values for target databases in the Data Safe service

- Support for content length and content type response headers when downloading PDFs in the Account Management service

- Support for creating Enterprise Manager-based zLinux host targets, creating alarms, and viewing top process analytics in the Operations Insights service

- Support for diagnostic reboots on VM instances in the Compute service



### Breaking Changes

- The data type of property `lifecycleState` in request `ListTargetDatabasesRequest` was changed from `com.oracle.bmc.datasafe.model.LifecycleState` to `com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState` in the Data Safe service

- The data type of property `lifecycleState` in model `TargetDatabase` was changed from `com.oracle.bmc.datasafe.model.LifecycleState` to `com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState` in the Data Safe service

- The data type of property `lifecycleState` in model `TargetDatabaseSummary` was changed from `com.oracle.bmc.datasafe.model.LifecycleState` to `com.oracle.bmc.datasafe.model.TargetDatabaseLifecycleState` in the Data Safe service


