### PR TITLE
Releasing version 2.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.27.0 - 2022-05-10
+### Added
+- Support for getting usage information for autonomous databases and Cloud at Customer autonomous databases in the Database service
+- Support for the "standby" lifecycle state on autonomous databases in the Database service
+- Support for BIP connections and dataflow operators in the Data Integration service
+
+### Breaking Changes
+- Support for retries by default on WAF Edge Policy GET / LIST operations in the Web Application Acceleration and Security service
+- Support for retries by default on some operations in the Stack Monitoring service
+- Support for retries by default on some resource discovery and monitoring operations in the Application Management service
+- Support for retries by default on some operations in the MySQL Database service
+- Return type of method `public com.oracle.bmc.dataintegration.model.CreateConnectionFromBICC getDefaultConnection()` has been changed to `com.oracle.bmc.dataintegration.model.CreateConnectionDetails` in the model `com.oracle.bmc.dataintegration.model.CreateDataAssetFromFusionApp` in the Data Integration service
+- Return type of method `public com.oracle.bmc.dataintegration.model.ConnectionFromBICCDetails getDefaultConnection()` has been changed to `com.oracle.bmc.dataintegration.model.ConnectionDetails` in the model `com.oracle.bmc.dataintegration.model.DataAssetFromFusionApp` in the Data Integration service
+- Return type of method `public com.oracle.bmc.dataintegration.model.ConnectionSummaryFromBICC getDefaultConnection()` has been changed to `com.oracle.bmc.dataintegration.model.ConnectionSummary` in the model `com.oracle.bmc.dataintegration.model.DataAssetSummaryFromFusionApp` in the Data Integration service
+
 ## 2.26.0 - 2022-05-03
 ### Added
 - Support for the Application Dependency Management service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-graalvm-addon/pom.xml
+++ b/bmc-addons/bmc-graalvm-addon/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -123,619 +123,619 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-ailanguage</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-aispeech</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-aivision</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-analytics</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-announcementsservice</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apigateway</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apmconfig</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apmtraces</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-applicationmigration</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-artifacts</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-audit</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-autoscaling</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-bastion</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-bds</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-blockchain</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-budget</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-certificates</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-cims</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-cloudguard</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-containerengine</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-core</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dashboardservice</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-database</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasemanagement</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasemigration</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasetools</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datacatalog</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dataconnectivity</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dataflow</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dataintegration</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datasafe</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datascience</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-devops</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dns</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dts</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-email</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-events</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-filestorage</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-functions</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-goldengate</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-healthchecks</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-identity</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-identitydataplane</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-jms</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-limits</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-loadbalancer</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-loganalytics</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-logging</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-loggingingestion</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-loggingsearch</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-managementagent</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-managementdashboard</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-marketplace</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-monitoring</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-mysql</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-nosql</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-oce</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-ocvp</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-oda</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-ons</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-opsi</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-optimizer</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osmanagement</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-ospgateway</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osubsubscription</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osubusage</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-resourcemanager</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-resourcesearch</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-rover</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-sch</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-secrets</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-servicecatalog</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-servicemesh</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-stackmonitoring</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-streaming</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-threatintelligence</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-usage</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-usageapi</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-vault</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-visualbuilder</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-waas</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-waf</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bmc-addons/bmc-graalvm-addon/src/main/assembly/assembly.xml
+++ b/bmc-addons/bmc-graalvm-addon/src/main/assembly/assembly.xml
@@ -1,0 +1,65 @@
+<!--
+
+    Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+    This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+
+    <id>release</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <!-- Include the README.md -->
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>README.md</include>
+            </includes>
+        </fileSet>
+        <!-- Include all of the Javadocs -->
+        <fileSet>
+            <directory>${project.build.directory}/apidocs</directory>
+            <outputDirectory>apidocs</outputDirectory>
+            <fileMode>0644</fileMode>
+        </fileSet>
+        <!-- Include the sources and javadoc jars for developers -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <includes>
+                <include>${project.artifactId}-${project.version}-*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>${project.artifactId}-${project.version}-signed.jar</exclude>
+            </excludes>
+            <outputDirectory>lib</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <files>
+        <!-- Explicitly copy the signed/unsigned jar and rename it in the release zip file.
+             If this is for a "signed" release, then the signed jar should be defined; else, the unsigned if the
+             build profile is "ziponly" -->
+        <file>
+            <source>${source.jar.for.zip}</source>
+            <outputDirectory>lib</outputDirectory>
+            <destName>${project.artifactId}-${project.version}.jar</destName>
+        </file>
+    </files>
+    <dependencySets>
+        <!-- 3P dependencies only that's exclusive to this add-on, exclude OCI and its related third-party dependencies -->
+        <dependencySet>
+            <includes>
+                <include>com.google.protobuf:protobuf-java</include>
+            </includes>
+            <outputDirectory>third-party/lib</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useProjectAttachments>false</useProjectAttachments>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-adm/pom.xml
+++ b/bmc-adm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-adm</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aispeech/pom.xml
+++ b/bmc-aispeech/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aispeech</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aivision/pom.xml
+++ b/bmc-aivision/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aivision</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-appmgmtcontrol/pom.xml
+++ b/bmc-appmgmtcontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-appmgmtcontrol/src/main/java/com/oracle/bmc/appmgmtcontrol/AppmgmtControl.java
+++ b/bmc-appmgmtcontrol/src/main/java/com/oracle/bmc/appmgmtcontrol/AppmgmtControl.java
@@ -68,7 +68,7 @@ public interface AppmgmtControl extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/appmgmtcontrol/GetMonitoredInstanceExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetMonitoredInstance API.
@@ -80,7 +80,7 @@ public interface AppmgmtControl extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/appmgmtcontrol/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
@@ -93,7 +93,7 @@ public interface AppmgmtControl extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/appmgmtcontrol/ListMonitoredInstancesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListMonitoredInstances API.
@@ -106,7 +106,7 @@ public interface AppmgmtControl extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/appmgmtcontrol/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestErrors API.
@@ -119,7 +119,7 @@ public interface AppmgmtControl extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/appmgmtcontrol/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestLogs API.
@@ -132,7 +132,7 @@ public interface AppmgmtControl extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/appmgmtcontrol/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.

--- a/bmc-appmgmtcontrol/src/main/java/com/oracle/bmc/appmgmtcontrol/AppmgmtControlClient.java
+++ b/bmc-appmgmtcontrol/src/main/java/com/oracle/bmc/appmgmtcontrol/AppmgmtControlClient.java
@@ -508,7 +508,7 @@ public class AppmgmtControlClient implements AppmgmtControl {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "AppmgmtControl",
@@ -542,7 +542,7 @@ public class AppmgmtControlClient implements AppmgmtControl {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "AppmgmtControl",
@@ -577,7 +577,7 @@ public class AppmgmtControlClient implements AppmgmtControl {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "AppmgmtControl",
@@ -612,7 +612,7 @@ public class AppmgmtControlClient implements AppmgmtControl {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "AppmgmtControl",
@@ -646,7 +646,7 @@ public class AppmgmtControlClient implements AppmgmtControl {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "AppmgmtControl",
@@ -680,7 +680,7 @@ public class AppmgmtControlClient implements AppmgmtControl {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "AppmgmtControl",

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,654 +19,659 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle.oci.sdk</groupId>
+        <artifactId>oci-java-sdk-addons-graalvm</artifactId>
+        <version>2.27.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificates</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usage</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasetools</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ospgateway</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identitydataplane</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-visualbuilder</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubusage</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubsubscription</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dashboardservice</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-threatintelligence</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aivision</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aispeech</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataconnectivity</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-stackmonitoring</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemesh</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-adm</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificates/pom.xml
+++ b/bmc-certificates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificates</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificatesmanagement/pom.xml
+++ b/bmc-certificatesmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-common/src/main/java/com/oracle/bmc/waiter/GenericWaiter.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/waiter/GenericWaiter.java
@@ -8,6 +8,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
+import com.oracle.bmc.ServiceDetails;
 import com.oracle.bmc.waiter.WaiterConfiguration.WaitContext;
 
 import lombok.RequiredArgsConstructor;
@@ -54,11 +55,16 @@ public class GenericWaiter {
             LOG.debug("Invoking function call");
             r = functionCall.apply(requestSupplier.get());
             if (terminationPredicate.apply(r)) {
+                LOG.debug(
+                        "Total Latency for {} API call is: {}ms",
+                        ServiceDetails.getOperationName(),
+                        (context.getCurrentTime() - context.getStartTime()));
                 return Optional.of(r);
             }
             context.incrementAttempts();
             context.setCurrentTime(System.currentTimeMillis());
 
+            LOG.debug("Retry attempt: {}", context.getAttemptsMade());
             if (waiterConfiguration.getTerminationStrategy().shouldTerminate(context)) {
                 LOG.debug("Termination strategy decided to terminate with context at: {}", context);
                 break;
@@ -74,7 +80,10 @@ public class GenericWaiter {
                 return Optional.absent();
             }
         }
-
+        LOG.debug(
+                "Total Latency for {} API call is: {}ms",
+                ServiceDetails.getOperationName(),
+                (context.getCurrentTime() - context.getStartTime()));
         return Optional.absent();
     }
 }

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dashboardservice/pom.xml
+++ b/bmc-dashboardservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dashboardservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabase.java
@@ -308,6 +308,42 @@ public class AutonomousContainerDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("availableCpus")
+        private Float availableCpus;
+
+        public Builder availableCpus(Float availableCpus) {
+            this.availableCpus = availableCpus;
+            this.__explicitlySet__.add("availableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("totalCpus")
+        private Integer totalCpus;
+
+        public Builder totalCpus(Integer totalCpus) {
+            this.totalCpus = totalCpus;
+            this.__explicitlySet__.add("totalCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+        private Float reclaimableCpus;
+
+        public Builder reclaimableCpus(Float reclaimableCpus) {
+            this.reclaimableCpus = reclaimableCpus;
+            this.__explicitlySet__.add("reclaimableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("provisionableCpus")
+        private java.util.List<Float> provisionableCpus;
+
+        public Builder provisionableCpus(java.util.List<Float> provisionableCpus) {
+            this.provisionableCpus = provisionableCpus;
+            this.__explicitlySet__.add("provisionableCpus");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -344,7 +380,11 @@ public class AutonomousContainerDatabase {
                             backupConfig,
                             keyStoreId,
                             keyStoreWalletName,
-                            memoryPerOracleComputeUnitInGBs);
+                            memoryPerOracleComputeUnitInGBs,
+                            availableCpus,
+                            totalCpus,
+                            reclaimableCpus,
+                            provisionableCpus);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -383,8 +423,11 @@ public class AutonomousContainerDatabase {
                             .backupConfig(o.getBackupConfig())
                             .keyStoreId(o.getKeyStoreId())
                             .keyStoreWalletName(o.getKeyStoreWalletName())
-                            .memoryPerOracleComputeUnitInGBs(
-                                    o.getMemoryPerOracleComputeUnitInGBs());
+                            .memoryPerOracleComputeUnitInGBs(o.getMemoryPerOracleComputeUnitInGBs())
+                            .availableCpus(o.getAvailableCpus())
+                            .totalCpus(o.getTotalCpus())
+                            .reclaimableCpus(o.getReclaimableCpus())
+                            .provisionableCpus(o.getProvisionableCpus());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -825,6 +868,30 @@ public class AutonomousContainerDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("memoryPerOracleComputeUnitInGBs")
     Integer memoryPerOracleComputeUnitInGBs;
+
+    /**
+     * Sum of OCPUs available on the Autonomous VM Cluster + Sum of Fractional OCPUs available in the Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableCpus")
+    Float availableCpus;
+
+    /**
+     * The number of CPU cores allocated to the Autonomous VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalCpus")
+    Integer totalCpus;
+
+    /**
+     * CPU cores that are not released to available pool after an Autonomous Database is terminated (Requires Autonomous Container Database restart).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+    Float reclaimableCpus;
+
+    /**
+     * An array of CPU values that can be used to successfully provision a single Autonomous Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("provisionableCpus")
+    java.util.List<Float> provisionableCpus;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseSummary.java
@@ -309,6 +309,42 @@ public class AutonomousContainerDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("availableCpus")
+        private Float availableCpus;
+
+        public Builder availableCpus(Float availableCpus) {
+            this.availableCpus = availableCpus;
+            this.__explicitlySet__.add("availableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("totalCpus")
+        private Integer totalCpus;
+
+        public Builder totalCpus(Integer totalCpus) {
+            this.totalCpus = totalCpus;
+            this.__explicitlySet__.add("totalCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+        private Float reclaimableCpus;
+
+        public Builder reclaimableCpus(Float reclaimableCpus) {
+            this.reclaimableCpus = reclaimableCpus;
+            this.__explicitlySet__.add("reclaimableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("provisionableCpus")
+        private java.util.List<Float> provisionableCpus;
+
+        public Builder provisionableCpus(java.util.List<Float> provisionableCpus) {
+            this.provisionableCpus = provisionableCpus;
+            this.__explicitlySet__.add("provisionableCpus");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -345,7 +381,11 @@ public class AutonomousContainerDatabaseSummary {
                             backupConfig,
                             keyStoreId,
                             keyStoreWalletName,
-                            memoryPerOracleComputeUnitInGBs);
+                            memoryPerOracleComputeUnitInGBs,
+                            availableCpus,
+                            totalCpus,
+                            reclaimableCpus,
+                            provisionableCpus);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -384,8 +424,11 @@ public class AutonomousContainerDatabaseSummary {
                             .backupConfig(o.getBackupConfig())
                             .keyStoreId(o.getKeyStoreId())
                             .keyStoreWalletName(o.getKeyStoreWalletName())
-                            .memoryPerOracleComputeUnitInGBs(
-                                    o.getMemoryPerOracleComputeUnitInGBs());
+                            .memoryPerOracleComputeUnitInGBs(o.getMemoryPerOracleComputeUnitInGBs())
+                            .availableCpus(o.getAvailableCpus())
+                            .totalCpus(o.getTotalCpus())
+                            .reclaimableCpus(o.getReclaimableCpus())
+                            .provisionableCpus(o.getProvisionableCpus());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -826,6 +869,30 @@ public class AutonomousContainerDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("memoryPerOracleComputeUnitInGBs")
     Integer memoryPerOracleComputeUnitInGBs;
+
+    /**
+     * Sum of OCPUs available on the Autonomous VM Cluster + Sum of Fractional OCPUs available in the Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableCpus")
+    Float availableCpus;
+
+    /**
+     * The number of CPU cores allocated to the Autonomous VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalCpus")
+    Integer totalCpus;
+
+    /**
+     * CPU cores that are not released to available pool after an Autonomous Database is terminated (Requires Autonomous Container Database restart).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+    Float reclaimableCpus;
+
+    /**
+     * An array of CPU values that can be used to successfully provision a single Autonomous Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("provisionableCpus")
+    java.util.List<Float> provisionableCpus;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -183,6 +183,15 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("provisionableCpus")
+        private java.util.List<Float> provisionableCpus;
+
+        public Builder provisionableCpus(java.util.List<Float> provisionableCpus) {
+            this.provisionableCpus = provisionableCpus;
+            this.__explicitlySet__.add("provisionableCpus");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
         private Integer dataStorageSizeInTBs;
 
@@ -822,6 +831,7 @@ public class AutonomousDatabase {
                             keyHistoryEntry,
                             cpuCoreCount,
                             ocpuCount,
+                            provisionableCpus,
                             dataStorageSizeInTBs,
                             memoryPerOracleComputeUnitInGBs,
                             dataStorageSizeInGBs,
@@ -916,6 +926,7 @@ public class AutonomousDatabase {
                             .keyHistoryEntry(o.getKeyHistoryEntry())
                             .cpuCoreCount(o.getCpuCoreCount())
                             .ocpuCount(o.getOcpuCount())
+                            .provisionableCpus(o.getProvisionableCpus())
                             .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
                             .memoryPerOracleComputeUnitInGBs(o.getMemoryPerOracleComputeUnitInGBs())
                             .dataStorageSizeInGBs(o.getDataStorageSizeInGBs())
@@ -1034,6 +1045,7 @@ public class AutonomousDatabase {
         RoleChangeInProgress("ROLE_CHANGE_IN_PROGRESS"),
         Upgrading("UPGRADING"),
         Inaccessible("INACCESSIBLE"),
+        Standby("STANDBY"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -1177,6 +1189,12 @@ public class AutonomousDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("ocpuCount")
     Float ocpuCount;
+
+    /**
+     * An array of CPU values that an Autonomous Database can be scaled to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("provisionableCpus")
+    java.util.List<Float> provisionableCpus;
 
     /**
      * The quantity of data in the database, in terabytes.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseStandbySummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseStandbySummary.java
@@ -127,6 +127,7 @@ public class AutonomousDatabaseStandbySummary {
         RoleChangeInProgress("ROLE_CHANGE_IN_PROGRESS"),
         Upgrading("UPGRADING"),
         Inaccessible("INACCESSIBLE"),
+        Standby("STANDBY"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -185,6 +185,15 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("provisionableCpus")
+        private java.util.List<Float> provisionableCpus;
+
+        public Builder provisionableCpus(java.util.List<Float> provisionableCpus) {
+            this.provisionableCpus = provisionableCpus;
+            this.__explicitlySet__.add("provisionableCpus");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
         private Integer dataStorageSizeInTBs;
 
@@ -824,6 +833,7 @@ public class AutonomousDatabaseSummary {
                             keyHistoryEntry,
                             cpuCoreCount,
                             ocpuCount,
+                            provisionableCpus,
                             dataStorageSizeInTBs,
                             memoryPerOracleComputeUnitInGBs,
                             dataStorageSizeInGBs,
@@ -918,6 +928,7 @@ public class AutonomousDatabaseSummary {
                             .keyHistoryEntry(o.getKeyHistoryEntry())
                             .cpuCoreCount(o.getCpuCoreCount())
                             .ocpuCount(o.getOcpuCount())
+                            .provisionableCpus(o.getProvisionableCpus())
                             .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
                             .memoryPerOracleComputeUnitInGBs(o.getMemoryPerOracleComputeUnitInGBs())
                             .dataStorageSizeInGBs(o.getDataStorageSizeInGBs())
@@ -1036,6 +1047,7 @@ public class AutonomousDatabaseSummary {
         RoleChangeInProgress("ROLE_CHANGE_IN_PROGRESS"),
         Upgrading("UPGRADING"),
         Inaccessible("INACCESSIBLE"),
+        Standby("STANDBY"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -1179,6 +1191,12 @@ public class AutonomousDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("ocpuCount")
     Float ocpuCount;
+
+    /**
+     * An array of CPU values that an Autonomous Database can be scaled to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("provisionableCpus")
+    java.util.List<Float> provisionableCpus;
 
     /**
      * The quantity of data in the database, in terabytes.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousVmCluster.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousVmCluster.java
@@ -280,6 +280,34 @@ public class AutonomousVmCluster {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+        private Integer reclaimableCpus;
+
+        public Builder reclaimableCpus(Integer reclaimableCpus) {
+            this.reclaimableCpus = reclaimableCpus;
+            this.__explicitlySet__.add("reclaimableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableContainerDatabases")
+        private Integer availableContainerDatabases;
+
+        public Builder availableContainerDatabases(Integer availableContainerDatabases) {
+            this.availableContainerDatabases = availableContainerDatabases;
+            this.__explicitlySet__.add("availableContainerDatabases");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableAutonomousDataStorageSizeInTBs")
+        private Double availableAutonomousDataStorageSizeInTBs;
+
+        public Builder availableAutonomousDataStorageSizeInTBs(
+                Double availableAutonomousDataStorageSizeInTBs) {
+            this.availableAutonomousDataStorageSizeInTBs = availableAutonomousDataStorageSizeInTBs;
+            this.__explicitlySet__.add("availableAutonomousDataStorageSizeInTBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -313,7 +341,10 @@ public class AutonomousVmCluster {
                             availableDataStorageSizeInTBs,
                             licenseModel,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            reclaimableCpus,
+                            availableContainerDatabases,
+                            availableAutonomousDataStorageSizeInTBs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -348,7 +379,11 @@ public class AutonomousVmCluster {
                             .availableDataStorageSizeInTBs(o.getAvailableDataStorageSizeInTBs())
                             .licenseModel(o.getLicenseModel())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .reclaimableCpus(o.getReclaimableCpus())
+                            .availableContainerDatabases(o.getAvailableContainerDatabases())
+                            .availableAutonomousDataStorageSizeInTBs(
+                                    o.getAvailableAutonomousDataStorageSizeInTBs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -555,7 +590,8 @@ public class AutonomousVmCluster {
     Double dataStorageSizeInGBs;
 
     /**
-     * The data storage available in TBs
+     * **Deprecated.** Use {@code availableAutonomousDataStorageSizeInTBs} for Autonomous Databases data storage available, in TBs.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("availableDataStorageSizeInTBs")
     Double availableDataStorageSizeInTBs;
@@ -630,6 +666,24 @@ public class AutonomousVmCluster {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * CPU cores that are not released to available pool after an Autonomous Database is terminated (Requires Autonomous Container Database restart).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+    Integer reclaimableCpus;
+
+    /**
+     * The number of Autonomous Container Databases that can be created with the currently available local storage.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableContainerDatabases")
+    Integer availableContainerDatabases;
+
+    /**
+     * The data disk group size available for Autonomous Databases, in TBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableAutonomousDataStorageSizeInTBs")
+    Double availableAutonomousDataStorageSizeInTBs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousVmClusterSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousVmClusterSummary.java
@@ -280,6 +280,34 @@ public class AutonomousVmClusterSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+        private Integer reclaimableCpus;
+
+        public Builder reclaimableCpus(Integer reclaimableCpus) {
+            this.reclaimableCpus = reclaimableCpus;
+            this.__explicitlySet__.add("reclaimableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableContainerDatabases")
+        private Integer availableContainerDatabases;
+
+        public Builder availableContainerDatabases(Integer availableContainerDatabases) {
+            this.availableContainerDatabases = availableContainerDatabases;
+            this.__explicitlySet__.add("availableContainerDatabases");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableAutonomousDataStorageSizeInTBs")
+        private Double availableAutonomousDataStorageSizeInTBs;
+
+        public Builder availableAutonomousDataStorageSizeInTBs(
+                Double availableAutonomousDataStorageSizeInTBs) {
+            this.availableAutonomousDataStorageSizeInTBs = availableAutonomousDataStorageSizeInTBs;
+            this.__explicitlySet__.add("availableAutonomousDataStorageSizeInTBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -313,7 +341,10 @@ public class AutonomousVmClusterSummary {
                             availableDataStorageSizeInTBs,
                             licenseModel,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            reclaimableCpus,
+                            availableContainerDatabases,
+                            availableAutonomousDataStorageSizeInTBs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -348,7 +379,11 @@ public class AutonomousVmClusterSummary {
                             .availableDataStorageSizeInTBs(o.getAvailableDataStorageSizeInTBs())
                             .licenseModel(o.getLicenseModel())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .reclaimableCpus(o.getReclaimableCpus())
+                            .availableContainerDatabases(o.getAvailableContainerDatabases())
+                            .availableAutonomousDataStorageSizeInTBs(
+                                    o.getAvailableAutonomousDataStorageSizeInTBs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -555,7 +590,8 @@ public class AutonomousVmClusterSummary {
     Double dataStorageSizeInGBs;
 
     /**
-     * The data storage available in TBs
+     * **Deprecated.** Use {@code availableAutonomousDataStorageSizeInTBs} for Autonomous Databases data storage available, in TBs.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("availableDataStorageSizeInTBs")
     Double availableDataStorageSizeInTBs;
@@ -630,6 +666,24 @@ public class AutonomousVmClusterSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * CPU cores that are not released to available pool after an Autonomous Database is terminated (Requires Autonomous Container Database restart).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+    Integer reclaimableCpus;
+
+    /**
+     * The number of Autonomous Container Databases that can be created with the currently available local storage.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableContainerDatabases")
+    Integer availableContainerDatabases;
+
+    /**
+     * The data disk group size available for Autonomous Databases, in TBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableAutonomousDataStorageSizeInTBs")
+    Double availableAutonomousDataStorageSizeInTBs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudAutonomousVmCluster.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudAutonomousVmCluster.java
@@ -271,6 +271,79 @@ public class CloudAutonomousVmCluster {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("availableCpus")
+        private Float availableCpus;
+
+        public Builder availableCpus(Float availableCpus) {
+            this.availableCpus = availableCpus;
+            this.__explicitlySet__.add("availableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+        private Float reclaimableCpus;
+
+        public Builder reclaimableCpus(Float reclaimableCpus) {
+            this.reclaimableCpus = reclaimableCpus;
+            this.__explicitlySet__.add("reclaimableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableContainerDatabases")
+        private Integer availableContainerDatabases;
+
+        public Builder availableContainerDatabases(Integer availableContainerDatabases) {
+            this.availableContainerDatabases = availableContainerDatabases;
+            this.__explicitlySet__.add("availableContainerDatabases");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("totalContainerDatabases")
+        private Integer totalContainerDatabases;
+
+        public Builder totalContainerDatabases(Integer totalContainerDatabases) {
+            this.totalContainerDatabases = totalContainerDatabases;
+            this.__explicitlySet__.add("totalContainerDatabases");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableAutonomousDataStorageSizeInTBs")
+        private Double availableAutonomousDataStorageSizeInTBs;
+
+        public Builder availableAutonomousDataStorageSizeInTBs(
+                Double availableAutonomousDataStorageSizeInTBs) {
+            this.availableAutonomousDataStorageSizeInTBs = availableAutonomousDataStorageSizeInTBs;
+            this.__explicitlySet__.add("availableAutonomousDataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousDataStorageSizeInTBs")
+        private Double autonomousDataStorageSizeInTBs;
+
+        public Builder autonomousDataStorageSizeInTBs(Double autonomousDataStorageSizeInTBs) {
+            this.autonomousDataStorageSizeInTBs = autonomousDataStorageSizeInTBs;
+            this.__explicitlySet__.add("autonomousDataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memoryPerOracleComputeUnitInGBs")
+        private Integer memoryPerOracleComputeUnitInGBs;
+
+        public Builder memoryPerOracleComputeUnitInGBs(Integer memoryPerOracleComputeUnitInGBs) {
+            this.memoryPerOracleComputeUnitInGBs = memoryPerOracleComputeUnitInGBs;
+            this.__explicitlySet__.add("memoryPerOracleComputeUnitInGBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -303,7 +376,15 @@ public class CloudAutonomousVmCluster {
                             lastMaintenanceRunId,
                             nextMaintenanceRunId,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            availableCpus,
+                            reclaimableCpus,
+                            availableContainerDatabases,
+                            totalContainerDatabases,
+                            availableAutonomousDataStorageSizeInTBs,
+                            autonomousDataStorageSizeInTBs,
+                            dbNodeStorageSizeInGBs,
+                            memoryPerOracleComputeUnitInGBs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -337,7 +418,17 @@ public class CloudAutonomousVmCluster {
                             .lastMaintenanceRunId(o.getLastMaintenanceRunId())
                             .nextMaintenanceRunId(o.getNextMaintenanceRunId())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .availableCpus(o.getAvailableCpus())
+                            .reclaimableCpus(o.getReclaimableCpus())
+                            .availableContainerDatabases(o.getAvailableContainerDatabases())
+                            .totalContainerDatabases(o.getTotalContainerDatabases())
+                            .availableAutonomousDataStorageSizeInTBs(
+                                    o.getAvailableAutonomousDataStorageSizeInTBs())
+                            .autonomousDataStorageSizeInTBs(o.getAutonomousDataStorageSizeInTBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .memoryPerOracleComputeUnitInGBs(
+                                    o.getMemoryPerOracleComputeUnitInGBs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -634,6 +725,54 @@ public class CloudAutonomousVmCluster {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * CPU cores available for allocation to Autonomous Databases.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableCpus")
+    Float availableCpus;
+
+    /**
+     * CPU cores that are not released to available pool after an Autonomous Database is terminated (Requires Autonomous Container Database restart).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+    Float reclaimableCpus;
+
+    /**
+     * The number of Autonomous Container Databases that can be created with the currently available local storage.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableContainerDatabases")
+    Integer availableContainerDatabases;
+
+    /**
+     * The total number of Autonomous Container Databases that can be created with the allocated local storage.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalContainerDatabases")
+    Integer totalContainerDatabases;
+
+    /**
+     * The data disk group size available for Autonomous Databases, in TBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableAutonomousDataStorageSizeInTBs")
+    Double availableAutonomousDataStorageSizeInTBs;
+
+    /**
+     * The data disk group size allocated for Autonomous Databases, in TBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autonomousDataStorageSizeInTBs")
+    Double autonomousDataStorageSizeInTBs;
+
+    /**
+     * The local node storage allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The amount of memory (in GBs) enabled per each OCPU core.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memoryPerOracleComputeUnitInGBs")
+    Integer memoryPerOracleComputeUnitInGBs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudAutonomousVmClusterSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudAutonomousVmClusterSummary.java
@@ -271,6 +271,79 @@ public class CloudAutonomousVmClusterSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("availableCpus")
+        private Float availableCpus;
+
+        public Builder availableCpus(Float availableCpus) {
+            this.availableCpus = availableCpus;
+            this.__explicitlySet__.add("availableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+        private Float reclaimableCpus;
+
+        public Builder reclaimableCpus(Float reclaimableCpus) {
+            this.reclaimableCpus = reclaimableCpus;
+            this.__explicitlySet__.add("reclaimableCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableContainerDatabases")
+        private Integer availableContainerDatabases;
+
+        public Builder availableContainerDatabases(Integer availableContainerDatabases) {
+            this.availableContainerDatabases = availableContainerDatabases;
+            this.__explicitlySet__.add("availableContainerDatabases");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("totalContainerDatabases")
+        private Integer totalContainerDatabases;
+
+        public Builder totalContainerDatabases(Integer totalContainerDatabases) {
+            this.totalContainerDatabases = totalContainerDatabases;
+            this.__explicitlySet__.add("totalContainerDatabases");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableAutonomousDataStorageSizeInTBs")
+        private Double availableAutonomousDataStorageSizeInTBs;
+
+        public Builder availableAutonomousDataStorageSizeInTBs(
+                Double availableAutonomousDataStorageSizeInTBs) {
+            this.availableAutonomousDataStorageSizeInTBs = availableAutonomousDataStorageSizeInTBs;
+            this.__explicitlySet__.add("availableAutonomousDataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousDataStorageSizeInTBs")
+        private Double autonomousDataStorageSizeInTBs;
+
+        public Builder autonomousDataStorageSizeInTBs(Double autonomousDataStorageSizeInTBs) {
+            this.autonomousDataStorageSizeInTBs = autonomousDataStorageSizeInTBs;
+            this.__explicitlySet__.add("autonomousDataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memoryPerOracleComputeUnitInGBs")
+        private Integer memoryPerOracleComputeUnitInGBs;
+
+        public Builder memoryPerOracleComputeUnitInGBs(Integer memoryPerOracleComputeUnitInGBs) {
+            this.memoryPerOracleComputeUnitInGBs = memoryPerOracleComputeUnitInGBs;
+            this.__explicitlySet__.add("memoryPerOracleComputeUnitInGBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -303,7 +376,15 @@ public class CloudAutonomousVmClusterSummary {
                             lastMaintenanceRunId,
                             nextMaintenanceRunId,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            availableCpus,
+                            reclaimableCpus,
+                            availableContainerDatabases,
+                            totalContainerDatabases,
+                            availableAutonomousDataStorageSizeInTBs,
+                            autonomousDataStorageSizeInTBs,
+                            dbNodeStorageSizeInGBs,
+                            memoryPerOracleComputeUnitInGBs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -337,7 +418,17 @@ public class CloudAutonomousVmClusterSummary {
                             .lastMaintenanceRunId(o.getLastMaintenanceRunId())
                             .nextMaintenanceRunId(o.getNextMaintenanceRunId())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .availableCpus(o.getAvailableCpus())
+                            .reclaimableCpus(o.getReclaimableCpus())
+                            .availableContainerDatabases(o.getAvailableContainerDatabases())
+                            .totalContainerDatabases(o.getTotalContainerDatabases())
+                            .availableAutonomousDataStorageSizeInTBs(
+                                    o.getAvailableAutonomousDataStorageSizeInTBs())
+                            .autonomousDataStorageSizeInTBs(o.getAutonomousDataStorageSizeInTBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .memoryPerOracleComputeUnitInGBs(
+                                    o.getMemoryPerOracleComputeUnitInGBs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -634,6 +725,54 @@ public class CloudAutonomousVmClusterSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * CPU cores available for allocation to Autonomous Databases.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableCpus")
+    Float availableCpus;
+
+    /**
+     * CPU cores that are not released to available pool after an Autonomous Database is terminated (Requires Autonomous Container Database restart).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reclaimableCpus")
+    Float reclaimableCpus;
+
+    /**
+     * The number of Autonomous Container Databases that can be created with the currently available local storage.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableContainerDatabases")
+    Integer availableContainerDatabases;
+
+    /**
+     * The total number of Autonomous Container Databases that can be created with the allocated local storage.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalContainerDatabases")
+    Integer totalContainerDatabases;
+
+    /**
+     * The data disk group size available for Autonomous Databases, in TBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableAutonomousDataStorageSizeInTBs")
+    Double availableAutonomousDataStorageSizeInTBs;
+
+    /**
+     * The data disk group size allocated for Autonomous Databases, in TBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autonomousDataStorageSizeInTBs")
+    Double autonomousDataStorageSizeInTBs;
+
+    /**
+     * The local node storage allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The amount of memory (in GBs) enabled per each OCPU core.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memoryPerOracleComputeUnitInGBs")
+    Integer memoryPerOracleComputeUnitInGBs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasetools/pom.xml
+++ b/bmc-databasetools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasetools</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataconnectivity/pom.xml
+++ b/bmc-dataconnectivity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataconnectivity</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AbstractCallAttribute.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AbstractCallAttribute.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The abstract write attribute.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType",
+    defaultImpl = AbstractCallAttribute.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BipCallAttribute.class,
+        name = "BIP_CALL_ATTRIBUTE"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class AbstractCallAttribute {
+
+    /**
+     * The fetch size for reading.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fetchSize")
+    Integer fetchSize;
+
+    /**
+     * The type of the abstract call attribute.
+     **/
+    public enum ModelType {
+        BipCallAttribute("BIP_CALL_ATTRIBUTE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ModelType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ModelType v : ModelType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ModelType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ModelType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ModelType: " + key);
+        }
+    };
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AbstractDataOperationConfig.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AbstractDataOperationConfig.java
@@ -41,6 +41,21 @@ package com.oracle.bmc.dataintegration.model;
 public class AbstractDataOperationConfig {
 
     /**
+     * This map is used for passing extra metatdata configuration that is required by read / write operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metadataConfigProperties")
+    java.util.Map<String, String> metadataConfigProperties;
+
+    /**
+     * this map is used for passing BIP report parameter values.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("derivedAttributes")
+    java.util.Map<String, String> derivedAttributes;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("callAttribute")
+    BipCallAttribute callAttribute;
+
+    /**
      * The type of data operation.
      **/
     public enum ModelType {

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AbstractReadAttribute.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AbstractReadAttribute.java
@@ -37,6 +37,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "BICC_READ_ATTRIBUTE"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BipReadAttributes.class,
+        name = "BIP_READ_ATTRIBUTE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = OracleReadAttribute.class,
         name = "ORACLEREADATTRIBUTE"
     )
@@ -52,6 +56,7 @@ public class AbstractReadAttribute {
         Oraclereadattribute("ORACLEREADATTRIBUTE"),
         OracleReadAttribute("ORACLE_READ_ATTRIBUTE"),
         BiccReadAttribute("BICC_READ_ATTRIBUTE"),
+        BipReadAttribute("BIP_READ_ATTRIBUTE"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Aggregator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Aggregator.java
@@ -94,9 +94,9 @@ public class Aggregator extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -208,7 +208,7 @@ public class Aggregator extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/BipCallAttribute.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/BipCallAttribute.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Properties to configure reading from a FUSION_APP BIP data asset / connection.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = BipCallAttribute.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BipCallAttribute extends AbstractCallAttribute {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("fetchSize")
+        private Integer fetchSize;
+
+        public Builder fetchSize(Integer fetchSize) {
+            this.fetchSize = fetchSize;
+            this.__explicitlySet__.add("fetchSize");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("offsetParameter")
+        private String offsetParameter;
+
+        public Builder offsetParameter(String offsetParameter) {
+            this.offsetParameter = offsetParameter;
+            this.__explicitlySet__.add("offsetParameter");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fetchNextRowsParameter")
+        private String fetchNextRowsParameter;
+
+        public Builder fetchNextRowsParameter(String fetchNextRowsParameter) {
+            this.fetchNextRowsParameter = fetchNextRowsParameter;
+            this.__explicitlySet__.add("fetchNextRowsParameter");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stagingDataAsset")
+        private DataAssetSummaryFromObjectStorage stagingDataAsset;
+
+        public Builder stagingDataAsset(DataAssetSummaryFromObjectStorage stagingDataAsset) {
+            this.stagingDataAsset = stagingDataAsset;
+            this.__explicitlySet__.add("stagingDataAsset");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stagingConnection")
+        private ConnectionSummaryFromObjectStorage stagingConnection;
+
+        public Builder stagingConnection(ConnectionSummaryFromObjectStorage stagingConnection) {
+            this.stagingConnection = stagingConnection;
+            this.__explicitlySet__.add("stagingConnection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bucketSchema")
+        private Schema bucketSchema;
+
+        public Builder bucketSchema(Schema bucketSchema) {
+            this.bucketSchema = bucketSchema;
+            this.__explicitlySet__.add("bucketSchema");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BipCallAttribute build() {
+            BipCallAttribute __instance__ =
+                    new BipCallAttribute(
+                            fetchSize,
+                            offsetParameter,
+                            fetchNextRowsParameter,
+                            stagingDataAsset,
+                            stagingConnection,
+                            bucketSchema);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BipCallAttribute o) {
+            Builder copiedBuilder =
+                    fetchSize(o.getFetchSize())
+                            .offsetParameter(o.getOffsetParameter())
+                            .fetchNextRowsParameter(o.getFetchNextRowsParameter())
+                            .stagingDataAsset(o.getStagingDataAsset())
+                            .stagingConnection(o.getStagingConnection())
+                            .bucketSchema(o.getBucketSchema());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BipCallAttribute(
+            Integer fetchSize,
+            String offsetParameter,
+            String fetchNextRowsParameter,
+            DataAssetSummaryFromObjectStorage stagingDataAsset,
+            ConnectionSummaryFromObjectStorage stagingConnection,
+            Schema bucketSchema) {
+        super(fetchSize);
+        this.offsetParameter = offsetParameter;
+        this.fetchNextRowsParameter = fetchNextRowsParameter;
+        this.stagingDataAsset = stagingDataAsset;
+        this.stagingConnection = stagingConnection;
+        this.bucketSchema = bucketSchema;
+    }
+
+    /**
+     * Name of BIP report parameter to control the offset of the chunk.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("offsetParameter")
+    String offsetParameter;
+
+    /**
+     * Name of BIP report parameter to control the fetch next rows of the chunk.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fetchNextRowsParameter")
+    String fetchNextRowsParameter;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stagingDataAsset")
+    DataAssetSummaryFromObjectStorage stagingDataAsset;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stagingConnection")
+    ConnectionSummaryFromObjectStorage stagingConnection;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("bucketSchema")
+    Schema bucketSchema;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/BipReadAttributes.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/BipReadAttributes.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Properties to configure reading from a FUSION_APP BIP data asset / connection.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BipReadAttributes.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BipReadAttributes extends AbstractReadAttribute {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("fetchSize")
+        private Integer fetchSize;
+
+        public Builder fetchSize(Integer fetchSize) {
+            this.fetchSize = fetchSize;
+            this.__explicitlySet__.add("fetchSize");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rowLimit")
+        private Integer rowLimit;
+
+        public Builder rowLimit(Integer rowLimit) {
+            this.rowLimit = rowLimit;
+            this.__explicitlySet__.add("rowLimit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("offsetParameter")
+        private String offsetParameter;
+
+        public Builder offsetParameter(String offsetParameter) {
+            this.offsetParameter = offsetParameter;
+            this.__explicitlySet__.add("offsetParameter");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fetchNextRowsParameter")
+        private String fetchNextRowsParameter;
+
+        public Builder fetchNextRowsParameter(String fetchNextRowsParameter) {
+            this.fetchNextRowsParameter = fetchNextRowsParameter;
+            this.__explicitlySet__.add("fetchNextRowsParameter");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customParameters")
+        private java.util.List<BipReportParameterValue> customParameters;
+
+        public Builder customParameters(java.util.List<BipReportParameterValue> customParameters) {
+            this.customParameters = customParameters;
+            this.__explicitlySet__.add("customParameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stagingDataAsset")
+        private DataAssetSummaryFromObjectStorage stagingDataAsset;
+
+        public Builder stagingDataAsset(DataAssetSummaryFromObjectStorage stagingDataAsset) {
+            this.stagingDataAsset = stagingDataAsset;
+            this.__explicitlySet__.add("stagingDataAsset");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stagingConnection")
+        private ConnectionSummaryFromObjectStorage stagingConnection;
+
+        public Builder stagingConnection(ConnectionSummaryFromObjectStorage stagingConnection) {
+            this.stagingConnection = stagingConnection;
+            this.__explicitlySet__.add("stagingConnection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bucketSchema")
+        private Schema bucketSchema;
+
+        public Builder bucketSchema(Schema bucketSchema) {
+            this.bucketSchema = bucketSchema;
+            this.__explicitlySet__.add("bucketSchema");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BipReadAttributes build() {
+            BipReadAttributes __instance__ =
+                    new BipReadAttributes(
+                            fetchSize,
+                            rowLimit,
+                            offsetParameter,
+                            fetchNextRowsParameter,
+                            customParameters,
+                            stagingDataAsset,
+                            stagingConnection,
+                            bucketSchema);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BipReadAttributes o) {
+            Builder copiedBuilder =
+                    fetchSize(o.getFetchSize())
+                            .rowLimit(o.getRowLimit())
+                            .offsetParameter(o.getOffsetParameter())
+                            .fetchNextRowsParameter(o.getFetchNextRowsParameter())
+                            .customParameters(o.getCustomParameters())
+                            .stagingDataAsset(o.getStagingDataAsset())
+                            .stagingConnection(o.getStagingConnection())
+                            .bucketSchema(o.getBucketSchema());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BipReadAttributes(
+            Integer fetchSize,
+            Integer rowLimit,
+            String offsetParameter,
+            String fetchNextRowsParameter,
+            java.util.List<BipReportParameterValue> customParameters,
+            DataAssetSummaryFromObjectStorage stagingDataAsset,
+            ConnectionSummaryFromObjectStorage stagingConnection,
+            Schema bucketSchema) {
+        super();
+        this.fetchSize = fetchSize;
+        this.rowLimit = rowLimit;
+        this.offsetParameter = offsetParameter;
+        this.fetchNextRowsParameter = fetchNextRowsParameter;
+        this.customParameters = customParameters;
+        this.stagingDataAsset = stagingDataAsset;
+        this.stagingConnection = stagingConnection;
+        this.bucketSchema = bucketSchema;
+    }
+
+    /**
+     * The fetch size for reading.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fetchSize")
+    Integer fetchSize;
+
+    /**
+     * The maximum number of rows to read.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rowLimit")
+    Integer rowLimit;
+
+    /**
+     * Name of BIP report parameter to control the start of the chunk
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("offsetParameter")
+    String offsetParameter;
+
+    /**
+     * Name of BIP report parameter to control the start of the chunk
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fetchNextRowsParameter")
+    String fetchNextRowsParameter;
+
+    /**
+     * An array of custom BIP report parameters and their values.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customParameters")
+    java.util.List<BipReportParameterValue> customParameters;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stagingDataAsset")
+    DataAssetSummaryFromObjectStorage stagingDataAsset;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stagingConnection")
+    ConnectionSummaryFromObjectStorage stagingConnection;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("bucketSchema")
+    Schema bucketSchema;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/BipReportParameterValue.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/BipReportParameterValue.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Report parameter name and value to be passed for BIP Report extraction.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BipReportParameterValue.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BipReportParameterValue {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            this.__explicitlySet__.add("value");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BipReportParameterValue build() {
+            BipReportParameterValue __instance__ = new BipReportParameterValue(name, value);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BipReportParameterValue o) {
+            Builder copiedBuilder = name(o.getName()).value(o.getValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * BIP Report parameter name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * BIP Report parameter value.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    String value;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ChildReference.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ChildReference.java
@@ -189,6 +189,9 @@ public class ChildReference {
         OracleAdwcConnection("ORACLE_ADWC_CONNECTION"),
         MysqlConnection("MYSQL_CONNECTION"),
         GenericJdbcConnection("GENERIC_JDBC_CONNECTION"),
+        BipConnection("BIP_CONNECTION"),
+        BiccConnection("BICC_CONNECTION"),
+        AmazonS3Connection("AMAZON_S3_CONNECTION"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConditionalCompositeFieldMap.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConditionalCompositeFieldMap.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * A conditional composite field map.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ConditionalCompositeFieldMap.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ConditionalCompositeFieldMap extends FieldMap {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fieldMapScope")
+        private java.util.List<ProjectionRule> fieldMapScope;
+
+        public Builder fieldMapScope(java.util.List<ProjectionRule> fieldMapScope) {
+            this.fieldMapScope = fieldMapScope;
+            this.__explicitlySet__.add("fieldMapScope");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+        private ConfigValues configValues;
+
+        public Builder configValues(ConfigValues configValues) {
+            this.configValues = configValues;
+            this.__explicitlySet__.add("configValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fieldMaps")
+        private java.util.List<FieldMap> fieldMaps;
+
+        public Builder fieldMaps(java.util.List<FieldMap> fieldMaps) {
+            this.fieldMaps = fieldMaps;
+            this.__explicitlySet__.add("fieldMaps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ConditionalCompositeFieldMap build() {
+            ConditionalCompositeFieldMap __instance__ =
+                    new ConditionalCompositeFieldMap(
+                            description,
+                            fieldMapScope,
+                            key,
+                            modelVersion,
+                            parentRef,
+                            configValues,
+                            objectStatus,
+                            fieldMaps);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ConditionalCompositeFieldMap o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .fieldMapScope(o.getFieldMapScope())
+                            .key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .configValues(o.getConfigValues())
+                            .objectStatus(o.getObjectStatus())
+                            .fieldMaps(o.getFieldMaps());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ConditionalCompositeFieldMap(
+            String description,
+            java.util.List<ProjectionRule> fieldMapScope,
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            ConfigValues configValues,
+            Integer objectStatus,
+            java.util.List<FieldMap> fieldMaps) {
+        super(description);
+        this.fieldMapScope = fieldMapScope;
+        this.key = key;
+        this.modelVersion = modelVersion;
+        this.parentRef = parentRef;
+        this.configValues = configValues;
+        this.objectStatus = objectStatus;
+        this.fieldMaps = fieldMaps;
+    }
+
+    /**
+     * An array of projection rules.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fieldMapScope")
+    java.util.List<ProjectionRule> fieldMapScope;
+
+    /**
+     * The object key.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * The object's model version.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+    ConfigValues configValues;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * An array of field maps.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fieldMaps")
+    java.util.List<FieldMap> fieldMaps;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConditionalOutputPort.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConditionalOutputPort.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The conditional output port details, used in operators such as split.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ConditionalOutputPort.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ConditionalOutputPort extends TypedObject {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+        private ConfigValues configValues;
+
+        public Builder configValues(ConfigValues configValues) {
+            this.configValues = configValues;
+            this.__explicitlySet__.add("configValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("portType")
+        private PortType portType;
+
+        public Builder portType(PortType portType) {
+            this.portType = portType;
+            this.__explicitlySet__.add("portType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fields")
+        private java.util.List<TypedObject> fields;
+
+        public Builder fields(java.util.List<TypedObject> fields) {
+            this.fields = fields;
+            this.__explicitlySet__.add("fields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("splitCondition")
+        private Expression splitCondition;
+
+        public Builder splitCondition(Expression splitCondition) {
+            this.splitCondition = splitCondition;
+            this.__explicitlySet__.add("splitCondition");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ConditionalOutputPort build() {
+            ConditionalOutputPort __instance__ =
+                    new ConditionalOutputPort(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            configValues,
+                            objectStatus,
+                            name,
+                            description,
+                            portType,
+                            fields,
+                            splitCondition);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ConditionalOutputPort o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .configValues(o.getConfigValues())
+                            .objectStatus(o.getObjectStatus())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .portType(o.getPortType())
+                            .fields(o.getFields())
+                            .splitCondition(o.getSplitCondition());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ConditionalOutputPort(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            ConfigValues configValues,
+            Integer objectStatus,
+            String name,
+            String description,
+            PortType portType,
+            java.util.List<TypedObject> fields,
+            Expression splitCondition) {
+        super(key, modelVersion, parentRef, configValues, objectStatus, name, description);
+        this.portType = portType;
+        this.fields = fields;
+        this.splitCondition = splitCondition;
+    }
+
+    /**
+     * The port details for the data asset.Type.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PortType {
+        Data("DATA"),
+        Control("CONTROL"),
+        Model("MODEL"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PortType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PortType v : PortType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PortType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PortType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PortType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The port details for the data asset.Type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("portType")
+    PortType portType;
+
+    /**
+     * An array of fields.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fields")
+    java.util.List<TypedObject> fields;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("splitCondition")
+    Expression splitCondition;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Connection.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Connection.java
@@ -49,6 +49,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "AMAZON_S3_CONNECTION"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ConnectionFromBIP.class,
+        name = "BIP_CONNECTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ConnectionFromMySQL.class,
         name = "MYSQL_CONNECTION"
     ),
@@ -146,6 +150,7 @@ public class Connection {
         GenericJdbcConnection("GENERIC_JDBC_CONNECTION"),
         BiccConnection("BICC_CONNECTION"),
         AmazonS3Connection("AMAZON_S3_CONNECTION"),
+        BipConnection("BIP_CONNECTION"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionDetails.java
@@ -59,6 +59,10 @@ package com.oracle.bmc.dataintegration.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ConnectionFromOracleDetails.class,
         name = "ORACLEDB_CONNECTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ConnectionFromBipDetails.class,
+        name = "BIP_CONNECTION"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
@@ -139,6 +143,7 @@ public class ConnectionDetails {
         GenericJdbcConnection("GENERIC_JDBC_CONNECTION"),
         BiccConnection("BICC_CONNECTION"),
         AmazonS3Connection("AMAZON_S3_CONNECTION"),
+        BipConnection("BIP_CONNECTION"),
         ;
 
         private final String value;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromBIP.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromBIP.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The connection details for a Fusion applications BIP connection.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ConnectionFromBIP.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ConnectionFromBIP extends Connection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("primarySchema")
+        private Schema primarySchema;
+
+        public Builder primarySchema(Schema primarySchema) {
+            this.primarySchema = primarySchema;
+            this.__explicitlySet__.add("primarySchema");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionProperties")
+        private java.util.List<ConnectionProperty> connectionProperties;
+
+        public Builder connectionProperties(
+                java.util.List<ConnectionProperty> connectionProperties) {
+            this.connectionProperties = connectionProperties;
+            this.__explicitlySet__.add("connectionProperties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
+        private Boolean isDefault;
+
+        public Builder isDefault(Boolean isDefault) {
+            this.isDefault = isDefault;
+            this.__explicitlySet__.add("isDefault");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keyMap")
+        private java.util.Map<String, String> keyMap;
+
+        public Builder keyMap(java.util.Map<String, String> keyMap) {
+            this.keyMap = keyMap;
+            this.__explicitlySet__.add("keyMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ConnectionFromBIP build() {
+            ConnectionFromBIP __instance__ =
+                    new ConnectionFromBIP(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            primarySchema,
+                            connectionProperties,
+                            isDefault,
+                            metadata,
+                            keyMap,
+                            username,
+                            passwordSecret);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ConnectionFromBIP o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .primarySchema(o.getPrimarySchema())
+                            .connectionProperties(o.getConnectionProperties())
+                            .isDefault(o.getIsDefault())
+                            .metadata(o.getMetadata())
+                            .keyMap(o.getKeyMap())
+                            .username(o.getUsername())
+                            .passwordSecret(o.getPasswordSecret());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ConnectionFromBIP(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            Integer objectStatus,
+            String identifier,
+            Schema primarySchema,
+            java.util.List<ConnectionProperty> connectionProperties,
+            Boolean isDefault,
+            ObjectMetadata metadata,
+            java.util.Map<String, String> keyMap,
+            String username,
+            SensitiveAttribute passwordSecret) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                objectStatus,
+                identifier,
+                primarySchema,
+                connectionProperties,
+                isDefault,
+                metadata,
+                keyMap);
+        this.username = username;
+        this.passwordSecret = passwordSecret;
+    }
+
+    /**
+     * The user name for the connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromBipDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromBipDetails.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The connection details for a Fusion applications BIP connection.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ConnectionFromBipDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ConnectionFromBipDetails extends ConnectionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("primarySchema")
+        private Schema primarySchema;
+
+        public Builder primarySchema(Schema primarySchema) {
+            this.primarySchema = primarySchema;
+            this.__explicitlySet__.add("primarySchema");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionProperties")
+        private java.util.List<ConnectionProperty> connectionProperties;
+
+        public Builder connectionProperties(
+                java.util.List<ConnectionProperty> connectionProperties) {
+            this.connectionProperties = connectionProperties;
+            this.__explicitlySet__.add("connectionProperties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
+        private Boolean isDefault;
+
+        public Builder isDefault(Boolean isDefault) {
+            this.isDefault = isDefault;
+            this.__explicitlySet__.add("isDefault");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ConnectionFromBipDetails build() {
+            ConnectionFromBipDetails __instance__ =
+                    new ConnectionFromBipDetails(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            primarySchema,
+                            connectionProperties,
+                            isDefault,
+                            metadata,
+                            username,
+                            passwordSecret);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ConnectionFromBipDetails o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .primarySchema(o.getPrimarySchema())
+                            .connectionProperties(o.getConnectionProperties())
+                            .isDefault(o.getIsDefault())
+                            .metadata(o.getMetadata())
+                            .username(o.getUsername())
+                            .passwordSecret(o.getPasswordSecret());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ConnectionFromBipDetails(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            Integer objectStatus,
+            String identifier,
+            Schema primarySchema,
+            java.util.List<ConnectionProperty> connectionProperties,
+            Boolean isDefault,
+            ObjectMetadata metadata,
+            String username,
+            SensitiveAttribute passwordSecret) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                objectStatus,
+                identifier,
+                primarySchema,
+                connectionProperties,
+                isDefault,
+                metadata);
+        this.username = username;
+        this.passwordSecret = passwordSecret;
+    }
+
+    /**
+     * The user name for the connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummary.java
@@ -57,6 +57,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "MYSQL_CONNECTION"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ConnectionSummaryFromBIP.class,
+        name = "BIP_CONNECTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ConnectionSummaryFromObjectStorage.class,
         name = "ORACLE_OBJECT_STORAGE_CONNECTION"
     )
@@ -146,6 +150,7 @@ public class ConnectionSummary {
         GenericJdbcConnection("GENERIC_JDBC_CONNECTION"),
         BiccConnection("BICC_CONNECTION"),
         AmazonS3Connection("AMAZON_S3_CONNECTION"),
+        BipConnection("BIP_CONNECTION"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummaryFromBIP.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummaryFromBIP.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The connection summary details for a Fusion applications BIP connection.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ConnectionSummaryFromBIP.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ConnectionSummaryFromBIP extends ConnectionSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("primarySchema")
+        private Schema primarySchema;
+
+        public Builder primarySchema(Schema primarySchema) {
+            this.primarySchema = primarySchema;
+            this.__explicitlySet__.add("primarySchema");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionProperties")
+        private java.util.List<ConnectionProperty> connectionProperties;
+
+        public Builder connectionProperties(
+                java.util.List<ConnectionProperty> connectionProperties) {
+            this.connectionProperties = connectionProperties;
+            this.__explicitlySet__.add("connectionProperties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
+        private Boolean isDefault;
+
+        public Builder isDefault(Boolean isDefault) {
+            this.isDefault = isDefault;
+            this.__explicitlySet__.add("isDefault");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keyMap")
+        private java.util.Map<String, String> keyMap;
+
+        public Builder keyMap(java.util.Map<String, String> keyMap) {
+            this.keyMap = keyMap;
+            this.__explicitlySet__.add("keyMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ConnectionSummaryFromBIP build() {
+            ConnectionSummaryFromBIP __instance__ =
+                    new ConnectionSummaryFromBIP(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            primarySchema,
+                            connectionProperties,
+                            isDefault,
+                            metadata,
+                            keyMap,
+                            username,
+                            passwordSecret);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ConnectionSummaryFromBIP o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .primarySchema(o.getPrimarySchema())
+                            .connectionProperties(o.getConnectionProperties())
+                            .isDefault(o.getIsDefault())
+                            .metadata(o.getMetadata())
+                            .keyMap(o.getKeyMap())
+                            .username(o.getUsername())
+                            .passwordSecret(o.getPasswordSecret());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ConnectionSummaryFromBIP(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            Integer objectStatus,
+            String identifier,
+            Schema primarySchema,
+            java.util.List<ConnectionProperty> connectionProperties,
+            Boolean isDefault,
+            ObjectMetadata metadata,
+            java.util.Map<String, String> keyMap,
+            String username,
+            SensitiveAttribute passwordSecret) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                objectStatus,
+                identifier,
+                primarySchema,
+                connectionProperties,
+                isDefault,
+                metadata,
+                keyMap);
+        this.username = username;
+        this.passwordSecret = passwordSecret;
+    }
+
+    /**
+     * The user name for the connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionDetails.java
@@ -49,6 +49,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "ORACLE_ATP_CONNECTION"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateConnectionFromBIP.class,
+        name = "BIP_CONNECTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateConnectionFromAdwc.class,
         name = "ORACLE_ADWC_CONNECTION"
     ),
@@ -124,6 +128,7 @@ public class CreateConnectionDetails {
         GenericJdbcConnection("GENERIC_JDBC_CONNECTION"),
         BiccConnection("BICC_CONNECTION"),
         AmazonS3Connection("AMAZON_S3_CONNECTION"),
+        BipConnection("BIP_CONNECTION"),
         ;
 
         private final String value;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromBIP.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromBIP.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The details to create a Fusion applications BIP connection.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateConnectionFromBIP.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateConnectionFromBIP extends CreateConnectionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionProperties")
+        private java.util.List<ConnectionProperty> connectionProperties;
+
+        public Builder connectionProperties(
+                java.util.List<ConnectionProperty> connectionProperties) {
+            this.connectionProperties = connectionProperties;
+            this.__explicitlySet__.add("connectionProperties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("registryMetadata")
+        private RegistryMetadata registryMetadata;
+
+        public Builder registryMetadata(RegistryMetadata registryMetadata) {
+            this.registryMetadata = registryMetadata;
+            this.__explicitlySet__.add("registryMetadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateConnectionFromBIP build() {
+            CreateConnectionFromBIP __instance__ =
+                    new CreateConnectionFromBIP(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectStatus,
+                            identifier,
+                            connectionProperties,
+                            registryMetadata,
+                            username,
+                            passwordSecret);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateConnectionFromBIP o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .connectionProperties(o.getConnectionProperties())
+                            .registryMetadata(o.getRegistryMetadata())
+                            .username(o.getUsername())
+                            .passwordSecret(o.getPasswordSecret());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateConnectionFromBIP(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<ConnectionProperty> connectionProperties,
+            RegistryMetadata registryMetadata,
+            String username,
+            SensitiveAttribute passwordSecret) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectStatus,
+                identifier,
+                connectionProperties,
+                registryMetadata);
+        this.username = username;
+        this.passwordSecret = passwordSecret;
+    }
+
+    /**
+     * The user name for the connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateDataAssetFromFusionApp.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateDataAssetFromFusionApp.java
@@ -123,11 +123,38 @@ public class CreateDataAssetFromFusionApp extends CreateDataAssetDetails {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
-        private CreateConnectionFromBICC defaultConnection;
+        private CreateConnectionDetails defaultConnection;
 
-        public Builder defaultConnection(CreateConnectionFromBICC defaultConnection) {
+        public Builder defaultConnection(CreateConnectionDetails defaultConnection) {
             this.defaultConnection = defaultConnection;
             this.__explicitlySet__.add("defaultConnection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stagingDataAsset")
+        private DataAssetSummaryFromObjectStorage stagingDataAsset;
+
+        public Builder stagingDataAsset(DataAssetSummaryFromObjectStorage stagingDataAsset) {
+            this.stagingDataAsset = stagingDataAsset;
+            this.__explicitlySet__.add("stagingDataAsset");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stagingConnection")
+        private ConnectionSummaryFromObjectStorage stagingConnection;
+
+        public Builder stagingConnection(ConnectionSummaryFromObjectStorage stagingConnection) {
+            this.stagingConnection = stagingConnection;
+            this.__explicitlySet__.add("stagingConnection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bucketSchema")
+        private Schema bucketSchema;
+
+        public Builder bucketSchema(Schema bucketSchema) {
+            this.bucketSchema = bucketSchema;
+            this.__explicitlySet__.add("bucketSchema");
             return this;
         }
 
@@ -147,7 +174,10 @@ public class CreateDataAssetFromFusionApp extends CreateDataAssetDetails {
                             assetProperties,
                             registryMetadata,
                             serviceUrl,
-                            defaultConnection);
+                            defaultConnection,
+                            stagingDataAsset,
+                            stagingConnection,
+                            bucketSchema);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -165,7 +195,10 @@ public class CreateDataAssetFromFusionApp extends CreateDataAssetDetails {
                             .assetProperties(o.getAssetProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .serviceUrl(o.getServiceUrl())
-                            .defaultConnection(o.getDefaultConnection());
+                            .defaultConnection(o.getDefaultConnection())
+                            .stagingDataAsset(o.getStagingDataAsset())
+                            .stagingConnection(o.getStagingConnection())
+                            .bucketSchema(o.getBucketSchema());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -191,7 +224,10 @@ public class CreateDataAssetFromFusionApp extends CreateDataAssetDetails {
             java.util.Map<String, String> assetProperties,
             RegistryMetadata registryMetadata,
             String serviceUrl,
-            CreateConnectionFromBICC defaultConnection) {
+            CreateConnectionDetails defaultConnection,
+            DataAssetSummaryFromObjectStorage stagingDataAsset,
+            ConnectionSummaryFromObjectStorage stagingConnection,
+            Schema bucketSchema) {
         super(
                 key,
                 modelVersion,
@@ -204,6 +240,9 @@ public class CreateDataAssetFromFusionApp extends CreateDataAssetDetails {
                 registryMetadata);
         this.serviceUrl = serviceUrl;
         this.defaultConnection = defaultConnection;
+        this.stagingDataAsset = stagingDataAsset;
+        this.stagingConnection = stagingConnection;
+        this.bucketSchema = bucketSchema;
     }
 
     /**
@@ -213,7 +252,16 @@ public class CreateDataAssetFromFusionApp extends CreateDataAssetDetails {
     String serviceUrl;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
-    CreateConnectionFromBICC defaultConnection;
+    CreateConnectionDetails defaultConnection;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stagingDataAsset")
+    DataAssetSummaryFromObjectStorage stagingDataAsset;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stagingConnection")
+    ConnectionSummaryFromObjectStorage stagingConnection;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("bucketSchema")
+    Schema bucketSchema;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskFromDataLoaderTask.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskFromDataLoaderTask.java
@@ -158,6 +158,34 @@ public class CreateTaskFromDataLoaderTask extends CreateTaskDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+        private ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+        public Builder conditionalCompositeFieldMap(
+                ConditionalCompositeFieldMap conditionalCompositeFieldMap) {
+            this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+            this.__explicitlySet__.add("conditionalCompositeFieldMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+        private Boolean isSingleLoad;
+
+        public Builder isSingleLoad(Boolean isSingleLoad) {
+            this.isSingleLoad = isSingleLoad;
+            this.__explicitlySet__.add("isSingleLoad");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+        private Integer parallelLoadLimit;
+
+        public Builder parallelLoadLimit(Integer parallelLoadLimit) {
+            this.parallelLoadLimit = parallelLoadLimit;
+            this.__explicitlySet__.add("parallelLoadLimit");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -177,7 +205,10 @@ public class CreateTaskFromDataLoaderTask extends CreateTaskDetails {
                             opConfigValues,
                             configProviderDelegate,
                             registryMetadata,
-                            dataFlow);
+                            dataFlow,
+                            conditionalCompositeFieldMap,
+                            isSingleLoad,
+                            parallelLoadLimit);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -198,7 +229,10 @@ public class CreateTaskFromDataLoaderTask extends CreateTaskDetails {
                             .opConfigValues(o.getOpConfigValues())
                             .configProviderDelegate(o.getConfigProviderDelegate())
                             .registryMetadata(o.getRegistryMetadata())
-                            .dataFlow(o.getDataFlow());
+                            .dataFlow(o.getDataFlow())
+                            .conditionalCompositeFieldMap(o.getConditionalCompositeFieldMap())
+                            .isSingleLoad(o.getIsSingleLoad())
+                            .parallelLoadLimit(o.getParallelLoadLimit());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -227,7 +261,10 @@ public class CreateTaskFromDataLoaderTask extends CreateTaskDetails {
             ConfigValues opConfigValues,
             CreateConfigProvider configProviderDelegate,
             RegistryMetadata registryMetadata,
-            DataFlow dataFlow) {
+            DataFlow dataFlow,
+            ConditionalCompositeFieldMap conditionalCompositeFieldMap,
+            Boolean isSingleLoad,
+            Integer parallelLoadLimit) {
         super(
                 key,
                 modelVersion,
@@ -243,10 +280,28 @@ public class CreateTaskFromDataLoaderTask extends CreateTaskDetails {
                 configProviderDelegate,
                 registryMetadata);
         this.dataFlow = dataFlow;
+        this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+        this.isSingleLoad = isSingleLoad;
+        this.parallelLoadLimit = parallelLoadLimit;
     }
 
     @com.fasterxml.jackson.annotation.JsonProperty("dataFlow")
     DataFlow dataFlow;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+    ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+    /**
+     * Defines whether Data Loader task is used for single load or multiple
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+    Boolean isSingleLoad;
+
+    /**
+     * Defines the number of entities being loaded in parallel at a time for a Data Loader task
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+    Integer parallelLoadLimit;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataAssetFromFusionApp.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataAssetFromFusionApp.java
@@ -159,9 +159,9 @@ public class DataAssetFromFusionApp extends DataAsset {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
-        private ConnectionFromBICCDetails defaultConnection;
+        private ConnectionDetails defaultConnection;
 
-        public Builder defaultConnection(ConnectionFromBICCDetails defaultConnection) {
+        public Builder defaultConnection(ConnectionDetails defaultConnection) {
             this.defaultConnection = defaultConnection;
             this.__explicitlySet__.add("defaultConnection");
             return this;
@@ -239,7 +239,7 @@ public class DataAssetFromFusionApp extends DataAsset {
             ObjectMetadata metadata,
             java.util.Map<String, String> keyMap,
             String serviceUrl,
-            ConnectionFromBICCDetails defaultConnection) {
+            ConnectionDetails defaultConnection) {
         super(
                 key,
                 modelVersion,
@@ -265,7 +265,7 @@ public class DataAssetFromFusionApp extends DataAsset {
     String serviceUrl;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
-    ConnectionFromBICCDetails defaultConnection;
+    ConnectionDetails defaultConnection;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataAssetSummaryFromFusionApp.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataAssetSummaryFromFusionApp.java
@@ -150,11 +150,38 @@ public class DataAssetSummaryFromFusionApp extends DataAssetSummary {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
-        private ConnectionSummaryFromBICC defaultConnection;
+        private ConnectionSummary defaultConnection;
 
-        public Builder defaultConnection(ConnectionSummaryFromBICC defaultConnection) {
+        public Builder defaultConnection(ConnectionSummary defaultConnection) {
             this.defaultConnection = defaultConnection;
             this.__explicitlySet__.add("defaultConnection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stagingDataAsset")
+        private DataAssetSummaryFromObjectStorage stagingDataAsset;
+
+        public Builder stagingDataAsset(DataAssetSummaryFromObjectStorage stagingDataAsset) {
+            this.stagingDataAsset = stagingDataAsset;
+            this.__explicitlySet__.add("stagingDataAsset");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stagingConnection")
+        private ConnectionSummaryFromObjectStorage stagingConnection;
+
+        public Builder stagingConnection(ConnectionSummaryFromObjectStorage stagingConnection) {
+            this.stagingConnection = stagingConnection;
+            this.__explicitlySet__.add("stagingConnection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bucketSchema")
+        private Schema bucketSchema;
+
+        public Builder bucketSchema(Schema bucketSchema) {
+            this.bucketSchema = bucketSchema;
+            this.__explicitlySet__.add("bucketSchema");
             return this;
         }
 
@@ -177,7 +204,10 @@ public class DataAssetSummaryFromFusionApp extends DataAssetSummary {
                             parentRef,
                             metadata,
                             serviceUrl,
-                            defaultConnection);
+                            defaultConnection,
+                            stagingDataAsset,
+                            stagingConnection,
+                            bucketSchema);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -198,7 +228,10 @@ public class DataAssetSummaryFromFusionApp extends DataAssetSummary {
                             .parentRef(o.getParentRef())
                             .metadata(o.getMetadata())
                             .serviceUrl(o.getServiceUrl())
-                            .defaultConnection(o.getDefaultConnection());
+                            .defaultConnection(o.getDefaultConnection())
+                            .stagingDataAsset(o.getStagingDataAsset())
+                            .stagingConnection(o.getStagingConnection())
+                            .bucketSchema(o.getBucketSchema());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -227,7 +260,10 @@ public class DataAssetSummaryFromFusionApp extends DataAssetSummary {
             ParentReference parentRef,
             ObjectMetadata metadata,
             String serviceUrl,
-            ConnectionSummaryFromBICC defaultConnection) {
+            ConnectionSummary defaultConnection,
+            DataAssetSummaryFromObjectStorage stagingDataAsset,
+            ConnectionSummaryFromObjectStorage stagingConnection,
+            Schema bucketSchema) {
         super(
                 key,
                 modelVersion,
@@ -243,6 +279,9 @@ public class DataAssetSummaryFromFusionApp extends DataAssetSummary {
                 metadata);
         this.serviceUrl = serviceUrl;
         this.defaultConnection = defaultConnection;
+        this.stagingDataAsset = stagingDataAsset;
+        this.stagingConnection = stagingConnection;
+        this.bucketSchema = bucketSchema;
     }
 
     /**
@@ -252,7 +291,16 @@ public class DataAssetSummaryFromFusionApp extends DataAssetSummary {
     String serviceUrl;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
-    ConnectionSummaryFromBICC defaultConnection;
+    ConnectionSummary defaultConnection;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stagingDataAsset")
+    DataAssetSummaryFromObjectStorage stagingDataAsset;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stagingConnection")
+    ConnectionSummaryFromObjectStorage stagingConnection;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("bucketSchema")
+    Schema bucketSchema;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataEntity.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataEntity.java
@@ -65,6 +65,7 @@ public class DataEntity {
         FileEntity("FILE_ENTITY"),
         SqlEntity("SQL_ENTITY"),
         DataStoreEntity("DATA_STORE_ENTITY"),
+        DerivedEntity("DERIVED_ENTITY"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Distinct.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Distinct.java
@@ -94,9 +94,9 @@ public class Distinct extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -197,7 +197,7 @@ public class Distinct extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/EndOperator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/EndOperator.java
@@ -94,9 +94,9 @@ public class EndOperator extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -208,7 +208,7 @@ public class EndOperator extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ExpressionOperator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ExpressionOperator.java
@@ -96,9 +96,9 @@ public class ExpressionOperator extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -221,7 +221,7 @@ public class ExpressionOperator extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/FieldMap.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/FieldMap.java
@@ -33,12 +33,24 @@ package com.oracle.bmc.dataintegration.model;
         name = "RULE_BASED_FIELD_MAP"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = RuleBasedEntityMap.class,
+        name = "RULE_BASED_ENTITY_MAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = NamedEntityMap.class,
+        name = "NAMED_ENTITY_MAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = DirectFieldMap.class,
         name = "DIRECT_FIELD_MAP"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CompositeFieldMap.class,
         name = "COMPOSITE_FIELD_MAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ConditionalCompositeFieldMap.class,
+        name = "CONDITIONAL_COMPOSITE_FIELD_MAP"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = DirectNamedFieldMap.class,
@@ -63,6 +75,9 @@ public class FieldMap {
         CompositeFieldMap("COMPOSITE_FIELD_MAP"),
         DirectFieldMap("DIRECT_FIELD_MAP"),
         RuleBasedFieldMap("RULE_BASED_FIELD_MAP"),
+        ConditionalCompositeFieldMap("CONDITIONAL_COMPOSITE_FIELD_MAP"),
+        NamedEntityMap("NAMED_ENTITY_MAP"),
+        RuleBasedEntityMap("RULE_BASED_ENTITY_MAP"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Filter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Filter.java
@@ -94,9 +94,9 @@ public class Filter extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -208,7 +208,7 @@ public class Filter extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Flatten.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Flatten.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about a flatten object.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Flatten.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Flatten extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<TypedObject> outputPorts;
+
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flattenDetails")
+        private FlattenDetails flattenDetails;
+
+        public Builder flattenDetails(FlattenDetails flattenDetails) {
+            this.flattenDetails = flattenDetails;
+            this.__explicitlySet__.add("flattenDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flattenField")
+        private DynamicProxyField flattenField;
+
+        public Builder flattenField(DynamicProxyField flattenField) {
+            this.flattenField = flattenField;
+            this.__explicitlySet__.add("flattenField");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Flatten build() {
+            Flatten __instance__ =
+                    new Flatten(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            flattenDetails,
+                            flattenField);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Flatten o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .flattenDetails(o.getFlattenDetails())
+                            .flattenField(o.getFlattenField());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public Flatten(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<TypedObject> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            FlattenDetails flattenDetails,
+            DynamicProxyField flattenField) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.flattenDetails = flattenDetails;
+        this.flattenField = flattenField;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("flattenDetails")
+    FlattenDetails flattenDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("flattenField")
+    DynamicProxyField flattenField;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/FlattenDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/FlattenDetails.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Details for the flatten operator.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = FlattenDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class FlattenDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("flattenProjectionPreferences")
+        private FlattenProjectionPreferences flattenProjectionPreferences;
+
+        public Builder flattenProjectionPreferences(
+                FlattenProjectionPreferences flattenProjectionPreferences) {
+            this.flattenProjectionPreferences = flattenProjectionPreferences;
+            this.__explicitlySet__.add("flattenProjectionPreferences");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flattenAttributeRoot")
+        private String flattenAttributeRoot;
+
+        public Builder flattenAttributeRoot(String flattenAttributeRoot) {
+            this.flattenAttributeRoot = flattenAttributeRoot;
+            this.__explicitlySet__.add("flattenAttributeRoot");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flattenAttributePath")
+        private String flattenAttributePath;
+
+        public Builder flattenAttributePath(String flattenAttributePath) {
+            this.flattenAttributePath = flattenAttributePath;
+            this.__explicitlySet__.add("flattenAttributePath");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flattenColumns")
+        private java.util.List<TypedObject> flattenColumns;
+
+        public Builder flattenColumns(java.util.List<TypedObject> flattenColumns) {
+            this.flattenColumns = flattenColumns;
+            this.__explicitlySet__.add("flattenColumns");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FlattenDetails build() {
+            FlattenDetails __instance__ =
+                    new FlattenDetails(
+                            flattenProjectionPreferences,
+                            flattenAttributeRoot,
+                            flattenAttributePath,
+                            flattenColumns);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FlattenDetails o) {
+            Builder copiedBuilder =
+                    flattenProjectionPreferences(o.getFlattenProjectionPreferences())
+                            .flattenAttributeRoot(o.getFlattenAttributeRoot())
+                            .flattenAttributePath(o.getFlattenAttributePath())
+                            .flattenColumns(o.getFlattenColumns());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("flattenProjectionPreferences")
+    FlattenProjectionPreferences flattenProjectionPreferences;
+
+    /**
+     * The string of flatten attribute column name where the flatten process starts.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("flattenAttributeRoot")
+    String flattenAttributeRoot;
+
+    /**
+     * The string of flatten attribute path in flattenAttributeRoot from upper level to leaf/targeted level concatenated with dot(.)
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("flattenAttributePath")
+    String flattenAttributePath;
+
+    /**
+     * The array of flatten columns which are the input to flatten.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("flattenColumns")
+    java.util.List<TypedObject> flattenColumns;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/FlattenProjectionPreferences.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/FlattenProjectionPreferences.java
@@ -1,0 +1,306 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The preferences for the flatten operation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = FlattenProjectionPreferences.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class FlattenProjectionPreferences {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("createArrayIndex")
+        private CreateArrayIndex createArrayIndex;
+
+        public Builder createArrayIndex(CreateArrayIndex createArrayIndex) {
+            this.createArrayIndex = createArrayIndex;
+            this.__explicitlySet__.add("createArrayIndex");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retainAllAttributes")
+        private RetainAllAttributes retainAllAttributes;
+
+        public Builder retainAllAttributes(RetainAllAttributes retainAllAttributes) {
+            this.retainAllAttributes = retainAllAttributes;
+            this.__explicitlySet__.add("retainAllAttributes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ignoreNullValues")
+        private IgnoreNullValues ignoreNullValues;
+
+        public Builder ignoreNullValues(IgnoreNullValues ignoreNullValues) {
+            this.ignoreNullValues = ignoreNullValues;
+            this.__explicitlySet__.add("ignoreNullValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retainParentNameLineage")
+        private RetainParentNameLineage retainParentNameLineage;
+
+        public Builder retainParentNameLineage(RetainParentNameLineage retainParentNameLineage) {
+            this.retainParentNameLineage = retainParentNameLineage;
+            this.__explicitlySet__.add("retainParentNameLineage");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FlattenProjectionPreferences build() {
+            FlattenProjectionPreferences __instance__ =
+                    new FlattenProjectionPreferences(
+                            createArrayIndex,
+                            retainAllAttributes,
+                            ignoreNullValues,
+                            retainParentNameLineage);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FlattenProjectionPreferences o) {
+            Builder copiedBuilder =
+                    createArrayIndex(o.getCreateArrayIndex())
+                            .retainAllAttributes(o.getRetainAllAttributes())
+                            .ignoreNullValues(o.getIgnoreNullValues())
+                            .retainParentNameLineage(o.getRetainParentNameLineage());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Property defining whether to create array indexes in flattened result.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum CreateArrayIndex {
+        Allow("ALLOW"),
+        DoNotAllow("DO_NOT_ALLOW"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, CreateArrayIndex> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (CreateArrayIndex v : CreateArrayIndex.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        CreateArrayIndex(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static CreateArrayIndex create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'CreateArrayIndex', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Property defining whether to create array indexes in flattened result.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createArrayIndex")
+    CreateArrayIndex createArrayIndex;
+    /**
+     * Property defining whether to retain all attributes in flattened result.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum RetainAllAttributes {
+        Allow("ALLOW"),
+        DoNotAllow("DO_NOT_ALLOW"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, RetainAllAttributes> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RetainAllAttributes v : RetainAllAttributes.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        RetainAllAttributes(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RetainAllAttributes create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'RetainAllAttributes', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Property defining whether to retain all attributes in flattened result.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retainAllAttributes")
+    RetainAllAttributes retainAllAttributes;
+    /**
+     * Property defining whether to ignore null values in flattened result.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum IgnoreNullValues {
+        Allow("ALLOW"),
+        DoNotAllow("DO_NOT_ALLOW"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, IgnoreNullValues> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (IgnoreNullValues v : IgnoreNullValues.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        IgnoreNullValues(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static IgnoreNullValues create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'IgnoreNullValues', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Property defining whether to ignore null values in flattened result.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ignoreNullValues")
+    IgnoreNullValues ignoreNullValues;
+    /**
+     * Property defining whether to retain parent name lineage.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum RetainParentNameLineage {
+        Allow("ALLOW"),
+        DoNotAllow("DO_NOT_ALLOW"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, RetainParentNameLineage> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RetainParentNameLineage v : RetainParentNameLineage.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        RetainParentNameLineage(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RetainParentNameLineage create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'RetainParentNameLineage', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Property defining whether to retain parent name lineage.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retainParentNameLineage")
+    RetainParentNameLineage retainParentNameLineage;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Function.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Function.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The Function operator supports users adding a custom OCI Function into the data flow.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Function.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Function extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<TypedObject> outputPorts;
+
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ociFunction")
+        private OciFunction ociFunction;
+
+        public Builder ociFunction(OciFunction ociFunction) {
+            this.ociFunction = ociFunction;
+            this.__explicitlySet__.add("ociFunction");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Function build() {
+            Function __instance__ =
+                    new Function(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            ociFunction);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Function o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .ociFunction(o.getOciFunction());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public Function(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<TypedObject> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            OciFunction ociFunction) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.ociFunction = ociFunction;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("ociFunction")
+    OciFunction ociFunction;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Intersect.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Intersect.java
@@ -94,9 +94,9 @@ public class Intersect extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -219,7 +219,7 @@ public class Intersect extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Joiner.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Joiner.java
@@ -94,9 +94,9 @@ public class Joiner extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -219,7 +219,7 @@ public class Joiner extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Lookup.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Lookup.java
@@ -94,9 +94,9 @@ public class Lookup extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -241,7 +241,7 @@ public class Lookup extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/MacroPivotField.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/MacroPivotField.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * MacroPivotField is used for the PivotField with macro expressions. It can contain the rules according to the macro pattern/attribute added and create new fields according to the PivotKeyValues
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = MacroPivotField.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MacroPivotField {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isUseSourceType")
+        private Boolean isUseSourceType;
+
+        public Builder isUseSourceType(Boolean isUseSourceType) {
+            this.isUseSourceType = isUseSourceType;
+            this.__explicitlySet__.add("isUseSourceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expr")
+        private Expression expr;
+
+        public Builder expr(Expression expr) {
+            this.expr = expr;
+            this.__explicitlySet__.add("expr");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("useType")
+        private ConfiguredType useType;
+
+        public Builder useType(ConfiguredType useType) {
+            this.useType = useType;
+            this.__explicitlySet__.add("useType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private BaseType type;
+
+        public Builder type(BaseType type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("columnNamePattern")
+        private String columnNamePattern;
+
+        public Builder columnNamePattern(String columnNamePattern) {
+            this.columnNamePattern = columnNamePattern;
+            this.__explicitlySet__.add("columnNamePattern");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MacroPivotField build() {
+            MacroPivotField __instance__ =
+                    new MacroPivotField(isUseSourceType, expr, useType, type, columnNamePattern);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MacroPivotField o) {
+            Builder copiedBuilder =
+                    isUseSourceType(o.getIsUseSourceType())
+                            .expr(o.getExpr())
+                            .useType(o.getUseType())
+                            .type(o.getType())
+                            .columnNamePattern(o.getColumnNamePattern());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Specifies whether the type of macro fields is inferred from an expression or useType (false) or the source field (true).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isUseSourceType")
+    Boolean isUseSourceType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("expr")
+    Expression expr;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("useType")
+    ConfiguredType useType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    BaseType type;
+
+    /**
+     * column name pattern can be used to generate the name structure of the generated columns. By default column names are of %PIVOT_KEY_VALUE% or %MACRO_INPUT%_%PIVOT_KEY_VALUE%, but we can change it something by passing something like MY_PREFIX%PIVOT_KEY_VALUE%MY_SUFFIX or MY_PREFIX%MACRO_INPUT%_%PIVOT_KEY_VALUE%MY_SUFFIX which will add custom prefix and suffix to the column name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("columnNamePattern")
+    String columnNamePattern;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/MergeOperator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/MergeOperator.java
@@ -94,9 +94,9 @@ public class MergeOperator extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -208,7 +208,7 @@ public class MergeOperator extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Minus.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Minus.java
@@ -94,9 +94,9 @@ public class Minus extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -219,7 +219,7 @@ public class Minus extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/NamedEntityMap.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/NamedEntityMap.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * A named field map.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = NamedEntityMap.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NamedEntityMap extends FieldMap {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+        private ConfigValues configValues;
+
+        public Builder configValues(ConfigValues configValues) {
+            this.configValues = configValues;
+            this.__explicitlySet__.add("configValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceEntity")
+        private String sourceEntity;
+
+        public Builder sourceEntity(String sourceEntity) {
+            this.sourceEntity = sourceEntity;
+            this.__explicitlySet__.add("sourceEntity");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetEntity")
+        private String targetEntity;
+
+        public Builder targetEntity(String targetEntity) {
+            this.targetEntity = targetEntity;
+            this.__explicitlySet__.add("targetEntity");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NamedEntityMap build() {
+            NamedEntityMap __instance__ =
+                    new NamedEntityMap(
+                            description,
+                            key,
+                            modelVersion,
+                            parentRef,
+                            configValues,
+                            sourceEntity,
+                            targetEntity,
+                            objectStatus);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NamedEntityMap o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .configValues(o.getConfigValues())
+                            .sourceEntity(o.getSourceEntity())
+                            .targetEntity(o.getTargetEntity())
+                            .objectStatus(o.getObjectStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public NamedEntityMap(
+            String description,
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            ConfigValues configValues,
+            String sourceEntity,
+            String targetEntity,
+            Integer objectStatus) {
+        super(description);
+        this.key = key;
+        this.modelVersion = modelVersion;
+        this.parentRef = parentRef;
+        this.configValues = configValues;
+        this.sourceEntity = sourceEntity;
+        this.targetEntity = targetEntity;
+        this.objectStatus = objectStatus;
+    }
+
+    /**
+     * The object key.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * The object's model version.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+    ConfigValues configValues;
+
+    /**
+     * The source entity name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceEntity")
+    String sourceEntity;
+
+    /**
+     * The target entity name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetEntity")
+    String targetEntity;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/OciFunction.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/OciFunction.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about the OCI Function.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = OciFunction.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OciFunction {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("functionId")
+        private String functionId;
+
+        public Builder functionId(String functionId) {
+            this.functionId = functionId;
+            this.__explicitlySet__.add("functionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("regionId")
+        private String regionId;
+
+        public Builder regionId(String regionId) {
+            this.regionId = regionId;
+            this.__explicitlySet__.add("regionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fnConfigDefinition")
+        private ConfigDefinition fnConfigDefinition;
+
+        public Builder fnConfigDefinition(ConfigDefinition fnConfigDefinition) {
+            this.fnConfigDefinition = fnConfigDefinition;
+            this.__explicitlySet__.add("fnConfigDefinition");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputShape")
+        private Shape inputShape;
+
+        public Builder inputShape(Shape inputShape) {
+            this.inputShape = inputShape;
+            this.__explicitlySet__.add("inputShape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputShape")
+        private Shape outputShape;
+
+        public Builder outputShape(Shape outputShape) {
+            this.outputShape = outputShape;
+            this.__explicitlySet__.add("outputShape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OciFunction build() {
+            OciFunction __instance__ =
+                    new OciFunction(
+                            functionId, regionId, fnConfigDefinition, inputShape, outputShape);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OciFunction o) {
+            Builder copiedBuilder =
+                    functionId(o.getFunctionId())
+                            .regionId(o.getRegionId())
+                            .fnConfigDefinition(o.getFnConfigDefinition())
+                            .inputShape(o.getInputShape())
+                            .outputShape(o.getOutputShape());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Ocid of the OCI Function.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("functionId")
+    String functionId;
+
+    /**
+     * Region where the OCI Function is deployed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("regionId")
+    String regionId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("fnConfigDefinition")
+    ConfigDefinition fnConfigDefinition;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("inputShape")
+    Shape inputShape;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("outputShape")
+    Shape outputShape;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Operator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Operator.java
@@ -37,6 +37,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "TASK_OPERATOR"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Flatten.class,
+        name = "FLATTEN_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = Aggregator.class,
         name = "AGGREGATOR_OPERATOR"
     ),
@@ -65,6 +69,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "EXPRESSION_OPERATOR"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Function.class,
+        name = "FUNCTION_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = Intersect.class,
         name = "INTERSECT_OPERATOR"
     ),
@@ -85,12 +93,20 @@ package com.oracle.bmc.dataintegration.model;
         name = "LOOKUP_OPERATOR"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Pivot.class,
+        name = "PIVOT_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = StartOperator.class,
         name = "START_OPERATOR"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = MergeOperator.class,
         name = "MERGE_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Split.class,
+        name = "SPLIT_OPERATOR"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = Minus.class,
@@ -143,7 +159,7 @@ public class Operator {
      * An array of output ports.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-    java.util.List<OutputPort> outputPorts;
+    java.util.List<TypedObject> outputPorts;
 
     /**
      * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
@@ -177,18 +193,22 @@ public class Operator {
         AggregatorOperator("AGGREGATOR_OPERATOR"),
         ProjectionOperator("PROJECTION_OPERATOR"),
         TargetOperator("TARGET_OPERATOR"),
+        FlattenOperator("FLATTEN_OPERATOR"),
         DistinctOperator("DISTINCT_OPERATOR"),
         SortOperator("SORT_OPERATOR"),
         UnionOperator("UNION_OPERATOR"),
         IntersectOperator("INTERSECT_OPERATOR"),
         MinusOperator("MINUS_OPERATOR"),
         MergeOperator("MERGE_OPERATOR"),
+        FunctionOperator("FUNCTION_OPERATOR"),
+        SplitOperator("SPLIT_OPERATOR"),
         StartOperator("START_OPERATOR"),
         EndOperator("END_OPERATOR"),
         PipelineOperator("PIPELINE_OPERATOR"),
         TaskOperator("TASK_OPERATOR"),
         ExpressionOperator("EXPRESSION_OPERATOR"),
         LookupOperator("LOOKUP_OPERATOR"),
+        PivotOperator("PIVOT_OPERATOR"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Pivot.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Pivot.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Pivot operator has one input and one output. Pivot operator takes group by columns, a pivot key with values and aggregations. Output is the pivoted table.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Pivot.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Pivot extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<TypedObject> outputPorts;
+
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("groupByColumns")
+        private DynamicProxyField groupByColumns;
+
+        public Builder groupByColumns(DynamicProxyField groupByColumns) {
+            this.groupByColumns = groupByColumns;
+            this.__explicitlySet__.add("groupByColumns");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pivotKeys")
+        private PivotKeys pivotKeys;
+
+        public Builder pivotKeys(PivotKeys pivotKeys) {
+            this.pivotKeys = pivotKeys;
+            this.__explicitlySet__.add("pivotKeys");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Pivot build() {
+            Pivot __instance__ =
+                    new Pivot(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            groupByColumns,
+                            pivotKeys);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Pivot o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .groupByColumns(o.getGroupByColumns())
+                            .pivotKeys(o.getPivotKeys());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public Pivot(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<TypedObject> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            DynamicProxyField groupByColumns,
+            PivotKeys pivotKeys) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.groupByColumns = groupByColumns;
+        this.pivotKeys = pivotKeys;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("groupByColumns")
+    DynamicProxyField groupByColumns;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("pivotKeys")
+    PivotKeys pivotKeys;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PivotField.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PivotField.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The type representing the pivot field. Pivot fields have an expression to define a macro and a pattern to generate the column name
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PivotField.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PivotField extends TypedObject {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+        private ConfigValues configValues;
+
+        public Builder configValues(ConfigValues configValues) {
+            this.configValues = configValues;
+            this.__explicitlySet__.add("configValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expr")
+        private Expression expr;
+
+        public Builder expr(Expression expr) {
+            this.expr = expr;
+            this.__explicitlySet__.add("expr");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("useType")
+        private ConfiguredType useType;
+
+        public Builder useType(ConfiguredType useType) {
+            this.useType = useType;
+            this.__explicitlySet__.add("useType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private BaseType type;
+
+        public Builder type(BaseType type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("columnNamePattern")
+        private String columnNamePattern;
+
+        public Builder columnNamePattern(String columnNamePattern) {
+            this.columnNamePattern = columnNamePattern;
+            this.__explicitlySet__.add("columnNamePattern");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PivotField build() {
+            PivotField __instance__ =
+                    new PivotField(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            configValues,
+                            objectStatus,
+                            name,
+                            description,
+                            expr,
+                            useType,
+                            type,
+                            columnNamePattern);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PivotField o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .configValues(o.getConfigValues())
+                            .objectStatus(o.getObjectStatus())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .expr(o.getExpr())
+                            .useType(o.getUseType())
+                            .type(o.getType())
+                            .columnNamePattern(o.getColumnNamePattern());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PivotField(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            ConfigValues configValues,
+            Integer objectStatus,
+            String name,
+            String description,
+            Expression expr,
+            ConfiguredType useType,
+            BaseType type,
+            String columnNamePattern) {
+        super(key, modelVersion, parentRef, configValues, objectStatus, name, description);
+        this.expr = expr;
+        this.useType = useType;
+        this.type = type;
+        this.columnNamePattern = columnNamePattern;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("expr")
+    Expression expr;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("useType")
+    ConfiguredType useType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    BaseType type;
+
+    /**
+     * column name pattern can be used to generate the name structure of the generated columns. By default column names are of %PIVOT_KEY_VALUE% or %MACRO_INPUT%_%PIVOT_KEY_VALUE%, but we can change it something by passing something like MY_PREFIX%PIVOT_KEY_VALUE%MY_SUFFIX or MY_PREFIX%MACRO_INPUT%_%PIVOT_KEY_VALUE%MY_SUFFIX which will add custom prefix and suffix to the column name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("columnNamePattern")
+    String columnNamePattern;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PivotKeys.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PivotKeys.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The type representing the pivot key and pivot value details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PivotKeys.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PivotKeys {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("pivotAxis")
+        private java.util.List<String> pivotAxis;
+
+        public Builder pivotAxis(java.util.List<String> pivotAxis) {
+            this.pivotAxis = pivotAxis;
+            this.__explicitlySet__.add("pivotAxis");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pivotKeyValueMap")
+        private java.util.Map<String, java.util.List<String>> pivotKeyValueMap;
+
+        public Builder pivotKeyValueMap(
+                java.util.Map<String, java.util.List<String>> pivotKeyValueMap) {
+            this.pivotKeyValueMap = pivotKeyValueMap;
+            this.__explicitlySet__.add("pivotKeyValueMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PivotKeys build() {
+            PivotKeys __instance__ =
+                    new PivotKeys(
+                            pivotAxis,
+                            pivotKeyValueMap,
+                            key,
+                            modelType,
+                            modelVersion,
+                            parentRef,
+                            objectStatus);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PivotKeys o) {
+            Builder copiedBuilder =
+                    pivotAxis(o.getPivotAxis())
+                            .pivotKeyValueMap(o.getPivotKeyValueMap())
+                            .key(o.getKey())
+                            .modelType(o.getModelType())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .objectStatus(o.getObjectStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The pivot axis is the point around which the table will be rotated, and the pivot values will be transposed into columns in the output table.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("pivotAxis")
+    java.util.List<String> pivotAxis;
+
+    /**
+     * Map of alias to pivot key values.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("pivotKeyValueMap")
+    java.util.Map<String, java.util.List<String>> pivotKeyValueMap;
+
+    /**
+     * The key of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    /**
+     * The model version of an object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Projection.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Projection.java
@@ -94,9 +94,9 @@ public class Projection extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -197,7 +197,7 @@ public class Projection extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObjectFromDataLoaderTask.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObjectFromDataLoaderTask.java
@@ -158,6 +158,34 @@ public class PublishedObjectFromDataLoaderTask extends PublishedObject {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+        private ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+        public Builder conditionalCompositeFieldMap(
+                ConditionalCompositeFieldMap conditionalCompositeFieldMap) {
+            this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+            this.__explicitlySet__.add("conditionalCompositeFieldMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+        private Boolean isSingleLoad;
+
+        public Builder isSingleLoad(Boolean isSingleLoad) {
+            this.isSingleLoad = isSingleLoad;
+            this.__explicitlySet__.add("isSingleLoad");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+        private Integer parallelLoadLimit;
+
+        public Builder parallelLoadLimit(Integer parallelLoadLimit) {
+            this.parallelLoadLimit = parallelLoadLimit;
+            this.__explicitlySet__.add("parallelLoadLimit");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -177,7 +205,10 @@ public class PublishedObjectFromDataLoaderTask extends PublishedObject {
                             parameters,
                             opConfigValues,
                             configProviderDelegate,
-                            dataFlow);
+                            dataFlow,
+                            conditionalCompositeFieldMap,
+                            isSingleLoad,
+                            parallelLoadLimit);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -198,7 +229,10 @@ public class PublishedObjectFromDataLoaderTask extends PublishedObject {
                             .parameters(o.getParameters())
                             .opConfigValues(o.getOpConfigValues())
                             .configProviderDelegate(o.getConfigProviderDelegate())
-                            .dataFlow(o.getDataFlow());
+                            .dataFlow(o.getDataFlow())
+                            .conditionalCompositeFieldMap(o.getConditionalCompositeFieldMap())
+                            .isSingleLoad(o.getIsSingleLoad())
+                            .parallelLoadLimit(o.getParallelLoadLimit());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -227,7 +261,10 @@ public class PublishedObjectFromDataLoaderTask extends PublishedObject {
             java.util.List<Parameter> parameters,
             ConfigValues opConfigValues,
             ConfigProvider configProviderDelegate,
-            DataFlow dataFlow) {
+            DataFlow dataFlow,
+            ConditionalCompositeFieldMap conditionalCompositeFieldMap,
+            Boolean isSingleLoad,
+            Integer parallelLoadLimit) {
         super(
                 key,
                 modelVersion,
@@ -243,6 +280,9 @@ public class PublishedObjectFromDataLoaderTask extends PublishedObject {
         this.opConfigValues = opConfigValues;
         this.configProviderDelegate = configProviderDelegate;
         this.dataFlow = dataFlow;
+        this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+        this.isSingleLoad = isSingleLoad;
+        this.parallelLoadLimit = parallelLoadLimit;
     }
 
     /**
@@ -271,6 +311,21 @@ public class PublishedObjectFromDataLoaderTask extends PublishedObject {
 
     @com.fasterxml.jackson.annotation.JsonProperty("dataFlow")
     DataFlow dataFlow;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+    ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+    /**
+     * If true, defines a singular load.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+    Boolean isSingleLoad;
+
+    /**
+     * If not a singular load, this defines the number of entities being loaded in parallel at a time for a Data Loader task.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+    Integer parallelLoadLimit;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ReadOperationConfig.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ReadOperationConfig.java
@@ -32,6 +32,34 @@ public class ReadOperationConfig extends AbstractDataOperationConfig {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("metadataConfigProperties")
+        private java.util.Map<String, String> metadataConfigProperties;
+
+        public Builder metadataConfigProperties(
+                java.util.Map<String, String> metadataConfigProperties) {
+            this.metadataConfigProperties = metadataConfigProperties;
+            this.__explicitlySet__.add("metadataConfigProperties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("derivedAttributes")
+        private java.util.Map<String, String> derivedAttributes;
+
+        public Builder derivedAttributes(java.util.Map<String, String> derivedAttributes) {
+            this.derivedAttributes = derivedAttributes;
+            this.__explicitlySet__.add("derivedAttributes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("callAttribute")
+        private BipCallAttribute callAttribute;
+
+        public Builder callAttribute(BipCallAttribute callAttribute) {
+            this.callAttribute = callAttribute;
+            this.__explicitlySet__.add("callAttribute");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("key")
         private String key;
 
@@ -110,6 +138,9 @@ public class ReadOperationConfig extends AbstractDataOperationConfig {
         public ReadOperationConfig build() {
             ReadOperationConfig __instance__ =
                     new ReadOperationConfig(
+                            metadataConfigProperties,
+                            derivedAttributes,
+                            callAttribute,
                             key,
                             modelVersion,
                             parentRef,
@@ -125,7 +156,10 @@ public class ReadOperationConfig extends AbstractDataOperationConfig {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ReadOperationConfig o) {
             Builder copiedBuilder =
-                    key(o.getKey())
+                    metadataConfigProperties(o.getMetadataConfigProperties())
+                            .derivedAttributes(o.getDerivedAttributes())
+                            .callAttribute(o.getCallAttribute())
+                            .key(o.getKey())
                             .modelVersion(o.getModelVersion())
                             .parentRef(o.getParentRef())
                             .operations(o.getOperations())
@@ -148,6 +182,9 @@ public class ReadOperationConfig extends AbstractDataOperationConfig {
 
     @Deprecated
     public ReadOperationConfig(
+            java.util.Map<String, String> metadataConfigProperties,
+            java.util.Map<String, String> derivedAttributes,
+            BipCallAttribute callAttribute,
             String key,
             String modelVersion,
             ParentReference parentRef,
@@ -156,7 +193,7 @@ public class ReadOperationConfig extends AbstractDataOperationConfig {
             PartitionConfig partitionConfig,
             AbstractReadAttribute readAttribute,
             Integer objectStatus) {
-        super();
+        super(metadataConfigProperties, derivedAttributes, callAttribute);
         this.key = key;
         this.modelVersion = modelVersion;
         this.parentRef = parentRef;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Reference.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Reference.java
@@ -200,6 +200,15 @@ public class Reference {
         OracleAdwcDataAsset("ORACLE_ADWC_DATA_ASSET"),
         MysqlDataAsset("MYSQL_DATA_ASSET"),
         GenericJdbcDataAsset("GENERIC_JDBC_DATA_ASSET"),
+        FusionAppDataAsset("FUSION_APP_DATA_ASSET"),
+        AmazonS3DataAsset("AMAZON_S3_DATA_ASSET"),
+        Schema("SCHEMA"),
+        IntegrationTask("INTEGRATION_TASK"),
+        DataLoaderTask("DATA_LOADER_TASK"),
+        SqlTask("SQL_TASK"),
+        OciDataflowTask("OCI_DATAFLOW_TASK"),
+        PipelineTask("PIPELINE_TASK"),
+        RestTask("REST_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ReferenceSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ReferenceSummary.java
@@ -200,6 +200,15 @@ public class ReferenceSummary {
         OracleAdwcDataAsset("ORACLE_ADWC_DATA_ASSET"),
         MysqlDataAsset("MYSQL_DATA_ASSET"),
         GenericJdbcDataAsset("GENERIC_JDBC_DATA_ASSET"),
+        FusionAppDataAsset("FUSION_APP_DATA_ASSET"),
+        AmazonS3DataAsset("AMAZON_S3_DATA_ASSET"),
+        Schema("SCHEMA"),
+        IntegrationTask("INTEGRATION_TASK"),
+        DataLoaderTask("DATA_LOADER_TASK"),
+        SqlTask("SQL_TASK"),
+        OciDataflowTask("OCI_DATAFLOW_TASK"),
+        PipelineTask("PIPELINE_TASK"),
+        RestTask("REST_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/RuleBasedEntityMap.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/RuleBasedEntityMap.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * A map of rule patterns.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RuleBasedEntityMap.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RuleBasedEntityMap extends FieldMap {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+        private ConfigValues configValues;
+
+        public Builder configValues(ConfigValues configValues) {
+            this.configValues = configValues;
+            this.__explicitlySet__.add("configValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("mapType")
+        private MapType mapType;
+
+        public Builder mapType(MapType mapType) {
+            this.mapType = mapType;
+            this.__explicitlySet__.add("mapType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fromPattern")
+        private String fromPattern;
+
+        public Builder fromPattern(String fromPattern) {
+            this.fromPattern = fromPattern;
+            this.__explicitlySet__.add("fromPattern");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("toPattern")
+        private String toPattern;
+
+        public Builder toPattern(String toPattern) {
+            this.toPattern = toPattern;
+            this.__explicitlySet__.add("toPattern");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isJavaRegexSyntax")
+        private Boolean isJavaRegexSyntax;
+
+        public Builder isJavaRegexSyntax(Boolean isJavaRegexSyntax) {
+            this.isJavaRegexSyntax = isJavaRegexSyntax;
+            this.__explicitlySet__.add("isJavaRegexSyntax");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RuleBasedEntityMap build() {
+            RuleBasedEntityMap __instance__ =
+                    new RuleBasedEntityMap(
+                            description,
+                            key,
+                            modelVersion,
+                            parentRef,
+                            configValues,
+                            mapType,
+                            fromPattern,
+                            toPattern,
+                            isJavaRegexSyntax,
+                            objectStatus);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RuleBasedEntityMap o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .configValues(o.getConfigValues())
+                            .mapType(o.getMapType())
+                            .fromPattern(o.getFromPattern())
+                            .toPattern(o.getToPattern())
+                            .isJavaRegexSyntax(o.getIsJavaRegexSyntax())
+                            .objectStatus(o.getObjectStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public RuleBasedEntityMap(
+            String description,
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            ConfigValues configValues,
+            MapType mapType,
+            String fromPattern,
+            String toPattern,
+            Boolean isJavaRegexSyntax,
+            Integer objectStatus) {
+        super(description);
+        this.key = key;
+        this.modelVersion = modelVersion;
+        this.parentRef = parentRef;
+        this.configValues = configValues;
+        this.mapType = mapType;
+        this.fromPattern = fromPattern;
+        this.toPattern = toPattern;
+        this.isJavaRegexSyntax = isJavaRegexSyntax;
+        this.objectStatus = objectStatus;
+    }
+
+    /**
+     * The object key.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * The object's model version.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+    ConfigValues configValues;
+    /**
+     * mapType
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum MapType {
+        Mapbyname("MAPBYNAME"),
+        Mapbypattern("MAPBYPATTERN"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, MapType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (MapType v : MapType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        MapType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static MapType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'MapType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * mapType
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("mapType")
+    MapType mapType;
+
+    /**
+     * The pattern to map from.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fromPattern")
+    String fromPattern;
+
+    /**
+     * The pattern to map to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("toPattern")
+    String toPattern;
+
+    /**
+     * Specifies whether the rule uses a java regex syntax.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isJavaRegexSyntax")
+    Boolean isJavaRegexSyntax;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/SortOper.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/SortOper.java
@@ -94,9 +94,9 @@ public class SortOper extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -208,7 +208,7 @@ public class SortOper extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Source.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Source.java
@@ -94,9 +94,9 @@ public class Source extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -274,7 +274,7 @@ public class Source extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Split.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Split.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about the split operator. Split operator has one input and many output links. Split operator allows users to take one data set and based on conditions produce many different outputs.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Split.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Split extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<TypedObject> outputPorts;
+
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataRoutingStrategy")
+        private DataRoutingStrategy dataRoutingStrategy;
+
+        public Builder dataRoutingStrategy(DataRoutingStrategy dataRoutingStrategy) {
+            this.dataRoutingStrategy = dataRoutingStrategy;
+            this.__explicitlySet__.add("dataRoutingStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Split build() {
+            Split __instance__ =
+                    new Split(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            dataRoutingStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Split o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .dataRoutingStrategy(o.getDataRoutingStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public Split(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<TypedObject> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            DataRoutingStrategy dataRoutingStrategy) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.dataRoutingStrategy = dataRoutingStrategy;
+    }
+
+    /**
+     * Specify how to handle data that matches a split condition. Either data that matches the first condition should be removed from further processing by other conditions, or all matched data should be evaluated for all conditions.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DataRoutingStrategy {
+        First("FIRST"),
+        All("ALL"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DataRoutingStrategy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DataRoutingStrategy v : DataRoutingStrategy.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DataRoutingStrategy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DataRoutingStrategy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DataRoutingStrategy', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Specify how to handle data that matches a split condition. Either data that matches the first condition should be removed from further processing by other conditions, or all matched data should be evaluated for all conditions.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataRoutingStrategy")
+    DataRoutingStrategy dataRoutingStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/StartOperator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/StartOperator.java
@@ -94,9 +94,9 @@ public class StartOperator extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -197,7 +197,7 @@ public class StartOperator extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Target.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Target.java
@@ -94,9 +94,9 @@ public class Target extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -174,6 +174,33 @@ public class Target extends Operator {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isUseSameSourceName")
+        private Boolean isUseSameSourceName;
+
+        public Builder isUseSameSourceName(Boolean isUseSameSourceName) {
+            this.isUseSameSourceName = isUseSameSourceName;
+            this.__explicitlySet__.add("isUseSameSourceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetEntityNamePrefix")
+        private String targetEntityNamePrefix;
+
+        public Builder targetEntityNamePrefix(String targetEntityNamePrefix) {
+            this.targetEntityNamePrefix = targetEntityNamePrefix;
+            this.__explicitlySet__.add("targetEntityNamePrefix");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetEntityNameSuffix")
+        private String targetEntityNameSuffix;
+
+        public Builder targetEntityNameSuffix(String targetEntityNameSuffix) {
+            this.targetEntityNameSuffix = targetEntityNameSuffix;
+            this.__explicitlySet__.add("targetEntityNameSuffix");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dataProperty")
         private DataProperty dataProperty;
 
@@ -210,6 +237,15 @@ public class Target extends Operator {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("loadOrder")
+        private Integer loadOrder;
+
+        public Builder loadOrder(Integer loadOrder) {
+            this.loadOrder = loadOrder;
+            this.__explicitlySet__.add("loadOrder");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -232,10 +268,14 @@ public class Target extends Operator {
                             isReadAccess,
                             isCopyFields,
                             isPredefinedShape,
+                            isUseSameSourceName,
+                            targetEntityNamePrefix,
+                            targetEntityNameSuffix,
                             dataProperty,
                             schemaDriftConfig,
                             fixedDataShape,
-                            writeOperationConfig);
+                            writeOperationConfig,
+                            loadOrder);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -259,10 +299,14 @@ public class Target extends Operator {
                             .isReadAccess(o.getIsReadAccess())
                             .isCopyFields(o.getIsCopyFields())
                             .isPredefinedShape(o.getIsPredefinedShape())
+                            .isUseSameSourceName(o.getIsUseSameSourceName())
+                            .targetEntityNamePrefix(o.getTargetEntityNamePrefix())
+                            .targetEntityNameSuffix(o.getTargetEntityNameSuffix())
                             .dataProperty(o.getDataProperty())
                             .schemaDriftConfig(o.getSchemaDriftConfig())
                             .fixedDataShape(o.getFixedDataShape())
-                            .writeOperationConfig(o.getWriteOperationConfig());
+                            .writeOperationConfig(o.getWriteOperationConfig())
+                            .loadOrder(o.getLoadOrder());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -285,7 +329,7 @@ public class Target extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,
@@ -294,10 +338,14 @@ public class Target extends Operator {
             Boolean isReadAccess,
             Boolean isCopyFields,
             Boolean isPredefinedShape,
+            Boolean isUseSameSourceName,
+            String targetEntityNamePrefix,
+            String targetEntityNameSuffix,
             DataProperty dataProperty,
             SchemaDriftConfig schemaDriftConfig,
             Shape fixedDataShape,
-            WriteOperationConfig writeOperationConfig) {
+            WriteOperationConfig writeOperationConfig,
+            Integer loadOrder) {
         super(
                 key,
                 modelVersion,
@@ -315,10 +363,14 @@ public class Target extends Operator {
         this.isReadAccess = isReadAccess;
         this.isCopyFields = isCopyFields;
         this.isPredefinedShape = isPredefinedShape;
+        this.isUseSameSourceName = isUseSameSourceName;
+        this.targetEntityNamePrefix = targetEntityNamePrefix;
+        this.targetEntityNameSuffix = targetEntityNameSuffix;
         this.dataProperty = dataProperty;
         this.schemaDriftConfig = schemaDriftConfig;
         this.fixedDataShape = fixedDataShape;
         this.writeOperationConfig = writeOperationConfig;
+        this.loadOrder = loadOrder;
     }
 
     @com.fasterxml.jackson.annotation.JsonProperty("entity")
@@ -341,6 +393,24 @@ public class Target extends Operator {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPredefinedShape")
     Boolean isPredefinedShape;
+
+    /**
+     * Specifies if entity name is the same as source.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isUseSameSourceName")
+    Boolean isUseSameSourceName;
+
+    /**
+     * Prefix for the entity Name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetEntityNamePrefix")
+    String targetEntityNamePrefix;
+
+    /**
+     * Suffix for the entity Name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetEntityNameSuffix")
+    String targetEntityNameSuffix;
     /**
      * Specifies the data property.
      **/
@@ -405,6 +475,12 @@ public class Target extends Operator {
 
     @com.fasterxml.jackson.annotation.JsonProperty("writeOperationConfig")
     WriteOperationConfig writeOperationConfig;
+
+    /**
+     * A numeric loading order number for the target.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("loadOrder")
+    Integer loadOrder;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskFromDataLoaderTaskDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskFromDataLoaderTaskDetails.java
@@ -185,6 +185,34 @@ public class TaskFromDataLoaderTaskDetails extends Task {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+        private ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+        public Builder conditionalCompositeFieldMap(
+                ConditionalCompositeFieldMap conditionalCompositeFieldMap) {
+            this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+            this.__explicitlySet__.add("conditionalCompositeFieldMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+        private Boolean isSingleLoad;
+
+        public Builder isSingleLoad(Boolean isSingleLoad) {
+            this.isSingleLoad = isSingleLoad;
+            this.__explicitlySet__.add("isSingleLoad");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+        private Integer parallelLoadLimit;
+
+        public Builder parallelLoadLimit(Integer parallelLoadLimit) {
+            this.parallelLoadLimit = parallelLoadLimit;
+            this.__explicitlySet__.add("parallelLoadLimit");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -207,7 +235,10 @@ public class TaskFromDataLoaderTaskDetails extends Task {
                             metadata,
                             keyMap,
                             registryMetadata,
-                            dataFlow);
+                            dataFlow,
+                            conditionalCompositeFieldMap,
+                            isSingleLoad,
+                            parallelLoadLimit);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -231,7 +262,10 @@ public class TaskFromDataLoaderTaskDetails extends Task {
                             .metadata(o.getMetadata())
                             .keyMap(o.getKeyMap())
                             .registryMetadata(o.getRegistryMetadata())
-                            .dataFlow(o.getDataFlow());
+                            .dataFlow(o.getDataFlow())
+                            .conditionalCompositeFieldMap(o.getConditionalCompositeFieldMap())
+                            .isSingleLoad(o.getIsSingleLoad())
+                            .parallelLoadLimit(o.getParallelLoadLimit());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -263,7 +297,10 @@ public class TaskFromDataLoaderTaskDetails extends Task {
             ObjectMetadata metadata,
             java.util.Map<String, String> keyMap,
             RegistryMetadata registryMetadata,
-            DataFlow dataFlow) {
+            DataFlow dataFlow,
+            ConditionalCompositeFieldMap conditionalCompositeFieldMap,
+            Boolean isSingleLoad,
+            Integer parallelLoadLimit) {
         super(
                 key,
                 modelVersion,
@@ -282,10 +319,28 @@ public class TaskFromDataLoaderTaskDetails extends Task {
                 keyMap,
                 registryMetadata);
         this.dataFlow = dataFlow;
+        this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+        this.isSingleLoad = isSingleLoad;
+        this.parallelLoadLimit = parallelLoadLimit;
     }
 
     @com.fasterxml.jackson.annotation.JsonProperty("dataFlow")
     DataFlow dataFlow;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+    ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+    /**
+     * Defines whether Data Loader task is used for single load or multiple
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+    Boolean isSingleLoad;
+
+    /**
+     * Defines the number of entities being loaded in parallel at a time for a Data Loader task
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+    Integer parallelLoadLimit;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskOperator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskOperator.java
@@ -94,9 +94,9 @@ public class TaskOperator extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -296,7 +296,7 @@ public class TaskOperator extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRunDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRunDetails.java
@@ -195,6 +195,15 @@ public class TaskRunDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("inputs")
+        private java.util.Map<String, ParameterValue> inputs;
+
+        public Builder inputs(java.util.Map<String, ParameterValue> inputs) {
+            this.inputs = inputs;
+            this.__explicitlySet__.add("inputs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("metadata")
         private ObjectMetadata metadata;
 
@@ -229,6 +238,7 @@ public class TaskRunDetails {
                             refTaskRunId,
                             reRunType,
                             stepId,
+                            inputs,
                             metadata);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -256,6 +266,7 @@ public class TaskRunDetails {
                             .refTaskRunId(o.getRefTaskRunId())
                             .reRunType(o.getReRunType())
                             .stepId(o.getStepId())
+                            .inputs(o.getInputs())
                             .metadata(o.getMetadata());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -525,6 +536,12 @@ public class TaskRunDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("stepId")
     String stepId;
+
+    /**
+     * A map of the configuration provider input bindings of the run.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("inputs")
+    java.util.Map<String, ParameterValue> inputs;
 
     @com.fasterxml.jackson.annotation.JsonProperty("metadata")
     ObjectMetadata metadata;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRunSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRunSummary.java
@@ -195,6 +195,15 @@ public class TaskRunSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("inputs")
+        private java.util.Map<String, ParameterValue> inputs;
+
+        public Builder inputs(java.util.Map<String, ParameterValue> inputs) {
+            this.inputs = inputs;
+            this.__explicitlySet__.add("inputs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("metadata")
         private ObjectMetadata metadata;
 
@@ -229,6 +238,7 @@ public class TaskRunSummary {
                             refTaskRunId,
                             reRunType,
                             stepId,
+                            inputs,
                             metadata);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -256,6 +266,7 @@ public class TaskRunSummary {
                             .refTaskRunId(o.getRefTaskRunId())
                             .reRunType(o.getReRunType())
                             .stepId(o.getStepId())
+                            .inputs(o.getInputs())
                             .metadata(o.getMetadata());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -525,6 +536,12 @@ public class TaskRunSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("stepId")
     String stepId;
+
+    /**
+     * A map of the configuration provider input bindings of the run.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("inputs")
+    java.util.Map<String, ParameterValue> inputs;
 
     @com.fasterxml.jackson.annotation.JsonProperty("metadata")
     ObjectMetadata metadata;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskSummaryFromDataLoaderTask.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskSummaryFromDataLoaderTask.java
@@ -176,6 +176,34 @@ public class TaskSummaryFromDataLoaderTask extends TaskSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+        private ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+        public Builder conditionalCompositeFieldMap(
+                ConditionalCompositeFieldMap conditionalCompositeFieldMap) {
+            this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+            this.__explicitlySet__.add("conditionalCompositeFieldMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+        private Boolean isSingleLoad;
+
+        public Builder isSingleLoad(Boolean isSingleLoad) {
+            this.isSingleLoad = isSingleLoad;
+            this.__explicitlySet__.add("isSingleLoad");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+        private Integer parallelLoadLimit;
+
+        public Builder parallelLoadLimit(Integer parallelLoadLimit) {
+            this.parallelLoadLimit = parallelLoadLimit;
+            this.__explicitlySet__.add("parallelLoadLimit");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -197,7 +225,10 @@ public class TaskSummaryFromDataLoaderTask extends TaskSummary {
                             configProviderDelegate,
                             metadata,
                             keyMap,
-                            dataFlow);
+                            dataFlow,
+                            conditionalCompositeFieldMap,
+                            isSingleLoad,
+                            parallelLoadLimit);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -220,7 +251,10 @@ public class TaskSummaryFromDataLoaderTask extends TaskSummary {
                             .configProviderDelegate(o.getConfigProviderDelegate())
                             .metadata(o.getMetadata())
                             .keyMap(o.getKeyMap())
-                            .dataFlow(o.getDataFlow());
+                            .dataFlow(o.getDataFlow())
+                            .conditionalCompositeFieldMap(o.getConditionalCompositeFieldMap())
+                            .isSingleLoad(o.getIsSingleLoad())
+                            .parallelLoadLimit(o.getParallelLoadLimit());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -251,7 +285,10 @@ public class TaskSummaryFromDataLoaderTask extends TaskSummary {
             ConfigProvider configProviderDelegate,
             ObjectMetadata metadata,
             java.util.Map<String, String> keyMap,
-            DataFlow dataFlow) {
+            DataFlow dataFlow,
+            ConditionalCompositeFieldMap conditionalCompositeFieldMap,
+            Boolean isSingleLoad,
+            Integer parallelLoadLimit) {
         super(
                 key,
                 modelVersion,
@@ -269,10 +306,28 @@ public class TaskSummaryFromDataLoaderTask extends TaskSummary {
                 metadata,
                 keyMap);
         this.dataFlow = dataFlow;
+        this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+        this.isSingleLoad = isSingleLoad;
+        this.parallelLoadLimit = parallelLoadLimit;
     }
 
     @com.fasterxml.jackson.annotation.JsonProperty("dataFlow")
     DataFlow dataFlow;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+    ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+    /**
+     * Defines whether Data Loader task is used for single load or multiple
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+    Boolean isSingleLoad;
+
+    /**
+     * Defines the number of entities being loaded in parallel at a time for a Data Loader task
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+    Integer parallelLoadLimit;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TypedObject.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TypedObject.java
@@ -50,6 +50,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "INPUT_PORT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ConditionalOutputPort.class,
+        name = "CONDITIONAL_OUTPUT_PORT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ProxyField.class,
         name = "PROXY_FIELD"
     ),
@@ -64,6 +68,10 @@ package com.oracle.bmc.dataintegration.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = Parameter.class,
         name = "PARAMETER"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PivotField.class,
+        name = "PIVOT_FIELD"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = OutputField.class,
@@ -139,6 +147,9 @@ public class TypedObject {
         DynamicInputField("DYNAMIC_INPUT_FIELD"),
         ProxyField("PROXY_FIELD"),
         Parameter("PARAMETER"),
+        PivotField("PIVOT_FIELD"),
+        MacroPivotField("MACRO_PIVOT_FIELD"),
+        ConditionalOutputPort("CONDITIONAL_OUTPUT_PORT"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Union.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Union.java
@@ -94,9 +94,9 @@ public class Union extends Operator {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
-        private java.util.List<OutputPort> outputPorts;
+        private java.util.List<TypedObject> outputPorts;
 
-        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+        public Builder outputPorts(java.util.List<TypedObject> outputPorts) {
             this.outputPorts = outputPorts;
             this.__explicitlySet__.add("outputPorts");
             return this;
@@ -219,7 +219,7 @@ public class Union extends Operator {
             String description,
             Integer objectVersion,
             java.util.List<InputPort> inputPorts,
-            java.util.List<OutputPort> outputPorts,
+            java.util.List<TypedObject> outputPorts,
             Integer objectStatus,
             String identifier,
             java.util.List<Parameter> parameters,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionDetails.java
@@ -57,6 +57,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "ORACLE_ADWC_CONNECTION"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateConnectionFromBIP.class,
+        name = "BIP_CONNECTION"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateConnectionFromMySQL.class,
         name = "MYSQL_CONNECTION"
     )
@@ -130,6 +134,7 @@ public class UpdateConnectionDetails {
         GenericJdbcConnection("GENERIC_JDBC_CONNECTION"),
         BiccConnection("BICC_CONNECTION"),
         AmazonS3Connection("AMAZON_S3_CONNECTION"),
+        BipConnection("BIP_CONNECTION"),
         ;
 
         private final String value;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromBIP.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromBIP.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The details to update a Fusion applications BIP connection.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateConnectionFromBIP.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateConnectionFromBIP extends UpdateConnectionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionProperties")
+        private java.util.List<ConnectionProperty> connectionProperties;
+
+        public Builder connectionProperties(
+                java.util.List<ConnectionProperty> connectionProperties) {
+            this.connectionProperties = connectionProperties;
+            this.__explicitlySet__.add("connectionProperties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("registryMetadata")
+        private RegistryMetadata registryMetadata;
+
+        public Builder registryMetadata(RegistryMetadata registryMetadata) {
+            this.registryMetadata = registryMetadata;
+            this.__explicitlySet__.add("registryMetadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateConnectionFromBIP build() {
+            UpdateConnectionFromBIP __instance__ =
+                    new UpdateConnectionFromBIP(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectStatus,
+                            objectVersion,
+                            identifier,
+                            connectionProperties,
+                            registryMetadata,
+                            username,
+                            passwordSecret);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateConnectionFromBIP o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectStatus(o.getObjectStatus())
+                            .objectVersion(o.getObjectVersion())
+                            .identifier(o.getIdentifier())
+                            .connectionProperties(o.getConnectionProperties())
+                            .registryMetadata(o.getRegistryMetadata())
+                            .username(o.getUsername())
+                            .passwordSecret(o.getPasswordSecret());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateConnectionFromBIP(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectStatus,
+            Integer objectVersion,
+            String identifier,
+            java.util.List<ConnectionProperty> connectionProperties,
+            RegistryMetadata registryMetadata,
+            String username,
+            SensitiveAttribute passwordSecret) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectStatus,
+                objectVersion,
+                identifier,
+                connectionProperties,
+                registryMetadata);
+        this.username = username;
+        this.passwordSecret = passwordSecret;
+    }
+
+    /**
+     * The user name for the connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateReferenceDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateReferenceDetails.java
@@ -89,7 +89,7 @@ public class UpdateReferenceDetails {
     java.util.Map<String, String> options;
 
     /**
-     * The new target object to reference. This should be of type {@code DataAsset}. The child references can be of type {@code Connection}.
+     * The new target object to reference. This can be of type {@code DataAsset}, {@code Schema} or {@code Task}. In case of {@code DataAsset}, the child references can be of type {@code Connection}.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("targetObject")
     Object targetObject;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateTaskFromDataLoaderTask.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateTaskFromDataLoaderTask.java
@@ -167,6 +167,34 @@ public class UpdateTaskFromDataLoaderTask extends UpdateTaskDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+        private ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+        public Builder conditionalCompositeFieldMap(
+                ConditionalCompositeFieldMap conditionalCompositeFieldMap) {
+            this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+            this.__explicitlySet__.add("conditionalCompositeFieldMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+        private Boolean isSingleLoad;
+
+        public Builder isSingleLoad(Boolean isSingleLoad) {
+            this.isSingleLoad = isSingleLoad;
+            this.__explicitlySet__.add("isSingleLoad");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+        private Integer parallelLoadLimit;
+
+        public Builder parallelLoadLimit(Integer parallelLoadLimit) {
+            this.parallelLoadLimit = parallelLoadLimit;
+            this.__explicitlySet__.add("parallelLoadLimit");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -187,7 +215,10 @@ public class UpdateTaskFromDataLoaderTask extends UpdateTaskDetails {
                             opConfigValues,
                             configProviderDelegate,
                             registryMetadata,
-                            dataFlow);
+                            dataFlow,
+                            conditionalCompositeFieldMap,
+                            isSingleLoad,
+                            parallelLoadLimit);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -209,7 +240,10 @@ public class UpdateTaskFromDataLoaderTask extends UpdateTaskDetails {
                             .opConfigValues(o.getOpConfigValues())
                             .configProviderDelegate(o.getConfigProviderDelegate())
                             .registryMetadata(o.getRegistryMetadata())
-                            .dataFlow(o.getDataFlow());
+                            .dataFlow(o.getDataFlow())
+                            .conditionalCompositeFieldMap(o.getConditionalCompositeFieldMap())
+                            .isSingleLoad(o.getIsSingleLoad())
+                            .parallelLoadLimit(o.getParallelLoadLimit());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -239,7 +273,10 @@ public class UpdateTaskFromDataLoaderTask extends UpdateTaskDetails {
             ConfigValues opConfigValues,
             ConfigProvider configProviderDelegate,
             RegistryMetadata registryMetadata,
-            DataFlow dataFlow) {
+            DataFlow dataFlow,
+            ConditionalCompositeFieldMap conditionalCompositeFieldMap,
+            Boolean isSingleLoad,
+            Integer parallelLoadLimit) {
         super(
                 key,
                 modelVersion,
@@ -256,10 +293,28 @@ public class UpdateTaskFromDataLoaderTask extends UpdateTaskDetails {
                 configProviderDelegate,
                 registryMetadata);
         this.dataFlow = dataFlow;
+        this.conditionalCompositeFieldMap = conditionalCompositeFieldMap;
+        this.isSingleLoad = isSingleLoad;
+        this.parallelLoadLimit = parallelLoadLimit;
     }
 
     @com.fasterxml.jackson.annotation.JsonProperty("dataFlow")
     DataFlow dataFlow;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("conditionalCompositeFieldMap")
+    ConditionalCompositeFieldMap conditionalCompositeFieldMap;
+
+    /**
+     * Defines whether Data Loader task is used for single load or multiple
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSingleLoad")
+    Boolean isSingleLoad;
+
+    /**
+     * Defines the number of entities being loaded in parallel at a time for a Data Loader task
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parallelLoadLimit")
+    Integer parallelLoadLimit;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/WriteOperationConfig.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/WriteOperationConfig.java
@@ -32,6 +32,34 @@ public class WriteOperationConfig extends AbstractDataOperationConfig {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("metadataConfigProperties")
+        private java.util.Map<String, String> metadataConfigProperties;
+
+        public Builder metadataConfigProperties(
+                java.util.Map<String, String> metadataConfigProperties) {
+            this.metadataConfigProperties = metadataConfigProperties;
+            this.__explicitlySet__.add("metadataConfigProperties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("derivedAttributes")
+        private java.util.Map<String, String> derivedAttributes;
+
+        public Builder derivedAttributes(java.util.Map<String, String> derivedAttributes) {
+            this.derivedAttributes = derivedAttributes;
+            this.__explicitlySet__.add("derivedAttributes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("callAttribute")
+        private BipCallAttribute callAttribute;
+
+        public Builder callAttribute(BipCallAttribute callAttribute) {
+            this.callAttribute = callAttribute;
+            this.__explicitlySet__.add("callAttribute");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("key")
         private String key;
 
@@ -128,6 +156,9 @@ public class WriteOperationConfig extends AbstractDataOperationConfig {
         public WriteOperationConfig build() {
             WriteOperationConfig __instance__ =
                     new WriteOperationConfig(
+                            metadataConfigProperties,
+                            derivedAttributes,
+                            callAttribute,
                             key,
                             modelVersion,
                             parentRef,
@@ -145,7 +176,10 @@ public class WriteOperationConfig extends AbstractDataOperationConfig {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(WriteOperationConfig o) {
             Builder copiedBuilder =
-                    key(o.getKey())
+                    metadataConfigProperties(o.getMetadataConfigProperties())
+                            .derivedAttributes(o.getDerivedAttributes())
+                            .callAttribute(o.getCallAttribute())
+                            .key(o.getKey())
                             .modelVersion(o.getModelVersion())
                             .parentRef(o.getParentRef())
                             .operations(o.getOperations())
@@ -170,6 +204,9 @@ public class WriteOperationConfig extends AbstractDataOperationConfig {
 
     @Deprecated
     public WriteOperationConfig(
+            java.util.Map<String, String> metadataConfigProperties,
+            java.util.Map<String, String> derivedAttributes,
+            BipCallAttribute callAttribute,
             String key,
             String modelVersion,
             ParentReference parentRef,
@@ -180,7 +217,7 @@ public class WriteOperationConfig extends AbstractDataOperationConfig {
             WriteMode writeMode,
             UniqueKey mergeKey,
             Integer objectStatus) {
-        super();
+        super(metadataConfigProperties, derivedAttributes, callAttribute);
         this.key = key;
         this.modelVersion = modelVersion;
         this.parentRef = parentRef;

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/DataSafeRestAPIClientExample.java
+++ b/bmc-examples/src/main/java/DataSafeRestAPIClientExample.java
@@ -1,0 +1,280 @@
+
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+import com.oracle.bmc.http.internal.RestClientFactory;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.oracle.bmc.ConfigFileReader;
+import com.oracle.bmc.Region;
+
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.datasafe.DataSafeClient;
+import com.oracle.bmc.datasafe.model.AuditEventSummary;
+import com.oracle.bmc.datasafe.requests.ListAuditEventsRequest;
+import com.oracle.bmc.datasafe.responses.ListAuditEventsResponse;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.ObjectStorageClient;
+import com.oracle.bmc.objectstorage.requests.GetNamespaceRequest;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.requests.PutObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import com.oracle.bmc.objectstorage.transfer.UploadConfiguration;
+import com.oracle.bmc.objectstorage.transfer.UploadManager;
+
+public class DataSafeRestAPIClientExample {
+    /**
+     * The entry point for the example.
+     *
+     * @param args Arguments to provide to the example. The following arguments are
+     *             expected:
+     *             <ul>
+     *             <li>The first is the name of bucket where auditEvents from
+     *             DataSafe will be copied</li>
+     *             <li>The second argument is the OCID of the compartment only
+     *             auditEvents in specified compartment OCID and its subcompartments
+     *             for which the user has INSPECT permissions directly or
+     *             indirectly</li>
+     *             </ul>
+     */
+    String configurationFilePath = "~/.oci/config";
+    String profile = "DEFAULT";
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 2) {
+            throw new IllegalArgumentException(
+                    "Unexpected number of arguments received. Consult the script header comments for expected arguments");
+        }
+        String bucketName = args[0];
+        String compartmentId = args[1];
+
+        /**
+         * Configuring the AuthenticationDetailsProvider. It's assuming there is a
+         * default OCI config file "~/.oci/config", and a profile in that config with
+         * the name "DEFAULT". Make changes to the following line if needed and use
+         * ConfigFileReader.parse(CONFIG_LOCATION, CONFIG_PROFILE);
+         */
+        final ConfigFileReader.ConfigFile configFile = ConfigFileReader.parseDefault();
+
+        final ConfigFileAuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(configFile);
+
+        ObjectStorage objStoreClient = new ObjectStorageClient(provider);
+        objStoreClient.setRegion(Region.EU_FRANKFURT_1);
+        System.out.println("Getting the namespace\n\n");
+        com.oracle.bmc.objectstorage.responses.GetNamespaceResponse namespaceResponse =
+                objStoreClient.getNamespace(GetNamespaceRequest.builder().build());
+        String namespaceName = namespaceResponse.getValue();
+
+        System.out.println("Namespace: " + namespaceName + "\n\n"); // its tenancy name
+        /* Get the cursor object */
+
+        GetObjectRequest gor =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName("cursor")
+                        .build();
+        System.out.println(
+                "Getting content for object cursor " + " from bucket: " + bucketName + "\n\n");
+
+        String result = "FAILED";
+
+        try {
+            GetObjectResponse response = objStoreClient.getObject(gor);
+            result =
+                    new BufferedReader(new InputStreamReader(response.getInputStream()))
+                            .lines()
+                            .collect(Collectors.joining("\n"));
+        } catch (com.oracle.bmc.model.BmcException e) {
+            System.out.println("ignore");
+        }
+        System.out.println(
+                "Finished reading content for object cursor, last upload's last auditEvent record's timecollected "
+                        + result
+                        + "\n\n");
+
+        DataSafeClient datasafeClient = new DataSafeClient(provider);
+
+        ListAuditEventsResponse eventList = null;
+
+        long count = 0;
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        String endDate = dateFormat.format(Date.from(Instant.now()));
+        String strDate = null;
+        /*
+         * when no prev data is uploaded we start pushing from 1 day before collected
+         * data
+         */
+        if (result.equals("FAILED")) {
+
+            Calendar cal = Calendar.getInstance();
+            cal.add(Calendar.DATE, -1);
+            Date OnedayBefore = cal.getTime();
+
+            strDate = dateFormat.format(OnedayBefore);
+            System.out.println(strDate);
+
+            eventList =
+                    datasafeClient.listAuditEvents(
+                            ListAuditEventsRequest.builder()
+                                    .compartmentId(compartmentId)
+                                    .compartmentIdInSubtree(true)
+                                    .accessLevel(ListAuditEventsRequest.AccessLevel.Accessible)
+                                    .limit(10000)
+                                    .scimQuery(
+                                            "(timeCollected gt \""
+                                                    + strDate
+                                                    + "\") and (timeCollected le \""
+                                                    + endDate
+                                                    + "\")")
+                                    .sortOrder(ListAuditEventsRequest.SortOrder.Asc)
+                                    .sortBy(ListAuditEventsRequest.SortBy.TimeCollected)
+                                    .build());
+
+        } else {
+            Date date = dateFormat.parse(result);
+            strDate = dateFormat.format(date);
+            eventList =
+                    datasafeClient.listAuditEvents(
+                            ListAuditEventsRequest.builder()
+                                    .compartmentId(compartmentId)
+                                    .compartmentIdInSubtree(true)
+                                    .accessLevel(ListAuditEventsRequest.AccessLevel.Accessible)
+                                    .limit(10000)
+                                    .scimQuery(
+                                            "(timeCollected gt \""
+                                                    + strDate
+                                                    + "\") and (timeCollected le \""
+                                                    + endDate
+                                                    + "\")")
+                                    .build());
+        }
+        System.out.println(
+                "Querying for auditEvents with timeCollected Start = "
+                        + strDate
+                        + ", End = "
+                        + endDate
+                        + "\n\n");
+
+        System.out.println(
+                "Count" + eventList.getAuditEventCollection().getItems().size() + "\n\n");
+        if (eventList.getAuditEventCollection().getItems().size() > 0) {
+            ObjectMapper mapper = RestClientFactory.getObjectMapper();
+            StringBuffer sb = new StringBuffer();
+            AtomicBoolean isFirst = new AtomicBoolean(true);
+            count = eventList.getAuditEventCollection().getItems().size();
+            eventList
+                    .getAuditEventCollection()
+                    .getItems()
+                    .forEach(
+                            it -> {
+                                try {
+                                    if (isFirst.get()) {
+                                        isFirst.set(false);
+                                    } else {
+                                        sb.append("\n");
+                                    }
+                                    sb.append(mapper.writeValueAsString(it));
+
+                                } catch (JsonProcessingException e) {
+                                    e.printStackTrace();
+                                }
+                            });
+            if (count > 0)
+                uploadtoOS(
+                        "auditeventjson"
+                                + Instant.now()
+                                + " _noofrecords_ "
+                                + count
+                                + " Start ="
+                                + strDate
+                                + ", End="
+                                + endDate,
+                        sb.toString(),
+                        bucketName,
+                        namespaceName);
+        }
+        if (count >= 1) {
+            AuditEventSummary lastrecord =
+                    eventList.getAuditEventCollection().getItems().get((int) (count - 1));
+            // upload the lastrecord's timecollected so that we start the next run's push to
+            // after that
+            uploadtoOS(
+                    "cursor",
+                    dateFormat.format(lastrecord.getTimeCollected()),
+                    bucketName,
+                    namespaceName);
+        }
+        objStoreClient.close();
+        datasafeClient.close();
+    }
+
+    private static void uploadtoOS(
+            String fileName, String value, String bucketName, String namespaceName)
+            throws Exception {
+        final ConfigFileReader.ConfigFile configFile = ConfigFileReader.parseDefault();
+
+        final ConfigFileAuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(configFile);
+        ObjectStorage client = new ObjectStorageClient(provider);
+
+        client.setRegion(Region.EU_FRANKFURT_1);
+        byte[] byteVal = value.getBytes(StandardCharsets.UTF_8);
+
+        UploadConfiguration uploadConfiguration =
+                UploadConfiguration.builder()
+                        .allowMultipartUploads(false)
+                        .allowParallelUploads(true)
+                        .build();
+        UploadManager uploadManager = new UploadManager(client, uploadConfiguration);
+
+        Map<String, String> metaData = new HashMap<>();
+        metaData.put("RequestId", "datasafeAuditEvents" + Instant.now());
+        PutObjectRequest request =
+                PutObjectRequest.builder()
+                        .opcMeta(metaData)
+                        .bucketName(bucketName)
+                        .namespaceName(namespaceName)
+                        .objectName(fileName)
+                        .contentType("text/plain")
+                        .contentLanguage("en")
+                        .contentEncoding("utf-8")
+                        .build();
+
+        UploadManager.UploadRequest uploadDetails =
+                UploadManager.UploadRequest.builder(
+                                new ByteArrayInputStream(byteVal), byteVal.length)
+                        .allowOverwrite(true)
+                        .build(request);
+        UploadManager.UploadResponse response = uploadManager.upload(uploadDetails);
+        System.out.println(
+                "Upload complete at  "
+                        + new Date()
+                        + " of "
+                        + fileName
+                        + "  OpcRequestId: "
+                        + response.getOpcRequestId()
+                        + "\n\n");
+    }
+}

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.26.0</version>
+        <version>2.27.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identitydataplane/pom.xml
+++ b/bmc-identitydataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-identitydataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/Channels.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/Channels.java
@@ -52,7 +52,7 @@ public interface Channels extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/CreateChannelExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateChannel API.
@@ -64,7 +64,7 @@ public interface Channels extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/DeleteChannelExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteChannel API.
@@ -79,7 +79,7 @@ public interface Channels extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GetChannelExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetChannel API.
@@ -91,7 +91,7 @@ public interface Channels extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ListChannelsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListChannels API.
@@ -105,7 +105,7 @@ public interface Channels extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ResetChannelExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ResetChannel API.
@@ -120,7 +120,7 @@ public interface Channels extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ResumeChannelExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ResumeChannel API.
@@ -136,7 +136,7 @@ public interface Channels extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/UpdateChannelExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateChannel API.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsClient.java
@@ -472,7 +472,7 @@ public class ChannelsClient implements Channels {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -508,7 +508,7 @@ public class ChannelsClient implements Channels {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Channels",
@@ -542,7 +542,7 @@ public class ChannelsClient implements Channels {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Channels",
@@ -576,7 +576,7 @@ public class ChannelsClient implements Channels {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Channels",
@@ -610,7 +610,7 @@ public class ChannelsClient implements Channels {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -646,7 +646,7 @@ public class ChannelsClient implements Channels {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -682,7 +682,7 @@ public class ChannelsClient implements Channels {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackups.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackups.java
@@ -66,7 +66,7 @@ public interface DbBackups extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/CreateBackupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateBackup API.
@@ -79,7 +79,7 @@ public interface DbBackups extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/DeleteBackupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteBackup API.
@@ -91,7 +91,7 @@ public interface DbBackups extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GetBackupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetBackup API.
@@ -104,7 +104,7 @@ public interface DbBackups extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ListBackupsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListBackups API.
@@ -116,7 +116,7 @@ public interface DbBackups extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/UpdateBackupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateBackup API.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackupsClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackupsClient.java
@@ -512,7 +512,7 @@ public class DbBackupsClient implements DbBackups {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -551,7 +551,7 @@ public class DbBackupsClient implements DbBackups {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbBackups",
@@ -585,7 +585,7 @@ public class DbBackupsClient implements DbBackups {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbBackups",
@@ -619,7 +619,7 @@ public class DbBackupsClient implements DbBackups {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbBackups",
@@ -653,7 +653,7 @@ public class DbBackupsClient implements DbBackups {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbBackups",

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystem.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystem.java
@@ -53,7 +53,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/AddAnalyticsClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use AddAnalyticsCluster API.
@@ -66,7 +66,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/AddHeatWaveClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use AddHeatWaveCluster API.
@@ -79,7 +79,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/CreateDbSystemExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateDbSystem API.
@@ -94,7 +94,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/DeleteAnalyticsClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteAnalyticsCluster API.
@@ -108,7 +108,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/DeleteDbSystemExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteDbSystem API.
@@ -122,7 +122,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/DeleteHeatWaveClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteHeatWaveCluster API.
@@ -136,7 +136,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GenerateAnalyticsClusterMemoryEstimateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GenerateAnalyticsClusterMemoryEstimate API.
@@ -150,7 +150,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GenerateHeatWaveClusterMemoryEstimateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GenerateHeatWaveClusterMemoryEstimate API.
@@ -165,7 +165,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GetAnalyticsClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAnalyticsCluster API.
@@ -180,7 +180,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GetAnalyticsClusterMemoryEstimateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAnalyticsClusterMemoryEstimate API.
@@ -193,7 +193,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GetDbSystemExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetDbSystem API.
@@ -205,7 +205,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GetHeatWaveClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetHeatWaveCluster API.
@@ -219,7 +219,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GetHeatWaveClusterMemoryEstimateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetHeatWaveClusterMemoryEstimate API.
@@ -234,7 +234,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ListDbSystemsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDbSystems API.
@@ -248,7 +248,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/RestartAnalyticsClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RestartAnalyticsCluster API.
@@ -260,7 +260,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/RestartDbSystemExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RestartDbSystem API.
@@ -272,7 +272,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/RestartHeatWaveClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RestartHeatWaveCluster API.
@@ -286,7 +286,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/StartAnalyticsClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use StartAnalyticsCluster API.
@@ -298,7 +298,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/StartDbSystemExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use StartDbSystem API.
@@ -310,7 +310,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/StartHeatWaveClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use StartHeatWaveCluster API.
@@ -324,7 +324,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/StopAnalyticsClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use StopAnalyticsCluster API.
@@ -339,7 +339,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/StopDbSystemExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use StopDbSystem API.
@@ -351,7 +351,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/StopHeatWaveClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use StopHeatWaveCluster API.
@@ -365,7 +365,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/UpdateAnalyticsClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateAnalyticsCluster API.
@@ -385,7 +385,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/UpdateDbSystemExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateDbSystem API.
@@ -398,7 +398,7 @@ public interface DbSystem extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/UpdateHeatWaveClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateHeatWaveCluster API.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemClient.java
@@ -472,7 +472,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -511,7 +511,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -550,7 +550,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -587,7 +587,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -622,7 +622,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -658,7 +658,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -696,7 +696,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -735,7 +735,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -771,7 +771,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -807,7 +807,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -841,7 +841,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -875,7 +875,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -911,7 +911,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -945,7 +945,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -980,7 +980,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1016,7 +1016,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1056,7 +1056,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1093,7 +1093,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1129,7 +1129,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1165,7 +1165,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1201,7 +1201,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1237,7 +1237,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1276,7 +1276,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1313,7 +1313,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -1351,7 +1351,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",
@@ -1390,7 +1390,7 @@ public class DbSystemClient implements DbSystem {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "DbSystem",

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/Mysqlaas.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/Mysqlaas.java
@@ -65,7 +65,7 @@ public interface Mysqlaas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/DeleteConfigurationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteConfiguration API.
@@ -78,7 +78,7 @@ public interface Mysqlaas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GetConfigurationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetConfiguration API.
@@ -98,7 +98,7 @@ public interface Mysqlaas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ListConfigurationsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListConfigurations API.
@@ -114,7 +114,7 @@ public interface Mysqlaas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ListShapesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListShapes API.
@@ -129,7 +129,7 @@ public interface Mysqlaas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ListVersionsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListVersions API.
@@ -141,7 +141,7 @@ public interface Mysqlaas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/UpdateConfigurationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateConfiguration API.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/MysqlaasClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/MysqlaasClient.java
@@ -508,7 +508,7 @@ public class MysqlaasClient implements Mysqlaas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Mysqlaas",
@@ -543,7 +543,7 @@ public class MysqlaasClient implements Mysqlaas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Mysqlaas",
@@ -577,7 +577,7 @@ public class MysqlaasClient implements Mysqlaas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Mysqlaas",
@@ -610,7 +610,7 @@ public class MysqlaasClient implements Mysqlaas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Mysqlaas",
@@ -644,7 +644,7 @@ public class MysqlaasClient implements Mysqlaas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Mysqlaas",
@@ -678,7 +678,7 @@ public class MysqlaasClient implements Mysqlaas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Mysqlaas",

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/WorkRequests.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/WorkRequests.java
@@ -51,7 +51,7 @@ public interface WorkRequests extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
@@ -64,7 +64,7 @@ public interface WorkRequests extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestErrors API.
@@ -77,7 +77,7 @@ public interface WorkRequests extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestLogs API.
@@ -90,7 +90,7 @@ public interface WorkRequests extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/WorkRequestsClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/WorkRequestsClient.java
@@ -472,7 +472,7 @@ public class WorkRequestsClient implements WorkRequests {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "WorkRequests",
@@ -507,7 +507,7 @@ public class WorkRequestsClient implements WorkRequests {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "WorkRequests",
@@ -541,7 +541,7 @@ public class WorkRequestsClient implements WorkRequests {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "WorkRequests",
@@ -575,7 +575,7 @@ public class WorkRequestsClient implements WorkRequests {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "WorkRequests",

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystem.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystem.java
@@ -458,8 +458,7 @@ public class DbSystem {
     String subnetId;
 
     /**
-     * If the policy is to enable high availability of the instance, by
-     * maintaining secondary/failover capacity as necessary.
+     * Specifies if the DB System is highly available.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isHighlyAvailable")

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSnapshot.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSnapshot.java
@@ -434,8 +434,7 @@ public class DbSystemSnapshot {
     Integer portX;
 
     /**
-     * If the policy is to enable high availability of the instance, by
-     * maintaining secondary/failover capacity as necessary.
+     * Specifies if the DB System is highly available.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isHighlyAvailable")

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSummary.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSummary.java
@@ -308,8 +308,7 @@ public class DbSystemSummary {
     String compartmentId;
 
     /**
-     * If the policy is to enable high availability of the instance, by
-     * maintaining secondary/failover capacity as necessary.
+     * Specifies if the DB System is highly available.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isHighlyAvailable")

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateDbSystemDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateDbSystemDetails.java
@@ -316,8 +316,12 @@ public class UpdateDbSystemDetails {
     String subnetId;
 
     /**
-     * If the policy is to enable high availability of the instance, by
-     * maintaining secondary/failover capacity as necessary.
+     * Specifies if the DB System is highly available.
+     * <p>
+     * Set to true to enable high availability. Two secondary MySQL instances are created and placed in the unused
+     * availability or fault domains, depending on your region and subnet type.
+     * Set to false to disable high availability. The secondary MySQL instances are removed and the MySQL instance
+     * in the preferred location is used.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isHighlyAvailable")

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ospgateway/pom.xml
+++ b/bmc-ospgateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ospgateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubbillingschedule/pom.xml
+++ b/bmc-osubbillingschedule/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osuborganizationsubscription/pom.xml
+++ b/bmc-osuborganizationsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubsubscription/pom.xml
+++ b/bmc-osubsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubusage/pom.xml
+++ b/bmc-osubusage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubusage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemanagerproxy/pom.xml
+++ b/bmc-servicemanagerproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemesh/pom.xml
+++ b/bmc-servicemesh/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemesh</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-stackmonitoring/pom.xml
+++ b/bmc-stackmonitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-stackmonitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/StackMonitoring.java
+++ b/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/StackMonitoring.java
@@ -103,7 +103,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/DeleteDiscoveryJobExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteDiscoveryJob API.
@@ -154,7 +154,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/GetDiscoveryJobExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetDiscoveryJob API.
@@ -166,7 +166,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/GetMonitoredResourceExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetMonitoredResource API.
@@ -178,7 +178,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
@@ -191,7 +191,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/ListDiscoveryJobLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDiscoveryJobLogs API.
@@ -204,7 +204,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/ListDiscoveryJobsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDiscoveryJobs API.
@@ -217,7 +217,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestErrors API.
@@ -230,7 +230,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestLogs API.
@@ -243,7 +243,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.
@@ -255,7 +255,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/SearchMonitoredResourceAssociationsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SearchMonitoredResourceAssociations API.
@@ -268,7 +268,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/SearchMonitoredResourceMembersExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SearchMonitoredResourceMembers API.
@@ -281,7 +281,7 @@ public interface StackMonitoring extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/stackmonitoring/SearchMonitoredResourcesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SearchMonitoredResources API.

--- a/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/StackMonitoringClient.java
+++ b/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/StackMonitoringClient.java
@@ -636,7 +636,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "StackMonitoring",
@@ -786,7 +786,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "StackMonitoring",
@@ -820,7 +820,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "StackMonitoring",
@@ -854,7 +854,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "StackMonitoring",
@@ -888,7 +888,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "StackMonitoring",
@@ -922,7 +922,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "StackMonitoring",
@@ -957,7 +957,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "StackMonitoring",
@@ -991,7 +991,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "StackMonitoring",
@@ -1025,7 +1025,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "StackMonitoring",
@@ -1062,7 +1062,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1104,7 +1104,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
@@ -1145,7 +1145,7 @@ public class StackMonitoringClient implements StackMonitoring {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(

--- a/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/model/WorkRequest.java
+++ b/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/model/WorkRequest.java
@@ -171,7 +171,7 @@ public class WorkRequest {
      * The ocid of the compartment that contains the work request. Work requests should be scoped to
      * the same compartment as the resource the work request affects. If the work request affects multiple resources,
      * and those resources are not in the same compartment, it is up to the service team to pick the primary
-     * resource whose compartment should be used
+     * resource whose compartment should be used.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/requests/ListWorkRequestErrorsRequest.java
+++ b/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/requests/ListWorkRequestErrorsRequest.java
@@ -55,13 +55,13 @@ public class ListWorkRequestErrorsRequest
     private com.oracle.bmc.stackmonitoring.model.SortOrder sortOrder;
 
     /**
-     * The field to sort by. Only one sort order may
+     * The field to sort by. Only one sort order may be provided. Default order for timestamp is descending. If no value is specified timestamp is default.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may
+     * The field to sort by. Only one sort order may be provided. Default order for timestamp is descending. If no value is specified timestamp is default.
      *
      **/
     public enum SortBy {

--- a/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/requests/ListWorkRequestLogsRequest.java
+++ b/bmc-stackmonitoring/src/main/java/com/oracle/bmc/stackmonitoring/requests/ListWorkRequestLogsRequest.java
@@ -54,13 +54,13 @@ public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcReque
     private com.oracle.bmc.stackmonitoring.model.SortOrder sortOrder;
 
     /**
-     * The field to sort by. Only one sort order may
+     * The field to sort by. Only one sort order may be provided. Default order for timestamp is descending. If no value is specified timestamp is default.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may
+     * The field to sort by. Only one sort order may be provided. Default order for timestamp is descending. If no value is specified timestamp is default.
      *
      **/
     public enum SortBy {

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-threatintelligence/pom.xml
+++ b/bmc-threatintelligence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-threatintelligence</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usage/pom.xml
+++ b/bmc-usage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-visualbuilder/pom.xml
+++ b/bmc-visualbuilder/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-visualbuilder</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/Redirect.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/Redirect.java
@@ -88,7 +88,7 @@ public interface Redirect extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetHttpRedirectExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetHttpRedirect API.
@@ -100,7 +100,7 @@ public interface Redirect extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListHttpRedirectsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListHttpRedirects API.

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/RedirectClient.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/RedirectClient.java
@@ -589,7 +589,7 @@ public class RedirectClient implements Redirect {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Redirect",
@@ -623,7 +623,7 @@ public class RedirectClient implements Redirect {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Redirect",

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/Waas.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/Waas.java
@@ -250,7 +250,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetAddressListExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAddressList API.
@@ -262,7 +262,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetCertificateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetCertificate API.
@@ -274,7 +274,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetCustomProtectionRuleExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetCustomProtectionRule API.
@@ -286,7 +286,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetDeviceFingerprintChallengeExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetDeviceFingerprintChallenge API.
@@ -299,7 +299,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetHumanInteractionChallengeExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetHumanInteractionChallenge API.
@@ -312,7 +312,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetJsChallengeExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetJsChallenge API.
@@ -324,7 +324,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetPolicyConfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPolicyConfig API.
@@ -336,7 +336,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetProtectionRuleExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetProtectionRule API.
@@ -348,7 +348,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetProtectionSettingsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetProtectionSettings API.
@@ -360,7 +360,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetWaasPolicyExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWaasPolicy API.
@@ -372,7 +372,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetWafAddressRateLimitingExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWafAddressRateLimiting API.
@@ -385,7 +385,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetWafConfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWafConfig API.
@@ -397,7 +397,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
@@ -410,7 +410,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListAccessRulesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAccessRules API.
@@ -422,7 +422,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListAddressListsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAddressLists API.
@@ -435,7 +435,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListCachingRulesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListCachingRules API.
@@ -452,7 +452,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListCaptchasExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListCaptchas API.
@@ -464,7 +464,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListCertificatesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListCertificates API.
@@ -476,7 +476,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListCustomProtectionRulesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListCustomProtectionRules API.
@@ -489,7 +489,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListEdgeSubnetsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListEdgeSubnets API.
@@ -504,7 +504,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListGoodBotsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListGoodBots API.
@@ -517,7 +517,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListProtectionRulesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListProtectionRules API.
@@ -532,7 +532,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListRecommendationsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListRecommendations API.
@@ -547,7 +547,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListThreatFeedsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListThreatFeeds API.
@@ -559,7 +559,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListWaasPoliciesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWaasPolicies API.
@@ -571,7 +571,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListWaasPolicyCustomProtectionRulesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWaasPolicyCustomProtectionRules API.
@@ -584,7 +584,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListWafBlockedRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWafBlockedRequests API.
@@ -599,7 +599,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListWafLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWafLogs API.
@@ -614,7 +614,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListWafRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWafRequests API.
@@ -628,7 +628,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListWafTrafficExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWafTraffic API.
@@ -640,7 +640,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListWhitelistsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWhitelists API.
@@ -652,7 +652,7 @@ public interface Waas extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/waas/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/WaasClient.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/WaasClient.java
@@ -1021,7 +1021,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1055,7 +1055,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1090,7 +1090,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1126,7 +1126,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1162,7 +1162,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1196,7 +1196,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1230,7 +1230,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1264,7 +1264,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1299,7 +1299,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1333,7 +1333,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1369,7 +1369,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1403,7 +1403,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1437,7 +1437,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1471,7 +1471,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1505,7 +1505,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1539,7 +1539,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1573,7 +1573,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1607,7 +1607,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1643,7 +1643,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1677,7 +1677,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1711,7 +1711,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1745,7 +1745,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1779,7 +1779,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1813,7 +1813,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1847,7 +1847,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1884,7 +1884,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1919,7 +1919,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1953,7 +1953,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -1987,7 +1987,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -2021,7 +2021,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -2055,7 +2055,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",
@@ -2089,7 +2089,7 @@ public class WaasClient implements Waas {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "Waas",

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CreateCustomProtectionRuleDetails.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CreateCustomProtectionRuleDetails.java
@@ -167,7 +167,7 @@ public class CreateCustomProtectionRuleDetails {
      *
      * The example contains two }SecRules{@code  each having distinct regex expression to match the }Cookie header value during the second input analysis phase.
      * <p>
-     * For more information about custom protection rules, see [Custom Protection Rules](https://docs.cloud.oracle.com/Content/WAF/tasks/customprotectionrules.htm).
+     * For more information about custom protection rules, see [Custom Protection Rules](https://docs.cloud.oracle.com/Content/WAF/Tasks/customprotectionrules.htm).
      * <p>
      * For more information about ModSecurity syntax, see [Making Rules: The Basic Syntax](https://www.modsecurity.org/CRS/Documentation/making.html).
      * <p>

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CustomProtectionRule.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CustomProtectionRule.java
@@ -221,7 +221,7 @@ public class CustomProtectionRule {
      *
      * The example contains two }SecRules{@code  each having distinct regex expression to match the }Cookie header value during the second input analysis phase.
      * <p>
-     * For more information about custom protection rules, see [Custom Protection Rules](https://docs.cloud.oracle.com/Content/WAF/tasks/customprotectionrules.htm).
+     * For more information about custom protection rules, see [Custom Protection Rules](https://docs.cloud.oracle.com/Content/WAF/Tasks/customprotectionrules.htm).
      * <p>
      * For more information about ModSecurity syntax, see [Making Rules: The Basic Syntax](https://www.modsecurity.org/CRS/Documentation/making.html).
      * <p>

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/UpdateCustomProtectionRuleDetails.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/UpdateCustomProtectionRuleDetails.java
@@ -145,7 +145,7 @@ public class UpdateCustomProtectionRuleDetails {
      *
      * The example contains two }SecRules{@code  each having distinct regex expression to match the }Cookie header value during the second input analysis phase.
      * <p>
-     * For more information about custom protection rules, see [Custom Protection Rules](https://docs.cloud.oracle.com/Content/WAF/tasks/customprotectionrules.htm).
+     * For more information about custom protection rules, see [Custom Protection Rules](https://docs.cloud.oracle.com/Content/WAF/Tasks/customprotectionrules.htm).
      * <p>
      * For more information about ModSecurity syntax, see [Making Rules: The Basic Syntax](https://www.modsecurity.org/CRS/Documentation/making.html).
      * <p>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.26.0</version>
+    <version>2.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.26.0</version>
+  <version>2.27.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for getting usage information for autonomous databases and Cloud at Customer autonomous databases in the Database service

- Support for the "standby" lifecycle state on autonomous databases in the Database service

- Support for BIP connections and dataflow operators in the Data Integration service



### Breaking Changes

- Support for retries by default on WAF Edge Policy GET / LIST operations in the Web Application Acceleration and Security service

- Support for retries by default on some operations in the Stack Monitoring service

- Support for retries by default on some resource discovery and monitoring operations in the Application Management service

- Support for retries by default on some operations in the MySQL Database service

- Return type of method `public com.oracle.bmc.dataintegration.model.CreateConnectionFromBICC getDefaultConnection()` has been changed to `com.oracle.bmc.dataintegration.model.CreateConnectionDetails` in the model `com.oracle.bmc.dataintegration.model.CreateDataAssetFromFusionApp` in the Data Integration service

- Return type of method `public com.oracle.bmc.dataintegration.model.ConnectionFromBICCDetails getDefaultConnection()` has been changed to `com.oracle.bmc.dataintegration.model.ConnectionDetails` in the model `com.oracle.bmc.dataintegration.model.DataAssetFromFusionApp` in the Data Integration service

- Return type of method `public com.oracle.bmc.dataintegration.model.ConnectionSummaryFromBICC getDefaultConnection()` has been changed to `com.oracle.bmc.dataintegration.model.ConnectionSummary` in the model `com.oracle.bmc.dataintegration.model.DataAssetSummaryFromFusionApp` in the Data Integration service