### PR TITLE
Releasing version 2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.28.0 - 2022-05-17
+### Added
+- Support for information requests in the Operator Access Control service
+- Support for Helm charts and repositories on deployments in the DevOps service
+- Support for Application Dependency Management service scan results on builds in the DevOps service
+- Support for build resources to use Bitbucket Cloud repositories for source code in the DevOps service
+- Support for character set selection on autonomous dedicated databases in the Database service
+- Support for listing autonomous dedicated database supported character sets in the Database service
+- Support for AMD E4 flex shapes on virtual machine database systems in the Database service
+- Support for terraform and improvements for cross-region ADGs in the Database service
+
+### Breaking Changes
+- Support for retries by default on GET / LIST operations in the Visual Builder service
+
 ## 2.27.0 - 2022-05-10
 ### Added
 - Support for getting usage information for autonomous databases and Cloud at Customer autonomous databases in the Database service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-graalvm-addon/pom.xml
+++ b/bmc-addons/bmc-graalvm-addon/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -123,619 +123,619 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-ailanguage</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-aispeech</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-aivision</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-analytics</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-announcementsservice</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apigateway</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apmconfig</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-apmtraces</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-applicationmigration</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-artifacts</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-audit</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-autoscaling</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-bastion</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-bds</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-blockchain</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-budget</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-certificates</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-cims</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-cloudguard</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-containerengine</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-core</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dashboardservice</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-database</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasemanagement</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasemigration</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasetools</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datacatalog</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dataconnectivity</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dataflow</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dataintegration</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datasafe</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-datascience</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-devops</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dns</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-dts</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-email</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-events</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-filestorage</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-functions</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-goldengate</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-healthchecks</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-identity</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-identitydataplane</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-jms</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-limits</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-loadbalancer</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-loganalytics</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-logging</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-loggingingestion</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-loggingsearch</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-managementagent</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-managementdashboard</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-marketplace</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-monitoring</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-mysql</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-nosql</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-oce</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-ocvp</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-oda</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-ons</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-opsi</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-optimizer</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osmanagement</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-ospgateway</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osubsubscription</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-osubusage</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-resourcemanager</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-resourcesearch</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-rover</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-sch</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-secrets</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-servicecatalog</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-servicemesh</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-stackmonitoring</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-streaming</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-threatintelligence</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-usage</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-usageapi</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-vault</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-visualbuilder</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-waas</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-waf</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-adm/pom.xml
+++ b/bmc-adm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-adm</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aispeech/pom.xml
+++ b/bmc-aispeech/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aispeech</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aivision/pom.xml
+++ b/bmc-aivision/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aivision</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-appmgmtcontrol/pom.xml
+++ b/bmc-appmgmtcontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,659 +19,659 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-graalvm</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificates</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usage</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasetools</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ospgateway</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identitydataplane</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-visualbuilder</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubusage</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubsubscription</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dashboardservice</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-threatintelligence</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aivision</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aispeech</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataconnectivity</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-stackmonitoring</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemesh</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-adm</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificates/pom.xml
+++ b/bmc-certificates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificates</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificatesmanagement/pom.xml
+++ b/bmc-certificatesmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dashboardservice/pom.xml
+++ b/bmc-dashboardservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dashboardservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
@@ -2279,6 +2279,19 @@ public interface Database extends AutoCloseable {
             ListAutonomousDatabaseBackupsRequest request);
 
     /**
+     * Gets a list of supported character sets.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListAutonomousDatabaseCharacterSetsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAutonomousDatabaseCharacterSets API.
+     */
+    ListAutonomousDatabaseCharacterSetsResponse listAutonomousDatabaseCharacterSets(
+            ListAutonomousDatabaseCharacterSetsRequest request);
+
+    /**
      * Lists the Autonomous Database clones for the specified Autonomous Database.
      *
      * @param request The request object containing the details to send
@@ -2633,6 +2646,20 @@ public interface Database extends AutoCloseable {
     ListDbServersResponse listDbServers(ListDbServersRequest request);
 
     /**
+     * Gets a list of expected compute performance parameters for a virtual machine DB system based on system configuration.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListDbSystemComputePerformancesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDbSystemComputePerformances API.
+     */
+    ListDbSystemComputePerformancesResponse listDbSystemComputePerformances(
+            ListDbSystemComputePerformancesRequest request);
+
+    /**
      * Gets the history of the patch actions performed on the specified DB system.
      *
      * @param request The request object containing the details to send
@@ -2670,6 +2697,20 @@ public interface Database extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListDbSystemShapesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDbSystemShapes API.
      */
     ListDbSystemShapesResponse listDbSystemShapes(ListDbSystemShapesRequest request);
+
+    /**
+     * Gets a list of possible expected storage performance parameters of a VMDB System based on Configuration.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListDbSystemStoragePerformancesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDbSystemStoragePerformances API.
+     */
+    ListDbSystemStoragePerformancesResponse listDbSystemStoragePerformances(
+            ListDbSystemStoragePerformancesRequest request);
 
     /**
      * Gets the history of the upgrade actions performed on the specified DB system.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
@@ -2896,6 +2896,24 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Gets a list of supported character sets.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListAutonomousDatabaseCharacterSetsResponse>
+            listAutonomousDatabaseCharacterSets(
+                    ListAutonomousDatabaseCharacterSetsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListAutonomousDatabaseCharacterSetsRequest,
+                                    ListAutonomousDatabaseCharacterSetsResponse>
+                            handler);
+
+    /**
      * Lists the Autonomous Database clones for the specified Autonomous Database.
      *
      *
@@ -3350,6 +3368,25 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets a list of expected compute performance parameters for a virtual machine DB system based on system configuration.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListDbSystemComputePerformancesResponse>
+            listDbSystemComputePerformances(
+                    ListDbSystemComputePerformancesRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListDbSystemComputePerformancesRequest,
+                                    ListDbSystemComputePerformancesResponse>
+                            handler);
+
+    /**
      * Gets the history of the patch actions performed on the specified DB system.
      *
      *
@@ -3400,6 +3437,25 @@ public interface DatabaseAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             ListDbSystemShapesRequest, ListDbSystemShapesResponse>
                     handler);
+
+    /**
+     * Gets a list of possible expected storage performance parameters of a VMDB System based on Configuration.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListDbSystemStoragePerformancesResponse>
+            listDbSystemStoragePerformances(
+                    ListDbSystemStoragePerformancesRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListDbSystemStoragePerformancesRequest,
+                                    ListDbSystemStoragePerformancesResponse>
+                            handler);
 
     /**
      * Gets the history of the upgrade actions performed on the specified DB system.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -8433,6 +8433,58 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListAutonomousDatabaseCharacterSetsResponse>
+            listAutonomousDatabaseCharacterSets(
+                    ListAutonomousDatabaseCharacterSetsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListAutonomousDatabaseCharacterSetsRequest,
+                                    ListAutonomousDatabaseCharacterSetsResponse>
+                            handler) {
+        LOG.trace("Called async listAutonomousDatabaseCharacterSets");
+        final ListAutonomousDatabaseCharacterSetsRequest interceptedRequest =
+                ListAutonomousDatabaseCharacterSetsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAutonomousDatabaseCharacterSetsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListAutonomousDatabaseCharacterSetsResponse>
+                transformer = ListAutonomousDatabaseCharacterSetsConverter.fromResponse();
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "Database",
+                "ListAutonomousDatabaseCharacterSets",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/database/20160918/AutonomousDatabaseCharacterSets/ListAutonomousDatabaseCharacterSets");
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListAutonomousDatabaseCharacterSetsRequest,
+                        ListAutonomousDatabaseCharacterSetsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListAutonomousDatabaseCharacterSetsRequest,
+                                ListAutonomousDatabaseCharacterSetsResponse>,
+                        java.util.concurrent.Future<ListAutonomousDatabaseCharacterSetsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListAutonomousDatabaseCharacterSetsRequest,
+                    ListAutonomousDatabaseCharacterSetsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListAutonomousDatabaseClonesResponse>
             listAutonomousDatabaseClones(
                     ListAutonomousDatabaseClonesRequest request,
@@ -9672,6 +9724,57 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListDbSystemComputePerformancesResponse>
+            listDbSystemComputePerformances(
+                    ListDbSystemComputePerformancesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListDbSystemComputePerformancesRequest,
+                                    ListDbSystemComputePerformancesResponse>
+                            handler) {
+        LOG.trace("Called async listDbSystemComputePerformances");
+        final ListDbSystemComputePerformancesRequest interceptedRequest =
+                ListDbSystemComputePerformancesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDbSystemComputePerformancesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListDbSystemComputePerformancesResponse>
+                transformer = ListDbSystemComputePerformancesConverter.fromResponse();
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "Database",
+                "ListDbSystemComputePerformances",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/database/20160918/DbSystemComputePerformanceSummary/ListDbSystemComputePerformances");
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListDbSystemComputePerformancesRequest,
+                        ListDbSystemComputePerformancesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListDbSystemComputePerformancesRequest,
+                                ListDbSystemComputePerformancesResponse>,
+                        java.util.concurrent.Future<ListDbSystemComputePerformancesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListDbSystemComputePerformancesRequest,
+                    ListDbSystemComputePerformancesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListDbSystemPatchHistoryEntriesResponse>
             listDbSystemPatchHistoryEntries(
                     ListDbSystemPatchHistoryEntriesRequest request,
@@ -9800,6 +9903,57 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListDbSystemShapesRequest, ListDbSystemShapesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListDbSystemStoragePerformancesResponse>
+            listDbSystemStoragePerformances(
+                    ListDbSystemStoragePerformancesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListDbSystemStoragePerformancesRequest,
+                                    ListDbSystemStoragePerformancesResponse>
+                            handler) {
+        LOG.trace("Called async listDbSystemStoragePerformances");
+        final ListDbSystemStoragePerformancesRequest interceptedRequest =
+                ListDbSystemStoragePerformancesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDbSystemStoragePerformancesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListDbSystemStoragePerformancesResponse>
+                transformer = ListDbSystemStoragePerformancesConverter.fromResponse();
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "Database",
+                "ListDbSystemStoragePerformances",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/database/20160918/DbSystemStoragePerformanceSummary/ListDbSystemStoragePerformances");
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListDbSystemStoragePerformancesRequest,
+                        ListDbSystemStoragePerformancesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListDbSystemStoragePerformancesRequest,
+                                ListDbSystemStoragePerformancesResponse>,
+                        java.util.concurrent.Future<ListDbSystemStoragePerformancesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListDbSystemStoragePerformancesRequest,
+                    ListDbSystemStoragePerformancesResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -6531,6 +6531,43 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public ListAutonomousDatabaseCharacterSetsResponse listAutonomousDatabaseCharacterSets(
+            ListAutonomousDatabaseCharacterSetsRequest request) {
+        LOG.trace("Called listAutonomousDatabaseCharacterSets");
+        final ListAutonomousDatabaseCharacterSetsRequest interceptedRequest =
+                ListAutonomousDatabaseCharacterSetsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAutonomousDatabaseCharacterSetsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListAutonomousDatabaseCharacterSetsResponse>
+                transformer = ListAutonomousDatabaseCharacterSetsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "Database",
+                "ListAutonomousDatabaseCharacterSets",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/database/20160918/AutonomousDatabaseCharacterSets/ListAutonomousDatabaseCharacterSets");
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListAutonomousDatabaseClonesResponse listAutonomousDatabaseClones(
             ListAutonomousDatabaseClonesRequest request) {
         LOG.trace("Called listAutonomousDatabaseClones");
@@ -7456,6 +7493,42 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public ListDbSystemComputePerformancesResponse listDbSystemComputePerformances(
+            ListDbSystemComputePerformancesRequest request) {
+        LOG.trace("Called listDbSystemComputePerformances");
+        final ListDbSystemComputePerformancesRequest interceptedRequest =
+                ListDbSystemComputePerformancesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDbSystemComputePerformancesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListDbSystemComputePerformancesResponse>
+                transformer = ListDbSystemComputePerformancesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "Database",
+                "ListDbSystemComputePerformances",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/database/20160918/DbSystemComputePerformanceSummary/ListDbSystemComputePerformances");
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListDbSystemPatchHistoryEntriesResponse listDbSystemPatchHistoryEntries(
             ListDbSystemPatchHistoryEntriesRequest request) {
         LOG.trace("Called listDbSystemPatchHistoryEntries");
@@ -7544,6 +7617,42 @@ public class DatabaseClient implements Database {
                 "ListDbSystemShapes",
                 ib.getRequestUri().toString(),
                 "https://docs.oracle.com/iaas/api/#/en/database/20160918/DbSystemShapeSummary/ListDbSystemShapes");
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListDbSystemStoragePerformancesResponse listDbSystemStoragePerformances(
+            ListDbSystemStoragePerformancesRequest request) {
+        LOG.trace("Called listDbSystemStoragePerformances");
+        final ListDbSystemStoragePerformancesRequest interceptedRequest =
+                ListDbSystemStoragePerformancesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDbSystemStoragePerformancesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListDbSystemStoragePerformancesResponse>
+                transformer = ListDbSystemStoragePerformancesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "Database",
+                "ListDbSystemStoragePerformances",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/database/20160918/DbSystemStoragePerformanceSummary/ListDbSystemStoragePerformances");
         return retrier.execute(
                 interceptedRequest,
                 retryRequest -> {

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListAutonomousDatabaseCharacterSetsConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListAutonomousDatabaseCharacterSetsConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListAutonomousDatabaseCharacterSetsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.ListAutonomousDatabaseCharacterSetsRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests.ListAutonomousDatabaseCharacterSetsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ListAutonomousDatabaseCharacterSetsRequest request) {
+        Validate.notNull(request, "request instance is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("autonomousDatabaseCharacterSets");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.ListAutonomousDatabaseCharacterSetsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .ListAutonomousDatabaseCharacterSetsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .ListAutonomousDatabaseCharacterSetsResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .ListAutonomousDatabaseCharacterSetsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ListAutonomousDatabaseCharacterSetsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                com.oracle.bmc.database.model
+                                                                        .AutonomousDatabaseCharacterSets>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        com.oracle.bmc.database
+                                                                                .model
+                                                                                .AutonomousDatabaseCharacterSets>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        com.oracle.bmc.database.model
+                                                                .AutonomousDatabaseCharacterSets>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .ListAutonomousDatabaseCharacterSetsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ListAutonomousDatabaseCharacterSetsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .ListAutonomousDatabaseCharacterSetsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbSystemComputePerformancesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbSystemComputePerformancesConverter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListDbSystemComputePerformancesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.ListDbSystemComputePerformancesRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests.ListDbSystemComputePerformancesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ListDbSystemComputePerformancesRequest request) {
+        Validate.notNull(request, "request instance is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("dbSystemComputePerformance");
+
+        if (request.getDbSystemShape() != null) {
+            target =
+                    target.queryParam(
+                            "dbSystemShape",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDbSystemShape()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.ListDbSystemComputePerformancesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.ListDbSystemComputePerformancesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .ListDbSystemComputePerformancesResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .ListDbSystemComputePerformancesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ListDbSystemComputePerformancesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                com.oracle.bmc.database.model
+                                                                        .DbSystemComputePerformanceSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        com.oracle.bmc.database
+                                                                                .model
+                                                                                .DbSystemComputePerformanceSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        com.oracle.bmc.database.model
+                                                                .DbSystemComputePerformanceSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .ListDbSystemComputePerformancesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ListDbSystemComputePerformancesResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .ListDbSystemComputePerformancesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbSystemStoragePerformancesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbSystemStoragePerformancesConverter.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListDbSystemStoragePerformancesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.ListDbSystemStoragePerformancesRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests.ListDbSystemStoragePerformancesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ListDbSystemStoragePerformancesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getStorageManagement(), "storageManagement is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("dbSystemStoragePerformance");
+
+        target =
+                target.queryParam(
+                        "storageManagement",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getStorageManagement().getValue()));
+
+        if (request.getShapeType() != null) {
+            target =
+                    target.queryParam(
+                            "shapeType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getShapeType()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.ListDbSystemStoragePerformancesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.ListDbSystemStoragePerformancesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .ListDbSystemStoragePerformancesResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .ListDbSystemStoragePerformancesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ListDbSystemStoragePerformancesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                com.oracle.bmc.database.model
+                                                                        .DbSystemStoragePerformanceSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        com.oracle.bmc.database
+                                                                                .model
+                                                                                .DbSystemStoragePerformanceSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        com.oracle.bmc.database.model
+                                                                .DbSystemStoragePerformanceSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .ListDbSystemStoragePerformancesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ListDbSystemStoragePerformancesResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .ListDbSystemStoragePerformancesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -108,6 +108,24 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+        private String characterSet;
+
+        public Builder characterSet(String characterSet) {
+            this.characterSet = characterSet;
+            this.__explicitlySet__.add("characterSet");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+        private String ncharacterSet;
+
+        public Builder ncharacterSet(String ncharacterSet) {
+            this.ncharacterSet = ncharacterSet;
+            this.__explicitlySet__.add("ncharacterSet");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isFreeTier")
         private Boolean isFreeTier;
 
@@ -625,6 +643,33 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+        private Boolean isLocalDataGuardEnabled;
+
+        public Builder isLocalDataGuardEnabled(Boolean isLocalDataGuardEnabled) {
+            this.isLocalDataGuardEnabled = isLocalDataGuardEnabled;
+            this.__explicitlySet__.add("isLocalDataGuardEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isRemoteDataGuardEnabled")
+        private Boolean isRemoteDataGuardEnabled;
+
+        public Builder isRemoteDataGuardEnabled(Boolean isRemoteDataGuardEnabled) {
+            this.isRemoteDataGuardEnabled = isRemoteDataGuardEnabled;
+            this.__explicitlySet__.add("isRemoteDataGuardEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("localStandbyDb")
+        private AutonomousDatabaseStandbySummary localStandbyDb;
+
+        public Builder localStandbyDb(AutonomousDatabaseStandbySummary localStandbyDb) {
+            this.localStandbyDb = localStandbyDb;
+            this.__explicitlySet__.add("localStandbyDb");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("role")
         private Role role;
 
@@ -823,6 +868,8 @@ public class AutonomousDatabase {
                             kmsKeyLifecycleDetails,
                             kmsKeyVersionId,
                             dbName,
+                            characterSet,
+                            ncharacterSet,
                             isFreeTier,
                             systemTags,
                             timeReclamationOfFreeAutonomousDatabase,
@@ -880,6 +927,9 @@ public class AutonomousDatabase {
                             isDataGuardEnabled,
                             failedDataRecoveryInSeconds,
                             standbyDb,
+                            isLocalDataGuardEnabled,
+                            isRemoteDataGuardEnabled,
+                            localStandbyDb,
                             role,
                             availableUpgradeVersions,
                             keyStoreId,
@@ -916,6 +966,8 @@ public class AutonomousDatabase {
                             .kmsKeyLifecycleDetails(o.getKmsKeyLifecycleDetails())
                             .kmsKeyVersionId(o.getKmsKeyVersionId())
                             .dbName(o.getDbName())
+                            .characterSet(o.getCharacterSet())
+                            .ncharacterSet(o.getNcharacterSet())
                             .isFreeTier(o.getIsFreeTier())
                             .systemTags(o.getSystemTags())
                             .timeReclamationOfFreeAutonomousDatabase(
@@ -975,6 +1027,9 @@ public class AutonomousDatabase {
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .failedDataRecoveryInSeconds(o.getFailedDataRecoveryInSeconds())
                             .standbyDb(o.getStandbyDb())
+                            .isLocalDataGuardEnabled(o.getIsLocalDataGuardEnabled())
+                            .isRemoteDataGuardEnabled(o.getIsRemoteDataGuardEnabled())
+                            .localStandbyDb(o.getLocalStandbyDb())
                             .role(o.getRole())
                             .availableUpgradeVersions(o.getAvailableUpgradeVersions())
                             .keyStoreId(o.getKeyStoreId())
@@ -1127,6 +1182,23 @@ public class AutonomousDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbName")
     String dbName;
+
+    /**
+     * The character set for the autonomous database.  The default is AL32UTF8. Allowed values are:
+     * <p>
+     * AL32UTF8, AR8ADOS710, AR8ADOS720, AR8APTEC715, AR8ARABICMACS, AR8ASMO8X, AR8ISO8859P6, AR8MSWIN1256, AR8MUSSAD768, AR8NAFITHA711, AR8NAFITHA721, AR8SAKHR706, AR8SAKHR707, AZ8ISO8859P9E, BG8MSWIN, BG8PC437S, BLT8CP921, BLT8ISO8859P13, BLT8MSWIN1257, BLT8PC775, BN8BSCII, CDN8PC863, CEL8ISO8859P14, CL8ISO8859P5, CL8ISOIR111, CL8KOI8R, CL8KOI8U, CL8MACCYRILLICS, CL8MSWIN1251, EE8ISO8859P2, EE8MACCES, EE8MACCROATIANS, EE8MSWIN1250, EE8PC852, EL8DEC, EL8ISO8859P7, EL8MACGREEKS, EL8MSWIN1253, EL8PC437S, EL8PC851, EL8PC869, ET8MSWIN923, HU8ABMOD, HU8CWI2, IN8ISCII, IS8PC861, IW8ISO8859P8, IW8MACHEBREWS, IW8MSWIN1255, IW8PC1507, JA16EUC, JA16EUCTILDE, JA16SJIS, JA16SJISTILDE, JA16VMS, KO16KSC5601, KO16KSCCS, KO16MSWIN949, LA8ISO6937, LA8PASSPORT, LT8MSWIN921, LT8PC772, LT8PC774, LV8PC1117, LV8PC8LR, LV8RST104090, N8PC865, NE8ISO8859P10, NEE8ISO8859P4, RU8BESTA, RU8PC855, RU8PC866, SE8ISO8859P3, TH8MACTHAIS, TH8TISASCII, TR8DEC, TR8MACTURKISHS, TR8MSWIN1254, TR8PC857, US7ASCII, US8PC437, UTF8, VN8MSWIN1258, VN8VN3, WE8DEC, WE8DG, WE8ISO8859P1, WE8ISO8859P15, WE8ISO8859P9, WE8MACROMAN8S, WE8MSWIN1252, WE8NCR4970, WE8NEXTSTEP, WE8PC850, WE8PC858, WE8PC860, WE8ROMAN8, ZHS16CGB231280, ZHS16GBK, ZHT16BIG5, ZHT16CCDC, ZHT16DBT, ZHT16HKSCS, ZHT16MSWIN950, ZHT32EUC, ZHT32SOPS, ZHT32TRIS
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+    String characterSet;
+
+    /**
+     * The national character set for the autonomous database.  The default is AL16UTF16. Allowed values are:
+     * AL16UTF16 or UTF8.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+    String ncharacterSet;
 
     /**
      * Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
@@ -1405,9 +1477,9 @@ public class AutonomousDatabase {
     String subnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
@@ -1998,7 +2070,8 @@ public class AutonomousDatabase {
     java.util.Date timeOfLastFailover;
 
     /**
-     * Indicates whether the Autonomous Database has local (in-region) Data Guard enabled. Not applicable to cross-region Autonomous Data Guard associations, or to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     * **Deprecated.** Indicates whether the Autonomous Database has local (in-region) Data Guard enabled. Not applicable to cross-region Autonomous Data Guard associations, or to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isDataGuardEnabled")
     Boolean isDataGuardEnabled;
@@ -2009,8 +2082,27 @@ public class AutonomousDatabase {
     @com.fasterxml.jackson.annotation.JsonProperty("failedDataRecoveryInSeconds")
     Integer failedDataRecoveryInSeconds;
 
+    /**
+     * **Deprecated** Autonomous Data Guard standby database details.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("standbyDb")
     AutonomousDatabaseStandbySummary standbyDb;
+
+    /**
+     * Indicates whether the Autonomous Database has local (in-region) Data Guard enabled. Not applicable to cross-region Autonomous Data Guard associations, or to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+    Boolean isLocalDataGuardEnabled;
+
+    /**
+     * Indicates whether the Autonomous Database has Cross Region Data Guard enabled. Not applicable to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isRemoteDataGuardEnabled")
+    Boolean isRemoteDataGuardEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("localStandbyDb")
+    AutonomousDatabaseStandbySummary localStandbyDb;
     /**
      * The Data Guard role of the Autonomous Container Database or Autonomous Database, if Autonomous Data Guard is enabled.
      *

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseCharacterSets.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseCharacterSets.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The Oracle Autonomous Database supported character sets.
+ * <p>
+ * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized, talk to an administrator. If you're an administrator who needs to write policies to give users access, see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AutonomousDatabaseCharacterSets.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AutonomousDatabaseCharacterSets {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AutonomousDatabaseCharacterSets build() {
+            AutonomousDatabaseCharacterSets __instance__ =
+                    new AutonomousDatabaseCharacterSets(name);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AutonomousDatabaseCharacterSets o) {
+            Builder copiedBuilder = name(o.getName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A valid Oracle character set.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -110,6 +110,24 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+        private String characterSet;
+
+        public Builder characterSet(String characterSet) {
+            this.characterSet = characterSet;
+            this.__explicitlySet__.add("characterSet");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+        private String ncharacterSet;
+
+        public Builder ncharacterSet(String ncharacterSet) {
+            this.ncharacterSet = ncharacterSet;
+            this.__explicitlySet__.add("ncharacterSet");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isFreeTier")
         private Boolean isFreeTier;
 
@@ -627,6 +645,33 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+        private Boolean isLocalDataGuardEnabled;
+
+        public Builder isLocalDataGuardEnabled(Boolean isLocalDataGuardEnabled) {
+            this.isLocalDataGuardEnabled = isLocalDataGuardEnabled;
+            this.__explicitlySet__.add("isLocalDataGuardEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isRemoteDataGuardEnabled")
+        private Boolean isRemoteDataGuardEnabled;
+
+        public Builder isRemoteDataGuardEnabled(Boolean isRemoteDataGuardEnabled) {
+            this.isRemoteDataGuardEnabled = isRemoteDataGuardEnabled;
+            this.__explicitlySet__.add("isRemoteDataGuardEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("localStandbyDb")
+        private AutonomousDatabaseStandbySummary localStandbyDb;
+
+        public Builder localStandbyDb(AutonomousDatabaseStandbySummary localStandbyDb) {
+            this.localStandbyDb = localStandbyDb;
+            this.__explicitlySet__.add("localStandbyDb");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("role")
         private Role role;
 
@@ -825,6 +870,8 @@ public class AutonomousDatabaseSummary {
                             kmsKeyLifecycleDetails,
                             kmsKeyVersionId,
                             dbName,
+                            characterSet,
+                            ncharacterSet,
                             isFreeTier,
                             systemTags,
                             timeReclamationOfFreeAutonomousDatabase,
@@ -882,6 +929,9 @@ public class AutonomousDatabaseSummary {
                             isDataGuardEnabled,
                             failedDataRecoveryInSeconds,
                             standbyDb,
+                            isLocalDataGuardEnabled,
+                            isRemoteDataGuardEnabled,
+                            localStandbyDb,
                             role,
                             availableUpgradeVersions,
                             keyStoreId,
@@ -918,6 +968,8 @@ public class AutonomousDatabaseSummary {
                             .kmsKeyLifecycleDetails(o.getKmsKeyLifecycleDetails())
                             .kmsKeyVersionId(o.getKmsKeyVersionId())
                             .dbName(o.getDbName())
+                            .characterSet(o.getCharacterSet())
+                            .ncharacterSet(o.getNcharacterSet())
                             .isFreeTier(o.getIsFreeTier())
                             .systemTags(o.getSystemTags())
                             .timeReclamationOfFreeAutonomousDatabase(
@@ -977,6 +1029,9 @@ public class AutonomousDatabaseSummary {
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .failedDataRecoveryInSeconds(o.getFailedDataRecoveryInSeconds())
                             .standbyDb(o.getStandbyDb())
+                            .isLocalDataGuardEnabled(o.getIsLocalDataGuardEnabled())
+                            .isRemoteDataGuardEnabled(o.getIsRemoteDataGuardEnabled())
+                            .localStandbyDb(o.getLocalStandbyDb())
                             .role(o.getRole())
                             .availableUpgradeVersions(o.getAvailableUpgradeVersions())
                             .keyStoreId(o.getKeyStoreId())
@@ -1129,6 +1184,23 @@ public class AutonomousDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbName")
     String dbName;
+
+    /**
+     * The character set for the autonomous database.  The default is AL32UTF8. Allowed values are:
+     * <p>
+     * AL32UTF8, AR8ADOS710, AR8ADOS720, AR8APTEC715, AR8ARABICMACS, AR8ASMO8X, AR8ISO8859P6, AR8MSWIN1256, AR8MUSSAD768, AR8NAFITHA711, AR8NAFITHA721, AR8SAKHR706, AR8SAKHR707, AZ8ISO8859P9E, BG8MSWIN, BG8PC437S, BLT8CP921, BLT8ISO8859P13, BLT8MSWIN1257, BLT8PC775, BN8BSCII, CDN8PC863, CEL8ISO8859P14, CL8ISO8859P5, CL8ISOIR111, CL8KOI8R, CL8KOI8U, CL8MACCYRILLICS, CL8MSWIN1251, EE8ISO8859P2, EE8MACCES, EE8MACCROATIANS, EE8MSWIN1250, EE8PC852, EL8DEC, EL8ISO8859P7, EL8MACGREEKS, EL8MSWIN1253, EL8PC437S, EL8PC851, EL8PC869, ET8MSWIN923, HU8ABMOD, HU8CWI2, IN8ISCII, IS8PC861, IW8ISO8859P8, IW8MACHEBREWS, IW8MSWIN1255, IW8PC1507, JA16EUC, JA16EUCTILDE, JA16SJIS, JA16SJISTILDE, JA16VMS, KO16KSC5601, KO16KSCCS, KO16MSWIN949, LA8ISO6937, LA8PASSPORT, LT8MSWIN921, LT8PC772, LT8PC774, LV8PC1117, LV8PC8LR, LV8RST104090, N8PC865, NE8ISO8859P10, NEE8ISO8859P4, RU8BESTA, RU8PC855, RU8PC866, SE8ISO8859P3, TH8MACTHAIS, TH8TISASCII, TR8DEC, TR8MACTURKISHS, TR8MSWIN1254, TR8PC857, US7ASCII, US8PC437, UTF8, VN8MSWIN1258, VN8VN3, WE8DEC, WE8DG, WE8ISO8859P1, WE8ISO8859P15, WE8ISO8859P9, WE8MACROMAN8S, WE8MSWIN1252, WE8NCR4970, WE8NEXTSTEP, WE8PC850, WE8PC858, WE8PC860, WE8ROMAN8, ZHS16CGB231280, ZHS16GBK, ZHT16BIG5, ZHT16CCDC, ZHT16DBT, ZHT16HKSCS, ZHT16MSWIN950, ZHT32EUC, ZHT32SOPS, ZHT32TRIS
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+    String characterSet;
+
+    /**
+     * The national character set for the autonomous database.  The default is AL16UTF16. Allowed values are:
+     * AL16UTF16 or UTF8.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+    String ncharacterSet;
 
     /**
      * Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
@@ -1407,9 +1479,9 @@ public class AutonomousDatabaseSummary {
     String subnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
@@ -2000,7 +2072,8 @@ public class AutonomousDatabaseSummary {
     java.util.Date timeOfLastFailover;
 
     /**
-     * Indicates whether the Autonomous Database has local (in-region) Data Guard enabled. Not applicable to cross-region Autonomous Data Guard associations, or to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     * **Deprecated.** Indicates whether the Autonomous Database has local (in-region) Data Guard enabled. Not applicable to cross-region Autonomous Data Guard associations, or to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isDataGuardEnabled")
     Boolean isDataGuardEnabled;
@@ -2011,8 +2084,27 @@ public class AutonomousDatabaseSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("failedDataRecoveryInSeconds")
     Integer failedDataRecoveryInSeconds;
 
+    /**
+     * **Deprecated** Autonomous Data Guard standby database details.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("standbyDb")
     AutonomousDatabaseStandbySummary standbyDb;
+
+    /**
+     * Indicates whether the Autonomous Database has local (in-region) Data Guard enabled. Not applicable to cross-region Autonomous Data Guard associations, or to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+    Boolean isLocalDataGuardEnabled;
+
+    /**
+     * Indicates whether the Autonomous Database has Cross Region Data Guard enabled. Not applicable to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isRemoteDataGuardEnabled")
+    Boolean isRemoteDataGuardEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("localStandbyDb")
+    AutonomousDatabaseStandbySummary localStandbyDb;
     /**
      * The Data Guard role of the Autonomous Container Database or Autonomous Database, if Autonomous Data Guard is enabled.
      *

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousExadataInfrastructure.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousExadataInfrastructure.java
@@ -312,9 +312,9 @@ public class AutonomousExadataInfrastructure {
     String subnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousExadataInfrastructureSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousExadataInfrastructureSummary.java
@@ -328,9 +328,9 @@ public class AutonomousExadataInfrastructureSummary {
     String subnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudAutonomousVmCluster.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudAutonomousVmCluster.java
@@ -481,9 +481,9 @@ public class CloudAutonomousVmCluster {
     String subnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudAutonomousVmClusterSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudAutonomousVmClusterSummary.java
@@ -481,9 +481,9 @@ public class CloudAutonomousVmClusterSummary {
     String subnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudVmCluster.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudVmCluster.java
@@ -548,9 +548,9 @@ public class CloudVmCluster {
     String backupSubnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudVmClusterSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudVmClusterSummary.java
@@ -536,9 +536,9 @@ public class CloudVmClusterSummary {
     String backupSubnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ComputePerformanceSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ComputePerformanceSummary.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Parameters detailing the compute performance for a specified DB system shape.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputePerformanceSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputePerformanceSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+        private Integer cpuCoreCount;
+
+        public Builder cpuCoreCount(Integer cpuCoreCount) {
+            this.cpuCoreCount = cpuCoreCount;
+            this.__explicitlySet__.add("cpuCoreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memoryInGBs")
+        private Double memoryInGBs;
+
+        public Builder memoryInGBs(Double memoryInGBs) {
+            this.memoryInGBs = memoryInGBs;
+            this.__explicitlySet__.add("memoryInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("networkBandwidthInGbps")
+        private Float networkBandwidthInGbps;
+
+        public Builder networkBandwidthInGbps(Float networkBandwidthInGbps) {
+            this.networkBandwidthInGbps = networkBandwidthInGbps;
+            this.__explicitlySet__.add("networkBandwidthInGbps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("networkIops")
+        private Float networkIops;
+
+        public Builder networkIops(Float networkIops) {
+            this.networkIops = networkIops;
+            this.__explicitlySet__.add("networkIops");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("networkThroughputInMbps")
+        private Float networkThroughputInMbps;
+
+        public Builder networkThroughputInMbps(Float networkThroughputInMbps) {
+            this.networkThroughputInMbps = networkThroughputInMbps;
+            this.__explicitlySet__.add("networkThroughputInMbps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputePerformanceSummary build() {
+            ComputePerformanceSummary __instance__ =
+                    new ComputePerformanceSummary(
+                            cpuCoreCount,
+                            memoryInGBs,
+                            networkBandwidthInGbps,
+                            networkIops,
+                            networkThroughputInMbps);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputePerformanceSummary o) {
+            Builder copiedBuilder =
+                    cpuCoreCount(o.getCpuCoreCount())
+                            .memoryInGBs(o.getMemoryInGBs())
+                            .networkBandwidthInGbps(o.getNetworkBandwidthInGbps())
+                            .networkIops(o.getNetworkIops())
+                            .networkThroughputInMbps(o.getNetworkThroughputInMbps());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The number of OCPU cores available.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+    Integer cpuCoreCount;
+
+    /**
+     * The amount of memory allocated for the VMDB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memoryInGBs")
+    Double memoryInGBs;
+
+    /**
+     * The network bandwidth of the VMDB system in gbps.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("networkBandwidthInGbps")
+    Float networkBandwidthInGbps;
+
+    /**
+     * IOPS for the VMDB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("networkIops")
+    Float networkIops;
+
+    /**
+     * Network throughput for the VMDB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("networkThroughputInMbps")
+    Float networkThroughputInMbps;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
@@ -71,6 +71,23 @@ public class CreateAutonomousDatabaseBase {
     String compartmentId;
 
     /**
+     * The character set for the autonomous database.  The default is AL32UTF8. Allowed values are:
+     * <p>
+     * AL32UTF8, AR8ADOS710, AR8ADOS720, AR8APTEC715, AR8ARABICMACS, AR8ASMO8X, AR8ISO8859P6, AR8MSWIN1256, AR8MUSSAD768, AR8NAFITHA711, AR8NAFITHA721, AR8SAKHR706, AR8SAKHR707, AZ8ISO8859P9E, BG8MSWIN, BG8PC437S, BLT8CP921, BLT8ISO8859P13, BLT8MSWIN1257, BLT8PC775, BN8BSCII, CDN8PC863, CEL8ISO8859P14, CL8ISO8859P5, CL8ISOIR111, CL8KOI8R, CL8KOI8U, CL8MACCYRILLICS, CL8MSWIN1251, EE8ISO8859P2, EE8MACCES, EE8MACCROATIANS, EE8MSWIN1250, EE8PC852, EL8DEC, EL8ISO8859P7, EL8MACGREEKS, EL8MSWIN1253, EL8PC437S, EL8PC851, EL8PC869, ET8MSWIN923, HU8ABMOD, HU8CWI2, IN8ISCII, IS8PC861, IW8ISO8859P8, IW8MACHEBREWS, IW8MSWIN1255, IW8PC1507, JA16EUC, JA16EUCTILDE, JA16SJIS, JA16SJISTILDE, JA16VMS, KO16KSC5601, KO16KSCCS, KO16MSWIN949, LA8ISO6937, LA8PASSPORT, LT8MSWIN921, LT8PC772, LT8PC774, LV8PC1117, LV8PC8LR, LV8RST104090, N8PC865, NE8ISO8859P10, NEE8ISO8859P4, RU8BESTA, RU8PC855, RU8PC866, SE8ISO8859P3, TH8MACTHAIS, TH8TISASCII, TR8DEC, TR8MACTURKISHS, TR8MSWIN1254, TR8PC857, US7ASCII, US8PC437, UTF8, VN8MSWIN1258, VN8VN3, WE8DEC, WE8DG, WE8ISO8859P1, WE8ISO8859P15, WE8ISO8859P9, WE8MACROMAN8S, WE8MSWIN1252, WE8NCR4970, WE8NEXTSTEP, WE8PC850, WE8PC858, WE8PC860, WE8ROMAN8, ZHS16CGB231280, ZHS16GBK, ZHT16BIG5, ZHT16CCDC, ZHT16DBT, ZHT16HKSCS, ZHT16MSWIN950, ZHT32EUC, ZHT32SOPS, ZHT32TRIS
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+    String characterSet;
+
+    /**
+     * The national character set for the autonomous database.  The default is AL16UTF16. Allowed values are:
+     * AL16UTF16 or UTF8.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+    String ncharacterSet;
+
+    /**
      * The database name. The name must begin with an alphabetic character and can contain a maximum of 14 alphanumeric characters. Special characters are not permitted. The database name must be unique in the tenancy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbName")
@@ -336,10 +353,17 @@ public class CreateAutonomousDatabaseBase {
     java.util.List<String> standbyWhitelistedIps;
 
     /**
-     * Indicates whether the Autonomous Database has local (in-region) Data Guard enabled. Not applicable to cross-region Autonomous Data Guard associations, or to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     * **Deprecated.** Indicates whether the Autonomous Database has local (in-region) Data Guard enabled. Not applicable to cross-region Autonomous Data Guard associations, or to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isDataGuardEnabled")
     Boolean isDataGuardEnabled;
+
+    /**
+     * Indicates whether the Autonomous Database has local (in-region) Data Guard enabled. Not applicable to cross-region Autonomous Data Guard associations, or to Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+    Boolean isLocalDataGuardEnabled;
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the subnet the resource is associated with.
@@ -358,9 +382,9 @@ public class CreateAutonomousDatabaseBase {
     String subnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
@@ -42,6 +42,24 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+        private String characterSet;
+
+        public Builder characterSet(String characterSet) {
+            this.characterSet = characterSet;
+            this.__explicitlySet__.add("characterSet");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+        private String ncharacterSet;
+
+        public Builder ncharacterSet(String ncharacterSet) {
+            this.ncharacterSet = ncharacterSet;
+            this.__explicitlySet__.add("ncharacterSet");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbName")
         private String dbName;
 
@@ -233,6 +251,15 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+        private Boolean isLocalDataGuardEnabled;
+
+        public Builder isLocalDataGuardEnabled(Boolean isLocalDataGuardEnabled) {
+            this.isLocalDataGuardEnabled = isLocalDataGuardEnabled;
+            this.__explicitlySet__.add("isLocalDataGuardEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
         private String subnetId;
 
@@ -378,6 +405,8 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             CreateAutonomousDatabaseCloneDetails __instance__ =
                     new CreateAutonomousDatabaseCloneDetails(
                             compartmentId,
+                            characterSet,
+                            ncharacterSet,
                             dbName,
                             cpuCoreCount,
                             ocpuCount,
@@ -399,6 +428,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             arePrimaryWhitelistedIpsUsed,
                             standbyWhitelistedIps,
                             isDataGuardEnabled,
+                            isLocalDataGuardEnabled,
                             subnetId,
                             nsgIds,
                             privateEndpointLabel,
@@ -422,6 +452,8 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
         public Builder copy(CreateAutonomousDatabaseCloneDetails o) {
             Builder copiedBuilder =
                     compartmentId(o.getCompartmentId())
+                            .characterSet(o.getCharacterSet())
+                            .ncharacterSet(o.getNcharacterSet())
                             .dbName(o.getDbName())
                             .cpuCoreCount(o.getCpuCoreCount())
                             .ocpuCount(o.getOcpuCount())
@@ -444,6 +476,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             .arePrimaryWhitelistedIpsUsed(o.getArePrimaryWhitelistedIpsUsed())
                             .standbyWhitelistedIps(o.getStandbyWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
+                            .isLocalDataGuardEnabled(o.getIsLocalDataGuardEnabled())
                             .subnetId(o.getSubnetId())
                             .nsgIds(o.getNsgIds())
                             .privateEndpointLabel(o.getPrivateEndpointLabel())
@@ -476,6 +509,8 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
     @Deprecated
     public CreateAutonomousDatabaseCloneDetails(
             String compartmentId,
+            String characterSet,
+            String ncharacterSet,
             String dbName,
             Integer cpuCoreCount,
             Float ocpuCount,
@@ -497,6 +532,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             Boolean arePrimaryWhitelistedIpsUsed,
             java.util.List<String> standbyWhitelistedIps,
             Boolean isDataGuardEnabled,
+            Boolean isLocalDataGuardEnabled,
             String subnetId,
             java.util.List<String> nsgIds,
             String privateEndpointLabel,
@@ -514,6 +550,8 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             CloneType cloneType) {
         super(
                 compartmentId,
+                characterSet,
+                ncharacterSet,
                 dbName,
                 cpuCoreCount,
                 ocpuCount,
@@ -535,6 +573,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                 arePrimaryWhitelistedIpsUsed,
                 standbyWhitelistedIps,
                 isDataGuardEnabled,
+                isLocalDataGuardEnabled,
                 subnetId,
                 nsgIds,
                 privateEndpointLabel,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
@@ -42,6 +42,24 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+        private String characterSet;
+
+        public Builder characterSet(String characterSet) {
+            this.characterSet = characterSet;
+            this.__explicitlySet__.add("characterSet");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+        private String ncharacterSet;
+
+        public Builder ncharacterSet(String ncharacterSet) {
+            this.ncharacterSet = ncharacterSet;
+            this.__explicitlySet__.add("ncharacterSet");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbName")
         private String dbName;
 
@@ -233,6 +251,15 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+        private Boolean isLocalDataGuardEnabled;
+
+        public Builder isLocalDataGuardEnabled(Boolean isLocalDataGuardEnabled) {
+            this.isLocalDataGuardEnabled = isLocalDataGuardEnabled;
+            this.__explicitlySet__.add("isLocalDataGuardEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
         private String subnetId;
 
@@ -360,6 +387,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             CreateAutonomousDatabaseDetails __instance__ =
                     new CreateAutonomousDatabaseDetails(
                             compartmentId,
+                            characterSet,
+                            ncharacterSet,
                             dbName,
                             cpuCoreCount,
                             ocpuCount,
@@ -381,6 +410,7 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             arePrimaryWhitelistedIpsUsed,
                             standbyWhitelistedIps,
                             isDataGuardEnabled,
+                            isLocalDataGuardEnabled,
                             subnetId,
                             nsgIds,
                             privateEndpointLabel,
@@ -402,6 +432,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
         public Builder copy(CreateAutonomousDatabaseDetails o) {
             Builder copiedBuilder =
                     compartmentId(o.getCompartmentId())
+                            .characterSet(o.getCharacterSet())
+                            .ncharacterSet(o.getNcharacterSet())
                             .dbName(o.getDbName())
                             .cpuCoreCount(o.getCpuCoreCount())
                             .ocpuCount(o.getOcpuCount())
@@ -424,6 +456,7 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             .arePrimaryWhitelistedIpsUsed(o.getArePrimaryWhitelistedIpsUsed())
                             .standbyWhitelistedIps(o.getStandbyWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
+                            .isLocalDataGuardEnabled(o.getIsLocalDataGuardEnabled())
                             .subnetId(o.getSubnetId())
                             .nsgIds(o.getNsgIds())
                             .privateEndpointLabel(o.getPrivateEndpointLabel())
@@ -454,6 +487,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
     @Deprecated
     public CreateAutonomousDatabaseDetails(
             String compartmentId,
+            String characterSet,
+            String ncharacterSet,
             String dbName,
             Integer cpuCoreCount,
             Float ocpuCount,
@@ -475,6 +510,7 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             Boolean arePrimaryWhitelistedIpsUsed,
             java.util.List<String> standbyWhitelistedIps,
             Boolean isDataGuardEnabled,
+            Boolean isLocalDataGuardEnabled,
             String subnetId,
             java.util.List<String> nsgIds,
             String privateEndpointLabel,
@@ -490,6 +526,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             AutonomousDatabaseSummary.DatabaseEdition databaseEdition) {
         super(
                 compartmentId,
+                characterSet,
+                ncharacterSet,
                 dbName,
                 cpuCoreCount,
                 ocpuCount,
@@ -511,6 +549,7 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                 arePrimaryWhitelistedIpsUsed,
                 standbyWhitelistedIps,
                 isDataGuardEnabled,
+                isLocalDataGuardEnabled,
                 subnetId,
                 nsgIds,
                 privateEndpointLabel,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
@@ -42,6 +42,24 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+        private String characterSet;
+
+        public Builder characterSet(String characterSet) {
+            this.characterSet = characterSet;
+            this.__explicitlySet__.add("characterSet");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+        private String ncharacterSet;
+
+        public Builder ncharacterSet(String ncharacterSet) {
+            this.ncharacterSet = ncharacterSet;
+            this.__explicitlySet__.add("ncharacterSet");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbName")
         private String dbName;
 
@@ -233,6 +251,15 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+        private Boolean isLocalDataGuardEnabled;
+
+        public Builder isLocalDataGuardEnabled(Boolean isLocalDataGuardEnabled) {
+            this.isLocalDataGuardEnabled = isLocalDataGuardEnabled;
+            this.__explicitlySet__.add("isLocalDataGuardEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
         private String subnetId;
 
@@ -378,6 +405,8 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             CreateAutonomousDatabaseFromBackupDetails __instance__ =
                     new CreateAutonomousDatabaseFromBackupDetails(
                             compartmentId,
+                            characterSet,
+                            ncharacterSet,
                             dbName,
                             cpuCoreCount,
                             ocpuCount,
@@ -399,6 +428,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             arePrimaryWhitelistedIpsUsed,
                             standbyWhitelistedIps,
                             isDataGuardEnabled,
+                            isLocalDataGuardEnabled,
                             subnetId,
                             nsgIds,
                             privateEndpointLabel,
@@ -422,6 +452,8 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
         public Builder copy(CreateAutonomousDatabaseFromBackupDetails o) {
             Builder copiedBuilder =
                     compartmentId(o.getCompartmentId())
+                            .characterSet(o.getCharacterSet())
+                            .ncharacterSet(o.getNcharacterSet())
                             .dbName(o.getDbName())
                             .cpuCoreCount(o.getCpuCoreCount())
                             .ocpuCount(o.getOcpuCount())
@@ -444,6 +476,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             .arePrimaryWhitelistedIpsUsed(o.getArePrimaryWhitelistedIpsUsed())
                             .standbyWhitelistedIps(o.getStandbyWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
+                            .isLocalDataGuardEnabled(o.getIsLocalDataGuardEnabled())
                             .subnetId(o.getSubnetId())
                             .nsgIds(o.getNsgIds())
                             .privateEndpointLabel(o.getPrivateEndpointLabel())
@@ -476,6 +509,8 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
     @Deprecated
     public CreateAutonomousDatabaseFromBackupDetails(
             String compartmentId,
+            String characterSet,
+            String ncharacterSet,
             String dbName,
             Integer cpuCoreCount,
             Float ocpuCount,
@@ -497,6 +532,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             Boolean arePrimaryWhitelistedIpsUsed,
             java.util.List<String> standbyWhitelistedIps,
             Boolean isDataGuardEnabled,
+            Boolean isLocalDataGuardEnabled,
             String subnetId,
             java.util.List<String> nsgIds,
             String privateEndpointLabel,
@@ -514,6 +550,8 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             CloneType cloneType) {
         super(
                 compartmentId,
+                characterSet,
+                ncharacterSet,
                 dbName,
                 cpuCoreCount,
                 ocpuCount,
@@ -535,6 +573,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                 arePrimaryWhitelistedIpsUsed,
                 standbyWhitelistedIps,
                 isDataGuardEnabled,
+                isLocalDataGuardEnabled,
                 subnetId,
                 nsgIds,
                 privateEndpointLabel,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
@@ -43,6 +43,24 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+        private String characterSet;
+
+        public Builder characterSet(String characterSet) {
+            this.characterSet = characterSet;
+            this.__explicitlySet__.add("characterSet");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+        private String ncharacterSet;
+
+        public Builder ncharacterSet(String ncharacterSet) {
+            this.ncharacterSet = ncharacterSet;
+            this.__explicitlySet__.add("ncharacterSet");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbName")
         private String dbName;
 
@@ -234,6 +252,15 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+        private Boolean isLocalDataGuardEnabled;
+
+        public Builder isLocalDataGuardEnabled(Boolean isLocalDataGuardEnabled) {
+            this.isLocalDataGuardEnabled = isLocalDataGuardEnabled;
+            this.__explicitlySet__.add("isLocalDataGuardEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
         private String subnetId;
 
@@ -388,6 +415,8 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             CreateAutonomousDatabaseFromBackupTimestampDetails __instance__ =
                     new CreateAutonomousDatabaseFromBackupTimestampDetails(
                             compartmentId,
+                            characterSet,
+                            ncharacterSet,
                             dbName,
                             cpuCoreCount,
                             ocpuCount,
@@ -409,6 +438,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             arePrimaryWhitelistedIpsUsed,
                             standbyWhitelistedIps,
                             isDataGuardEnabled,
+                            isLocalDataGuardEnabled,
                             subnetId,
                             nsgIds,
                             privateEndpointLabel,
@@ -433,6 +463,8 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
         public Builder copy(CreateAutonomousDatabaseFromBackupTimestampDetails o) {
             Builder copiedBuilder =
                     compartmentId(o.getCompartmentId())
+                            .characterSet(o.getCharacterSet())
+                            .ncharacterSet(o.getNcharacterSet())
                             .dbName(o.getDbName())
                             .cpuCoreCount(o.getCpuCoreCount())
                             .ocpuCount(o.getOcpuCount())
@@ -455,6 +487,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             .arePrimaryWhitelistedIpsUsed(o.getArePrimaryWhitelistedIpsUsed())
                             .standbyWhitelistedIps(o.getStandbyWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
+                            .isLocalDataGuardEnabled(o.getIsLocalDataGuardEnabled())
                             .subnetId(o.getSubnetId())
                             .nsgIds(o.getNsgIds())
                             .privateEndpointLabel(o.getPrivateEndpointLabel())
@@ -488,6 +521,8 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
     @Deprecated
     public CreateAutonomousDatabaseFromBackupTimestampDetails(
             String compartmentId,
+            String characterSet,
+            String ncharacterSet,
             String dbName,
             Integer cpuCoreCount,
             Float ocpuCount,
@@ -509,6 +544,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             Boolean arePrimaryWhitelistedIpsUsed,
             java.util.List<String> standbyWhitelistedIps,
             Boolean isDataGuardEnabled,
+            Boolean isLocalDataGuardEnabled,
             String subnetId,
             java.util.List<String> nsgIds,
             String privateEndpointLabel,
@@ -527,6 +563,8 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             CloneType cloneType) {
         super(
                 compartmentId,
+                characterSet,
+                ncharacterSet,
                 dbName,
                 cpuCoreCount,
                 ocpuCount,
@@ -548,6 +586,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                 arePrimaryWhitelistedIpsUsed,
                 standbyWhitelistedIps,
                 isDataGuardEnabled,
+                isLocalDataGuardEnabled,
                 subnetId,
                 nsgIds,
                 privateEndpointLabel,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCloudAutonomousVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCloudAutonomousVmClusterDetails.java
@@ -233,9 +233,9 @@ public class CreateCloudAutonomousVmClusterDetails {
     LicenseModel licenseModel;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCloudVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCloudVmClusterDetails.java
@@ -480,9 +480,9 @@ public class CreateCloudVmClusterDetails {
     Integer scanListenerPortTcpSsl;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCrossRegionAutonomousDatabaseDataGuardDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCrossRegionAutonomousDatabaseDataGuardDetails.java
@@ -6,6 +6,10 @@ package com.oracle.bmc.database.model;
 
 /**
  * Details to create an Autonomous Data Guard association for an existing Autonomous Database where the standby is in a different (remote) region from the source primary database.
+ * *IMPORTANT*
+ * Note the following for creating standby databases in cross-region Autonomous Data Guard associations:
+ *   - To create your standby database in a region different from the region of the primary, use the API endpoint of the region in which the standby will be located. For example, if the primary database is in the IAD region, and you want to create the standby in the PHX region, make the API call using the PHX endpoint (https://database.us-phoenix-1.oraclecloud.com). See [API Endpoints](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#REST_APIs) for the list of Database Service API endpoints.
+ *   - In the request to create the standby database, the {@code sourceId} value should be the OCID of the primary database.
  * The following parameters are required for the cross-region standby database and must contain the same values as the source Autonomous Database:
  *   - dbName
  *   - cpuCoreCount
@@ -21,7 +25,7 @@ package com.oracle.bmc.database.model;
  *   - whitelistedIps
  *   - isMtlsConnectionRequired
  * Example I - Creating a cross-region standby with required parameters only:
- *     {
+ *     {@code {
  *       "compartmentId": "ocid.compartment.oc1..<var>&lt;unique_ID&gt;</var>",
  *       "cpuCoreCount": 1,
  *       "dbName": "adatabasedb1",
@@ -29,9 +33,9 @@ package com.oracle.bmc.database.model;
  *       "dataStorageSizeInTBs": 1,
  *       "source": "CROSS_REGION_DATAGUARD",
  *       "adminPassword" : "<var>&lt;password&gt;</var>",
- *     }
+ *     }}
  *  Example II - Creating a cross-region standby that specifies optional parameters in addition to the required parameters:
- *     {
+ *     {@code {
  *       "compartmentId": "ocid.compartment.oc1..<var>&lt;unique_ID&gt;</var>",
  *       "cpuCoreCount": 1,
  *       "dbName": "adatabasedb1",
@@ -42,7 +46,7 @@ package com.oracle.bmc.database.model;
  *       "dbVersion": "19c",
  *       "licenseModel": "LICENSE_INCLUDED",
  *       "isAutoScalingForStorageEnabled": "true"
- *     }
+ *     }}
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -77,6 +81,24 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
         public Builder compartmentId(String compartmentId) {
             this.compartmentId = compartmentId;
             this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+        private String characterSet;
+
+        public Builder characterSet(String characterSet) {
+            this.characterSet = characterSet;
+            this.__explicitlySet__.add("characterSet");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+        private String ncharacterSet;
+
+        public Builder ncharacterSet(String ncharacterSet) {
+            this.ncharacterSet = ncharacterSet;
+            this.__explicitlySet__.add("ncharacterSet");
             return this;
         }
 
@@ -271,6 +293,15 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+        private Boolean isLocalDataGuardEnabled;
+
+        public Builder isLocalDataGuardEnabled(Boolean isLocalDataGuardEnabled) {
+            this.isLocalDataGuardEnabled = isLocalDataGuardEnabled;
+            this.__explicitlySet__.add("isLocalDataGuardEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
         private String subnetId;
 
@@ -407,6 +438,8 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
             CreateCrossRegionAutonomousDatabaseDataGuardDetails __instance__ =
                     new CreateCrossRegionAutonomousDatabaseDataGuardDetails(
                             compartmentId,
+                            characterSet,
+                            ncharacterSet,
                             dbName,
                             cpuCoreCount,
                             ocpuCount,
@@ -428,6 +461,7 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
                             arePrimaryWhitelistedIpsUsed,
                             standbyWhitelistedIps,
                             isDataGuardEnabled,
+                            isLocalDataGuardEnabled,
                             subnetId,
                             nsgIds,
                             privateEndpointLabel,
@@ -450,6 +484,8 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
         public Builder copy(CreateCrossRegionAutonomousDatabaseDataGuardDetails o) {
             Builder copiedBuilder =
                     compartmentId(o.getCompartmentId())
+                            .characterSet(o.getCharacterSet())
+                            .ncharacterSet(o.getNcharacterSet())
                             .dbName(o.getDbName())
                             .cpuCoreCount(o.getCpuCoreCount())
                             .ocpuCount(o.getOcpuCount())
@@ -472,6 +508,7 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
                             .arePrimaryWhitelistedIpsUsed(o.getArePrimaryWhitelistedIpsUsed())
                             .standbyWhitelistedIps(o.getStandbyWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
+                            .isLocalDataGuardEnabled(o.getIsLocalDataGuardEnabled())
                             .subnetId(o.getSubnetId())
                             .nsgIds(o.getNsgIds())
                             .privateEndpointLabel(o.getPrivateEndpointLabel())
@@ -503,6 +540,8 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
     @Deprecated
     public CreateCrossRegionAutonomousDatabaseDataGuardDetails(
             String compartmentId,
+            String characterSet,
+            String ncharacterSet,
             String dbName,
             Integer cpuCoreCount,
             Float ocpuCount,
@@ -524,6 +563,7 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
             Boolean arePrimaryWhitelistedIpsUsed,
             java.util.List<String> standbyWhitelistedIps,
             Boolean isDataGuardEnabled,
+            Boolean isLocalDataGuardEnabled,
             String subnetId,
             java.util.List<String> nsgIds,
             String privateEndpointLabel,
@@ -540,6 +580,8 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
             String sourceId) {
         super(
                 compartmentId,
+                characterSet,
+                ncharacterSet,
                 dbName,
                 cpuCoreCount,
                 ocpuCount,
@@ -561,6 +603,7 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
                 arePrimaryWhitelistedIpsUsed,
                 standbyWhitelistedIps,
                 isDataGuardEnabled,
+                isLocalDataGuardEnabled,
                 subnetId,
                 nsgIds,
                 privateEndpointLabel,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationWithNewDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationWithNewDbSystemDetails.java
@@ -126,6 +126,25 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+        private Integer cpuCoreCount;
+
+        public Builder cpuCoreCount(Integer cpuCoreCount) {
+            this.cpuCoreCount = cpuCoreCount;
+            this.__explicitlySet__.add("cpuCoreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+        private StorageVolumePerformanceMode storageVolumePerformanceMode;
+
+        public Builder storageVolumePerformanceMode(
+                StorageVolumePerformanceMode storageVolumePerformanceMode) {
+            this.storageVolumePerformanceMode = storageVolumePerformanceMode;
+            this.__explicitlySet__.add("storageVolumePerformanceMode");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
         private String subnetId;
 
@@ -178,6 +197,8 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
                             displayName,
                             availabilityDomain,
                             shape,
+                            cpuCoreCount,
+                            storageVolumePerformanceMode,
                             subnetId,
                             nsgIds,
                             backupNetworkNsgIds,
@@ -199,6 +220,8 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
                             .displayName(o.getDisplayName())
                             .availabilityDomain(o.getAvailabilityDomain())
                             .shape(o.getShape())
+                            .cpuCoreCount(o.getCpuCoreCount())
+                            .storageVolumePerformanceMode(o.getStorageVolumePerformanceMode())
                             .subnetId(o.getSubnetId())
                             .nsgIds(o.getNsgIds())
                             .backupNetworkNsgIds(o.getBackupNetworkNsgIds())
@@ -228,6 +251,8 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
             String displayName,
             String availabilityDomain,
             String shape,
+            Integer cpuCoreCount,
+            StorageVolumePerformanceMode storageVolumePerformanceMode,
             String subnetId,
             java.util.List<String> nsgIds,
             java.util.List<String> backupNetworkNsgIds,
@@ -243,6 +268,8 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
         this.displayName = displayName;
         this.availabilityDomain = availabilityDomain;
         this.shape = shape;
+        this.cpuCoreCount = cpuCoreCount;
+        this.storageVolumePerformanceMode = storageVolumePerformanceMode;
         this.subnetId = subnetId;
         this.nsgIds = nsgIds;
         this.backupNetworkNsgIds = backupNetworkNsgIds;
@@ -272,6 +299,54 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
     String shape;
 
     /**
+     * The number of OCPU cores available for AMD-based virtual machine DB systems.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+    Integer cpuCoreCount;
+    /**
+     * The block storage volume performance level. Valid values are {@code BALANCED} and {@code HIGH_PERFORMANCE}. See [Block Volume Performance](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeperformance.htm) for more information.
+     *
+     **/
+    public enum StorageVolumePerformanceMode {
+        Balanced("BALANCED"),
+        HighPerformance("HIGH_PERFORMANCE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, StorageVolumePerformanceMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (StorageVolumePerformanceMode v : StorageVolumePerformanceMode.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        StorageVolumePerformanceMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static StorageVolumePerformanceMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid StorageVolumePerformanceMode: " + key);
+        }
+    };
+    /**
+     * The block storage volume performance level. Valid values are {@code BALANCED} and {@code HIGH_PERFORMANCE}. See [Block Volume Performance](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeperformance.htm) for more information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+    StorageVolumePerformanceMode storageVolumePerformanceMode;
+
+    /**
      * The OCID of the subnet the DB system is associated with.
      * **Subnet Restrictions:**
      * - For 1- and 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.16.16/28
@@ -285,9 +360,9 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
     String subnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseSoftwareImageDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseSoftwareImageDetails.java
@@ -291,7 +291,7 @@ public class CreateDatabaseSoftwareImageDetails {
     java.util.List<String> databaseSoftwareImageOneOffPatches;
 
     /**
-     * output from lsinventory which will get passed as a string
+     * The output from the OPatch lsInventory command, which is passed as a string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lsInventory")
     String lsInventory;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
@@ -42,6 +42,24 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
+        private String characterSet;
+
+        public Builder characterSet(String characterSet) {
+            this.characterSet = characterSet;
+            this.__explicitlySet__.add("characterSet");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ncharacterSet")
+        private String ncharacterSet;
+
+        public Builder ncharacterSet(String ncharacterSet) {
+            this.ncharacterSet = ncharacterSet;
+            this.__explicitlySet__.add("ncharacterSet");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbName")
         private String dbName;
 
@@ -233,6 +251,15 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+        private Boolean isLocalDataGuardEnabled;
+
+        public Builder isLocalDataGuardEnabled(Boolean isLocalDataGuardEnabled) {
+            this.isLocalDataGuardEnabled = isLocalDataGuardEnabled;
+            this.__explicitlySet__.add("isLocalDataGuardEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
         private String subnetId;
 
@@ -378,6 +405,8 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             CreateRefreshableAutonomousDatabaseCloneDetails __instance__ =
                     new CreateRefreshableAutonomousDatabaseCloneDetails(
                             compartmentId,
+                            characterSet,
+                            ncharacterSet,
                             dbName,
                             cpuCoreCount,
                             ocpuCount,
@@ -399,6 +428,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             arePrimaryWhitelistedIpsUsed,
                             standbyWhitelistedIps,
                             isDataGuardEnabled,
+                            isLocalDataGuardEnabled,
                             subnetId,
                             nsgIds,
                             privateEndpointLabel,
@@ -422,6 +452,8 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
         public Builder copy(CreateRefreshableAutonomousDatabaseCloneDetails o) {
             Builder copiedBuilder =
                     compartmentId(o.getCompartmentId())
+                            .characterSet(o.getCharacterSet())
+                            .ncharacterSet(o.getNcharacterSet())
                             .dbName(o.getDbName())
                             .cpuCoreCount(o.getCpuCoreCount())
                             .ocpuCount(o.getOcpuCount())
@@ -444,6 +476,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             .arePrimaryWhitelistedIpsUsed(o.getArePrimaryWhitelistedIpsUsed())
                             .standbyWhitelistedIps(o.getStandbyWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
+                            .isLocalDataGuardEnabled(o.getIsLocalDataGuardEnabled())
                             .subnetId(o.getSubnetId())
                             .nsgIds(o.getNsgIds())
                             .privateEndpointLabel(o.getPrivateEndpointLabel())
@@ -476,6 +509,8 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
     @Deprecated
     public CreateRefreshableAutonomousDatabaseCloneDetails(
             String compartmentId,
+            String characterSet,
+            String ncharacterSet,
             String dbName,
             Integer cpuCoreCount,
             Float ocpuCount,
@@ -497,6 +532,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             Boolean arePrimaryWhitelistedIpsUsed,
             java.util.List<String> standbyWhitelistedIps,
             Boolean isDataGuardEnabled,
+            Boolean isLocalDataGuardEnabled,
             String subnetId,
             java.util.List<String> nsgIds,
             String privateEndpointLabel,
@@ -514,6 +550,8 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             RefreshableMode refreshableMode) {
         super(
                 compartmentId,
+                characterSet,
+                ncharacterSet,
                 dbName,
                 cpuCoreCount,
                 ocpuCount,
@@ -535,6 +573,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                 arePrimaryWhitelistedIpsUsed,
                 standbyWhitelistedIps,
                 isDataGuardEnabled,
+                isLocalDataGuardEnabled,
                 subnetId,
                 nsgIds,
                 privateEndpointLabel,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DataCollectionOptions.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DataCollectionOptions.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.database.model;
 
 /**
- * Indicates user preferences for the various diagnostic collection options for the VM cluster.
+ * Indicates user preferences for the various diagnostic collection options for the VM cluster/Cloud VM cluster/VMBM DBCS.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -63,7 +63,7 @@ public class DataCollectionOptions {
     }
 
     /**
-     * Indicates whether diagnostic collection is enabled for the VM cluster. Enabling diagnostic collection allows you to receive Events service notifications for guest VM issues. Diagnostic collection also allows Oracle to provide enhanced service and proactive support for your Exadata system. You can enable diagnostic collection during VM cluster provisioning. You can also disable or enable it at any time using the {@code UpdateVmCluster} API.
+     * Indicates whether diagnostic collection is enabled for the VM cluster/Cloud VM cluster/VMBM DBCS. Enabling diagnostic collection allows you to receive Events service notifications for guest VM issues. Diagnostic collection also allows Oracle to provide enhanced service and proactive support for your Exadata system. You can enable diagnostic collection during VM cluster/Cloud VM cluster provisioning. You can also disable or enable it at any time using the {@code UpdateVmCluster} or {@code updateCloudVmCluster} API.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isDiagnosticsEventsEnabled")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSoftwareImage.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSoftwareImage.java
@@ -484,7 +484,7 @@ public class DatabaseSoftwareImage {
     java.util.List<String> databaseSoftwareImageOneOffPatches;
 
     /**
-     * output from lsinventory which will get passed as a string
+     * The output from the OPatch lsInventory command, which is passed as a string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lsInventory")
     String lsInventory;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSoftwareImageSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSoftwareImageSummary.java
@@ -490,7 +490,7 @@ public class DatabaseSoftwareImageSummary {
     java.util.List<String> databaseSoftwareImageOneOffPatches;
 
     /**
-     * output from lsinventory which will get passed as a string
+     * The output from the OPatch lsInventory command, which is passed as a string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lsInventory")
     String lsInventory;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystem.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystem.java
@@ -114,6 +114,25 @@ public class DbSystem {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+        private StorageVolumePerformanceMode storageVolumePerformanceMode;
+
+        public Builder storageVolumePerformanceMode(
+                StorageVolumePerformanceMode storageVolumePerformanceMode) {
+            this.storageVolumePerformanceMode = storageVolumePerformanceMode;
+            this.__explicitlySet__.add("storageVolumePerformanceMode");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("shape")
         private String shape;
 
@@ -447,6 +466,8 @@ public class DbSystem {
                             backupSubnetId,
                             nsgIds,
                             backupNetworkNsgIds,
+                            memorySizeInGBs,
+                            storageVolumePerformanceMode,
                             shape,
                             dbSystemOptions,
                             sshPublicKeys,
@@ -499,6 +520,8 @@ public class DbSystem {
                             .backupSubnetId(o.getBackupSubnetId())
                             .nsgIds(o.getNsgIds())
                             .backupNetworkNsgIds(o.getBackupNetworkNsgIds())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .storageVolumePerformanceMode(o.getStorageVolumePerformanceMode())
                             .shape(o.getShape())
                             .dbSystemOptions(o.getDbSystemOptions())
                             .sshPublicKeys(o.getSshPublicKeys())
@@ -606,9 +629,9 @@ public class DbSystem {
     String backupSubnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
@@ -620,6 +643,65 @@ public class DbSystem {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("backupNetworkNsgIds")
     java.util.List<String> backupNetworkNsgIds;
+
+    /**
+     * Memory allocated to the DB system, in gigabytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+    /**
+     * The block storage volume performance level. Valid values are {@code BALANCED} and {@code HIGH_PERFORMANCE}. See [Block Volume Performance](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeperformance.htm) for more information.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum StorageVolumePerformanceMode {
+        Balanced("BALANCED"),
+        HighPerformance("HIGH_PERFORMANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, StorageVolumePerformanceMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (StorageVolumePerformanceMode v : StorageVolumePerformanceMode.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        StorageVolumePerformanceMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static StorageVolumePerformanceMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'StorageVolumePerformanceMode', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The block storage volume performance level. Valid values are {@code BALANCED} and {@code HIGH_PERFORMANCE}. See [Block Volume Performance](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeperformance.htm) for more information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+    StorageVolumePerformanceMode storageVolumePerformanceMode;
 
     /**
      * The shape of the DB system. The shape determines resources to allocate to the DB system.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemComputePerformanceSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemComputePerformanceSummary.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Representation of disk performance detail parameters.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DbSystemComputePerformanceSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DbSystemComputePerformanceSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("shape")
+        private String shape;
+
+        public Builder shape(String shape) {
+            this.shape = shape;
+            this.__explicitlySet__.add("shape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computePerformanceList")
+        private java.util.List<ComputePerformanceSummary> computePerformanceList;
+
+        public Builder computePerformanceList(
+                java.util.List<ComputePerformanceSummary> computePerformanceList) {
+            this.computePerformanceList = computePerformanceList;
+            this.__explicitlySet__.add("computePerformanceList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DbSystemComputePerformanceSummary build() {
+            DbSystemComputePerformanceSummary __instance__ =
+                    new DbSystemComputePerformanceSummary(shape, computePerformanceList);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DbSystemComputePerformanceSummary o) {
+            Builder copiedBuilder =
+                    shape(o.getShape()).computePerformanceList(o.getComputePerformanceList());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The shape of the DB system.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shape")
+    String shape;
+
+    /**
+     * List of Compute performance details for the specified DB system shape.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computePerformanceList")
+    java.util.List<ComputePerformanceSummary> computePerformanceList;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemShapeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemShapeSummary.java
@@ -49,6 +49,15 @@ public class DbSystemShapeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeType")
+        private ShapeType shapeType;
+
+        public Builder shapeType(ShapeType shapeType) {
+            this.shapeType = shapeType;
+            this.__explicitlySet__.add("shapeType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("shape")
         private String shape;
 
@@ -229,6 +238,7 @@ public class DbSystemShapeSummary {
                     new DbSystemShapeSummary(
                             name,
                             shapeFamily,
+                            shapeType,
                             shape,
                             availableCoreCount,
                             minimumCoreCount,
@@ -257,6 +267,7 @@ public class DbSystemShapeSummary {
             Builder copiedBuilder =
                     name(o.getName())
                             .shapeFamily(o.getShapeFamily())
+                            .shapeType(o.getShapeType())
                             .shape(o.getShape())
                             .availableCoreCount(o.getAvailableCoreCount())
                             .minimumCoreCount(o.getMinimumCoreCount())
@@ -301,6 +312,57 @@ public class DbSystemShapeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("shapeFamily")
     String shapeFamily;
+    /**
+     * The shape type for the virtual machine DB system. Shape type is determined by CPU hardware. Valid values are {@code AMD} and {@code INTEL}.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ShapeType {
+        Amd("AMD"),
+        Intel("INTEL"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ShapeType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ShapeType v : ShapeType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ShapeType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ShapeType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ShapeType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The shape type for the virtual machine DB system. Shape type is determined by CPU hardware. Valid values are {@code AMD} and {@code INTEL}.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeType")
+    ShapeType shapeType;
 
     /**
      * Deprecated. Use {@code name} instead of {@code shape}.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemStoragePerformanceSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemStoragePerformanceSummary.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Representation of storage performance summary per shapeType .
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DbSystemStoragePerformanceSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DbSystemStoragePerformanceSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeType")
+        private ShapeType shapeType;
+
+        public Builder shapeType(ShapeType shapeType) {
+            this.shapeType = shapeType;
+            this.__explicitlySet__.add("shapeType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStoragePerformanceList")
+        private java.util.List<StoragePerformanceDetails> dataStoragePerformanceList;
+
+        public Builder dataStoragePerformanceList(
+                java.util.List<StoragePerformanceDetails> dataStoragePerformanceList) {
+            this.dataStoragePerformanceList = dataStoragePerformanceList;
+            this.__explicitlySet__.add("dataStoragePerformanceList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("recoStoragePerformanceList")
+        private java.util.List<StoragePerformanceDetails> recoStoragePerformanceList;
+
+        public Builder recoStoragePerformanceList(
+                java.util.List<StoragePerformanceDetails> recoStoragePerformanceList) {
+            this.recoStoragePerformanceList = recoStoragePerformanceList;
+            this.__explicitlySet__.add("recoStoragePerformanceList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DbSystemStoragePerformanceSummary build() {
+            DbSystemStoragePerformanceSummary __instance__ =
+                    new DbSystemStoragePerformanceSummary(
+                            shapeType, dataStoragePerformanceList, recoStoragePerformanceList);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DbSystemStoragePerformanceSummary o) {
+            Builder copiedBuilder =
+                    shapeType(o.getShapeType())
+                            .dataStoragePerformanceList(o.getDataStoragePerformanceList())
+                            .recoStoragePerformanceList(o.getRecoStoragePerformanceList());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * ShapeType of the DbSystems,INTEL or AMD
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ShapeType {
+        Amd("AMD"),
+        Intel("INTEL"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ShapeType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ShapeType v : ShapeType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ShapeType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ShapeType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ShapeType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * ShapeType of the DbSystems,INTEL or AMD
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeType")
+    ShapeType shapeType;
+
+    /**
+     * List of storage performance for the DATA disks
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataStoragePerformanceList")
+    java.util.List<StoragePerformanceDetails> dataStoragePerformanceList;
+
+    /**
+     * List of storage performance for the RECO disks
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("recoStoragePerformanceList")
+    java.util.List<StoragePerformanceDetails> recoStoragePerformanceList;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemSummary.java
@@ -127,6 +127,25 @@ public class DbSystemSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+        private StorageVolumePerformanceMode storageVolumePerformanceMode;
+
+        public Builder storageVolumePerformanceMode(
+                StorageVolumePerformanceMode storageVolumePerformanceMode) {
+            this.storageVolumePerformanceMode = storageVolumePerformanceMode;
+            this.__explicitlySet__.add("storageVolumePerformanceMode");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("shape")
         private String shape;
 
@@ -459,6 +478,8 @@ public class DbSystemSummary {
                             backupSubnetId,
                             nsgIds,
                             backupNetworkNsgIds,
+                            memorySizeInGBs,
+                            storageVolumePerformanceMode,
                             shape,
                             dbSystemOptions,
                             sshPublicKeys,
@@ -510,6 +531,8 @@ public class DbSystemSummary {
                             .backupSubnetId(o.getBackupSubnetId())
                             .nsgIds(o.getNsgIds())
                             .backupNetworkNsgIds(o.getBackupNetworkNsgIds())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .storageVolumePerformanceMode(o.getStorageVolumePerformanceMode())
                             .shape(o.getShape())
                             .dbSystemOptions(o.getDbSystemOptions())
                             .sshPublicKeys(o.getSshPublicKeys())
@@ -614,9 +637,9 @@ public class DbSystemSummary {
     String backupSubnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
@@ -628,6 +651,65 @@ public class DbSystemSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("backupNetworkNsgIds")
     java.util.List<String> backupNetworkNsgIds;
+
+    /**
+     * Memory allocated to the DB system, in gigabytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+    /**
+     * The block storage volume performance level. Valid values are {@code BALANCED} and {@code HIGH_PERFORMANCE}. See [Block Volume Performance](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeperformance.htm) for more information.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum StorageVolumePerformanceMode {
+        Balanced("BALANCED"),
+        HighPerformance("HIGH_PERFORMANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, StorageVolumePerformanceMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (StorageVolumePerformanceMode v : StorageVolumePerformanceMode.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        StorageVolumePerformanceMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static StorageVolumePerformanceMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'StorageVolumePerformanceMode', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The block storage volume performance level. Valid values are {@code BALANCED} and {@code HIGH_PERFORMANCE}. See [Block Volume Performance](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeperformance.htm) for more information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+    StorageVolumePerformanceMode storageVolumePerformanceMode;
 
     /**
      * The shape of the DB system. The shape determines resources to allocate to the DB system.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DiskPerformanceDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DiskPerformanceDetails.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Representation of disk performance detail parameters.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DiskPerformanceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DiskPerformanceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("diskIops")
+        private Float diskIops;
+
+        public Builder diskIops(Float diskIops) {
+            this.diskIops = diskIops;
+            this.__explicitlySet__.add("diskIops");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("diskThroughputInMbps")
+        private Float diskThroughputInMbps;
+
+        public Builder diskThroughputInMbps(Float diskThroughputInMbps) {
+            this.diskThroughputInMbps = diskThroughputInMbps;
+            this.__explicitlySet__.add("diskThroughputInMbps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DiskPerformanceDetails build() {
+            DiskPerformanceDetails __instance__ =
+                    new DiskPerformanceDetails(diskIops, diskThroughputInMbps);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DiskPerformanceDetails o) {
+            Builder copiedBuilder =
+                    diskIops(o.getDiskIops()).diskThroughputInMbps(o.getDiskThroughputInMbps());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Disk IOPS in thousands.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("diskIops")
+    Float diskIops;
+
+    /**
+     * Disk Throughput in Mbps.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("diskThroughputInMbps")
+    Float diskThroughputInMbps;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchAutonomousExadataInfrastructureDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchAutonomousExadataInfrastructureDetails.java
@@ -208,9 +208,9 @@ public class LaunchAutonomousExadataInfrastructureDetails {
     String subnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemBase.java
@@ -117,9 +117,9 @@ public class LaunchDbSystemBase {
     String backupSubnetId;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
@@ -151,6 +151,48 @@ public class LaunchDbSystemBase {
 
     @com.fasterxml.jackson.annotation.JsonProperty("dbSystemOptions")
     DbSystemOptions dbSystemOptions;
+    /**
+     * The block storage volume performance level. Valid values are {@code BALANCED} and {@code HIGH_PERFORMANCE}. See [Block Volume Performance](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeperformance.htm) for more information.
+     *
+     **/
+    public enum StorageVolumePerformanceMode {
+        Balanced("BALANCED"),
+        HighPerformance("HIGH_PERFORMANCE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, StorageVolumePerformanceMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (StorageVolumePerformanceMode v : StorageVolumePerformanceMode.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        StorageVolumePerformanceMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static StorageVolumePerformanceMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid StorageVolumePerformanceMode: " + key);
+        }
+    };
+    /**
+     * The block storage volume performance level. Valid values are {@code BALANCED} and {@code HIGH_PERFORMANCE}. See [Block Volume Performance](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeperformance.htm) for more information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+    StorageVolumePerformanceMode storageVolumePerformanceMode;
 
     /**
      * If true, Sparse Diskgroup is configured for Exadata dbsystem. If False, Sparse diskgroup is not configured.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemDetails.java
@@ -132,6 +132,16 @@ public class LaunchDbSystemDetails extends LaunchDbSystemBase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+        private StorageVolumePerformanceMode storageVolumePerformanceMode;
+
+        public Builder storageVolumePerformanceMode(
+                StorageVolumePerformanceMode storageVolumePerformanceMode) {
+            this.storageVolumePerformanceMode = storageVolumePerformanceMode;
+            this.__explicitlySet__.add("storageVolumePerformanceMode");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sparseDiskgroup")
         private Boolean sparseDiskgroup;
 
@@ -321,6 +331,7 @@ public class LaunchDbSystemDetails extends LaunchDbSystemBase {
                             shape,
                             timeZone,
                             dbSystemOptions,
+                            storageVolumePerformanceMode,
                             sparseDiskgroup,
                             sshPublicKeys,
                             hostname,
@@ -358,6 +369,7 @@ public class LaunchDbSystemDetails extends LaunchDbSystemBase {
                             .shape(o.getShape())
                             .timeZone(o.getTimeZone())
                             .dbSystemOptions(o.getDbSystemOptions())
+                            .storageVolumePerformanceMode(o.getStorageVolumePerformanceMode())
                             .sparseDiskgroup(o.getSparseDiskgroup())
                             .sshPublicKeys(o.getSshPublicKeys())
                             .hostname(o.getHostname())
@@ -403,6 +415,7 @@ public class LaunchDbSystemDetails extends LaunchDbSystemBase {
             String shape,
             String timeZone,
             DbSystemOptions dbSystemOptions,
+            StorageVolumePerformanceMode storageVolumePerformanceMode,
             Boolean sparseDiskgroup,
             java.util.List<String> sshPublicKeys,
             String hostname,
@@ -434,6 +447,7 @@ public class LaunchDbSystemDetails extends LaunchDbSystemBase {
                 shape,
                 timeZone,
                 dbSystemOptions,
+                storageVolumePerformanceMode,
                 sparseDiskgroup,
                 sshPublicKeys,
                 hostname,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemFromBackupDetails.java
@@ -132,6 +132,16 @@ public class LaunchDbSystemFromBackupDetails extends LaunchDbSystemBase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+        private StorageVolumePerformanceMode storageVolumePerformanceMode;
+
+        public Builder storageVolumePerformanceMode(
+                StorageVolumePerformanceMode storageVolumePerformanceMode) {
+            this.storageVolumePerformanceMode = storageVolumePerformanceMode;
+            this.__explicitlySet__.add("storageVolumePerformanceMode");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sparseDiskgroup")
         private Boolean sparseDiskgroup;
 
@@ -312,6 +322,7 @@ public class LaunchDbSystemFromBackupDetails extends LaunchDbSystemBase {
                             shape,
                             timeZone,
                             dbSystemOptions,
+                            storageVolumePerformanceMode,
                             sparseDiskgroup,
                             sshPublicKeys,
                             hostname,
@@ -348,6 +359,7 @@ public class LaunchDbSystemFromBackupDetails extends LaunchDbSystemBase {
                             .shape(o.getShape())
                             .timeZone(o.getTimeZone())
                             .dbSystemOptions(o.getDbSystemOptions())
+                            .storageVolumePerformanceMode(o.getStorageVolumePerformanceMode())
                             .sparseDiskgroup(o.getSparseDiskgroup())
                             .sshPublicKeys(o.getSshPublicKeys())
                             .hostname(o.getHostname())
@@ -392,6 +404,7 @@ public class LaunchDbSystemFromBackupDetails extends LaunchDbSystemBase {
             String shape,
             String timeZone,
             DbSystemOptions dbSystemOptions,
+            StorageVolumePerformanceMode storageVolumePerformanceMode,
             Boolean sparseDiskgroup,
             java.util.List<String> sshPublicKeys,
             String hostname,
@@ -422,6 +435,7 @@ public class LaunchDbSystemFromBackupDetails extends LaunchDbSystemBase {
                 shape,
                 timeZone,
                 dbSystemOptions,
+                storageVolumePerformanceMode,
                 sparseDiskgroup,
                 sshPublicKeys,
                 hostname,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemFromDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemFromDatabaseDetails.java
@@ -132,6 +132,16 @@ public class LaunchDbSystemFromDatabaseDetails extends LaunchDbSystemBase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+        private StorageVolumePerformanceMode storageVolumePerformanceMode;
+
+        public Builder storageVolumePerformanceMode(
+                StorageVolumePerformanceMode storageVolumePerformanceMode) {
+            this.storageVolumePerformanceMode = storageVolumePerformanceMode;
+            this.__explicitlySet__.add("storageVolumePerformanceMode");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sparseDiskgroup")
         private Boolean sparseDiskgroup;
 
@@ -312,6 +322,7 @@ public class LaunchDbSystemFromDatabaseDetails extends LaunchDbSystemBase {
                             shape,
                             timeZone,
                             dbSystemOptions,
+                            storageVolumePerformanceMode,
                             sparseDiskgroup,
                             sshPublicKeys,
                             hostname,
@@ -348,6 +359,7 @@ public class LaunchDbSystemFromDatabaseDetails extends LaunchDbSystemBase {
                             .shape(o.getShape())
                             .timeZone(o.getTimeZone())
                             .dbSystemOptions(o.getDbSystemOptions())
+                            .storageVolumePerformanceMode(o.getStorageVolumePerformanceMode())
                             .sparseDiskgroup(o.getSparseDiskgroup())
                             .sshPublicKeys(o.getSshPublicKeys())
                             .hostname(o.getHostname())
@@ -392,6 +404,7 @@ public class LaunchDbSystemFromDatabaseDetails extends LaunchDbSystemBase {
             String shape,
             String timeZone,
             DbSystemOptions dbSystemOptions,
+            StorageVolumePerformanceMode storageVolumePerformanceMode,
             Boolean sparseDiskgroup,
             java.util.List<String> sshPublicKeys,
             String hostname,
@@ -422,6 +435,7 @@ public class LaunchDbSystemFromDatabaseDetails extends LaunchDbSystemBase {
                 shape,
                 timeZone,
                 dbSystemOptions,
+                storageVolumePerformanceMode,
                 sparseDiskgroup,
                 sshPublicKeys,
                 hostname,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemFromDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemFromDbSystemDetails.java
@@ -132,6 +132,16 @@ public class LaunchDbSystemFromDbSystemDetails extends LaunchDbSystemBase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("storageVolumePerformanceMode")
+        private StorageVolumePerformanceMode storageVolumePerformanceMode;
+
+        public Builder storageVolumePerformanceMode(
+                StorageVolumePerformanceMode storageVolumePerformanceMode) {
+            this.storageVolumePerformanceMode = storageVolumePerformanceMode;
+            this.__explicitlySet__.add("storageVolumePerformanceMode");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sparseDiskgroup")
         private Boolean sparseDiskgroup;
 
@@ -303,6 +313,7 @@ public class LaunchDbSystemFromDbSystemDetails extends LaunchDbSystemBase {
                             shape,
                             timeZone,
                             dbSystemOptions,
+                            storageVolumePerformanceMode,
                             sparseDiskgroup,
                             sshPublicKeys,
                             hostname,
@@ -338,6 +349,7 @@ public class LaunchDbSystemFromDbSystemDetails extends LaunchDbSystemBase {
                             .shape(o.getShape())
                             .timeZone(o.getTimeZone())
                             .dbSystemOptions(o.getDbSystemOptions())
+                            .storageVolumePerformanceMode(o.getStorageVolumePerformanceMode())
                             .sparseDiskgroup(o.getSparseDiskgroup())
                             .sshPublicKeys(o.getSshPublicKeys())
                             .hostname(o.getHostname())
@@ -381,6 +393,7 @@ public class LaunchDbSystemFromDbSystemDetails extends LaunchDbSystemBase {
             String shape,
             String timeZone,
             DbSystemOptions dbSystemOptions,
+            StorageVolumePerformanceMode storageVolumePerformanceMode,
             Boolean sparseDiskgroup,
             java.util.List<String> sshPublicKeys,
             String hostname,
@@ -410,6 +423,7 @@ public class LaunchDbSystemFromDbSystemDetails extends LaunchDbSystemBase {
                 shape,
                 timeZone,
                 dbSystemOptions,
+                storageVolumePerformanceMode,
                 sparseDiskgroup,
                 sshPublicKeys,
                 hostname,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/StoragePerformanceDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/StoragePerformanceDetails.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Representation of storage performance detail parameters.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = StoragePerformanceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class StoragePerformanceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInGBs")
+        private Integer sizeInGBs;
+
+        public Builder sizeInGBs(Integer sizeInGBs) {
+            this.sizeInGBs = sizeInGBs;
+            this.__explicitlySet__.add("sizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("balancedDiskPerformance")
+        private DiskPerformanceDetails balancedDiskPerformance;
+
+        public Builder balancedDiskPerformance(DiskPerformanceDetails balancedDiskPerformance) {
+            this.balancedDiskPerformance = balancedDiskPerformance;
+            this.__explicitlySet__.add("balancedDiskPerformance");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("highDiskPerformance")
+        private DiskPerformanceDetails highDiskPerformance;
+
+        public Builder highDiskPerformance(DiskPerformanceDetails highDiskPerformance) {
+            this.highDiskPerformance = highDiskPerformance;
+            this.__explicitlySet__.add("highDiskPerformance");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public StoragePerformanceDetails build() {
+            StoragePerformanceDetails __instance__ =
+                    new StoragePerformanceDetails(
+                            sizeInGBs, balancedDiskPerformance, highDiskPerformance);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(StoragePerformanceDetails o) {
+            Builder copiedBuilder =
+                    sizeInGBs(o.getSizeInGBs())
+                            .balancedDiskPerformance(o.getBalancedDiskPerformance())
+                            .highDiskPerformance(o.getHighDiskPerformance());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Size in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInGBs")
+    Integer sizeInGBs;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("balancedDiskPerformance")
+    DiskPerformanceDetails balancedDiskPerformance;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("highDiskPerformance")
+    DiskPerformanceDetails highDiskPerformance;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
@@ -205,6 +205,15 @@ public class UpdateAutonomousDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+        private Boolean isLocalDataGuardEnabled;
+
+        public Builder isLocalDataGuardEnabled(Boolean isLocalDataGuardEnabled) {
+            this.isLocalDataGuardEnabled = isLocalDataGuardEnabled;
+            this.__explicitlySet__.add("isLocalDataGuardEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isDataGuardEnabled")
         private Boolean isDataGuardEnabled;
 
@@ -357,6 +366,7 @@ public class UpdateAutonomousDatabaseDetails {
                             isAutoScalingEnabled,
                             isRefreshableClone,
                             refreshableMode,
+                            isLocalDataGuardEnabled,
                             isDataGuardEnabled,
                             peerDbId,
                             dbVersion,
@@ -397,6 +407,7 @@ public class UpdateAutonomousDatabaseDetails {
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .isRefreshableClone(o.getIsRefreshableClone())
                             .refreshableMode(o.getRefreshableMode())
+                            .isLocalDataGuardEnabled(o.getIsLocalDataGuardEnabled())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .peerDbId(o.getPeerDbId())
                             .dbVersion(o.getDbVersion())
@@ -434,7 +445,11 @@ public class UpdateAutonomousDatabaseDetails {
     Integer cpuCoreCount;
 
     /**
-     * The number of OCPU cores to be made available to the Autonomous Database. To provision less than 1 core, enter a fractional value in an increment of 0.1. To provision 1 or more cores, you must enter an integer between 1 and the maximum number of cores available to the infrastructure shape. For example, you can provision 0.3 or 0.4 cores, but not 0.35 cores. Likewise, you can provision 2 cores or 3 cores, but not 2.5 cores. The maximum number of cores is determined by the infrastructure shape. See [Characteristics of Infrastructure Shapes](https://www.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/autonomous-database&id=ATPFG-GUID-B0F033C1-CC5A-42F0-B2E7-3CECFEDA1FD1) for shape details.
+     * The number of OCPU cores to be made available to the Autonomous Database.
+     * <p>
+     * For databases on dedicated Exadata infrastructure, you can specify a fractional value for this parameter. Fractional values are not supported for Autonomous Database on shared Exadata infrastructure.
+     * <p>
+     * To provision less than 1 core, enter a fractional value in an increment of 0.1. To provision 1 or more cores, you must enter an integer between 1 and the maximum number of cores available to the infrastructure shape. For example, you can provision 0.3 or 0.4 cores, but not 0.35 cores. Likewise, you can provision 2 cores or 3 cores, but not 2.5 cores. The maximum number of cores is determined by the infrastructure shape. See [Characteristics of Infrastructure Shapes](https://www.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/autonomous-database&id=ATPFG-GUID-B0F033C1-CC5A-42F0-B2E7-3CECFEDA1FD1) for shape details.
      * <p>
      **Note:** This parameter cannot be used with the {@code cpuCoreCount} parameter.
      *
@@ -726,6 +741,18 @@ public class UpdateAutonomousDatabaseDetails {
      * To create a local standby, set to {@code TRUE}. To delete a local standby, set to {@code FALSE}. For more information on using Autonomous Data Guard on shared Exadata infrastructure (local and cross-region) , see [About Standby Databases](https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/autonomous-data-guard-about.html#GUID-045AD017-8120-4BDC-AF58-7430FFE28D2B)
      * <p>
      * To enable cross-region Autonomous Data Guard on shared Exadata infrastructure, see {@link #createCrossRegionAutonomousDatabaseDataGuardDetails(CreateCrossRegionAutonomousDatabaseDataGuardDetailsRequest) createCrossRegionAutonomousDatabaseDataGuardDetails}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLocalDataGuardEnabled")
+    Boolean isLocalDataGuardEnabled;
+
+    /**
+     * ** Deprecated. ** Indicates whether the Autonomous Database has a local (in-region) standby database. Not applicable when creating a cross-region Autonomous Data Guard associations, or to
+     * Autonomous Databases using dedicated Exadata infrastructure or Exadata Cloud@Customer infrastructure.
+     * <p>
+     * To create a local standby, set to {@code TRUE}. To delete a local standby, set to {@code FALSE}. For more information on using Autonomous Data Guard on shared Exadata infrastructure (local and cross-region) , see [About Standby Databases](https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/autonomous-data-guard-about.html#GUID-045AD017-8120-4BDC-AF58-7430FFE28D2B)
+     * <p>
+     * To enable cross-region Autonomous Data Guard on shared Exadata infrastructure, see {@link #createCrossRegionAutonomousDatabaseDataGuardDetails(CreateCrossRegionAutonomousDatabaseDataGuardDetailsRequest) createCrossRegionAutonomousDatabaseDataGuardDetails}.
      * <p>
      * To delete a cross-region standby database, provide the {@code peerDbId} for the standby database in a remote region, and set {@code isDataGuardEnabled} to {@code FALSE}.
      *
@@ -851,9 +878,9 @@ public class UpdateAutonomousDatabaseDetails {
     String privateEndpointLabel;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousExadataInfrastructureDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousExadataInfrastructureDetails.java
@@ -119,9 +119,9 @@ public class UpdateAutonomousExadataInfrastructureDetails {
     MaintenanceWindow maintenanceWindowDetails;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateCloudAutonomousVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateCloudAutonomousVmClusterDetails.java
@@ -181,9 +181,9 @@ public class UpdateCloudAutonomousVmClusterDetails {
     LicenseModel licenseModel;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateCloudVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateCloudVmClusterDetails.java
@@ -257,9 +257,9 @@ public class UpdateCloudVmClusterDetails {
     UpdateDetails updateDetails;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateDbSystemDetails.java
@@ -246,9 +246,9 @@ public class UpdateDbSystemDetails {
     String shape;
 
     /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * The list of [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
      * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds list cannot be empty.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListAutonomousDatabaseCharacterSetsRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListAutonomousDatabaseCharacterSetsRequest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListAutonomousDatabaseCharacterSetsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListAutonomousDatabaseCharacterSetsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListAutonomousDatabaseCharacterSetsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListAutonomousDatabaseCharacterSetsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAutonomousDatabaseCharacterSetsRequest o) {
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListAutonomousDatabaseCharacterSetsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListAutonomousDatabaseCharacterSetsRequest
+         */
+        public ListAutonomousDatabaseCharacterSetsRequest build() {
+            ListAutonomousDatabaseCharacterSetsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbSystemComputePerformancesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbSystemComputePerformancesRequest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListDbSystemComputePerformancesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListDbSystemComputePerformancesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListDbSystemComputePerformancesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * If provided, filters the results to the set of database versions which are supported for the given shape.
+     */
+    private String dbSystemShape;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListDbSystemComputePerformancesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDbSystemComputePerformancesRequest o) {
+            dbSystemShape(o.getDbSystemShape());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListDbSystemComputePerformancesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListDbSystemComputePerformancesRequest
+         */
+        public ListDbSystemComputePerformancesRequest build() {
+            ListDbSystemComputePerformancesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbSystemStoragePerformancesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbSystemStoragePerformancesRequest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListDbSystemStoragePerformancesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListDbSystemStoragePerformancesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListDbSystemStoragePerformancesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The DB system storage management option. Used to list database versions available for that storage manager. Valid values are {@code ASM} and {@code LVM}.
+     * * ASM specifies Oracle Automatic Storage Management
+     * * LVM specifies logical volume manager, sometimes called logical disk manager.
+     *
+     */
+    private com.oracle.bmc.database.model.DbSystemOptions.StorageManagement storageManagement;
+
+    /**
+     * Optional. Filters the performance results by shape type.
+     */
+    private String shapeType;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListDbSystemStoragePerformancesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDbSystemStoragePerformancesRequest o) {
+            storageManagement(o.getStorageManagement());
+            shapeType(o.getShapeType());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListDbSystemStoragePerformancesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListDbSystemStoragePerformancesRequest
+         */
+        public ListDbSystemStoragePerformancesRequest build() {
+            ListDbSystemStoragePerformancesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListAutonomousDatabaseCharacterSetsResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListAutonomousDatabaseCharacterSetsResponse.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListAutonomousDatabaseCharacterSetsResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the {@code page} parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of com.oracle.bmc.database.model.AutonomousDatabaseCharacterSets instances.
+     */
+    private java.util.List<com.oracle.bmc.database.model.AutonomousDatabaseCharacterSets> items;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "items"
+    })
+    private ListAutonomousDatabaseCharacterSetsResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            java.util.List<com.oracle.bmc.database.model.AutonomousDatabaseCharacterSets> items) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.items = items;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAutonomousDatabaseCharacterSetsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+
+        public ListAutonomousDatabaseCharacterSetsResponse build() {
+            return new ListAutonomousDatabaseCharacterSetsResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, items);
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListDbSystemComputePerformancesResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListDbSystemComputePerformancesResponse.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListDbSystemComputePerformancesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the {@code page} parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of com.oracle.bmc.database.model.DbSystemComputePerformanceSummary instances.
+     */
+    private java.util.List<com.oracle.bmc.database.model.DbSystemComputePerformanceSummary> items;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "items"
+    })
+    private ListDbSystemComputePerformancesResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            java.util.List<com.oracle.bmc.database.model.DbSystemComputePerformanceSummary> items) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.items = items;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDbSystemComputePerformancesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+
+        public ListDbSystemComputePerformancesResponse build() {
+            return new ListDbSystemComputePerformancesResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, items);
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListDbSystemStoragePerformancesResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListDbSystemStoragePerformancesResponse.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListDbSystemStoragePerformancesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the {@code page} parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of com.oracle.bmc.database.model.DbSystemStoragePerformanceSummary instances.
+     */
+    private java.util.List<com.oracle.bmc.database.model.DbSystemStoragePerformanceSummary> items;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "items"
+    })
+    private ListDbSystemStoragePerformancesResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            java.util.List<com.oracle.bmc.database.model.DbSystemStoragePerformanceSummary> items) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.items = items;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDbSystemStoragePerformancesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+
+        public ListDbSystemStoragePerformancesResponse build() {
+            return new ListDbSystemStoragePerformancesResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, items);
+        }
+    }
+}

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasetools/pom.xml
+++ b/bmc-databasetools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasetools</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataconnectivity/pom.xml
+++ b/bmc-dataconnectivity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataconnectivity</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudAppPasswordConnection.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudAppPasswordConnection.java
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * The properties that define a connection of the type {@code BITBUCKET_CLOUD_APP_PASSWORD}.
+ * This type corresponds to a connection in Bitbucket Cloud that is authenticated with a App Password along with username.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BitbucketCloudAppPasswordConnection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "connectionType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BitbucketCloudAppPasswordConnection extends Connection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("appPassword")
+        private String appPassword;
+
+        public Builder appPassword(String appPassword) {
+            this.appPassword = appPassword;
+            this.__explicitlySet__.add("appPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BitbucketCloudAppPasswordConnection build() {
+            BitbucketCloudAppPasswordConnection __instance__ =
+                    new BitbucketCloudAppPasswordConnection(
+                            id,
+                            description,
+                            displayName,
+                            compartmentId,
+                            projectId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            username,
+                            appPassword);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BitbucketCloudAppPasswordConnection o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .projectId(o.getProjectId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .username(o.getUsername())
+                            .appPassword(o.getAppPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BitbucketCloudAppPasswordConnection(
+            String id,
+            String description,
+            String displayName,
+            String compartmentId,
+            String projectId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String username,
+            String appPassword) {
+        super(
+                id,
+                description,
+                displayName,
+                compartmentId,
+                projectId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.username = username;
+        this.appPassword = appPassword;
+    }
+
+    /**
+     * Public Bitbucket Cloud Username in plain text
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    /**
+     * OCID of personal Bitbucket Cloud AppPassword saved in secret store
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("appPassword")
+    String appPassword;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudAppPasswordConnectionSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudAppPasswordConnectionSummary.java
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Summary information for a connection of the type {@code BITBUCKET_CLOUD_APP_PASSWORD}.
+ * This type corresponds to a connection in Bitbucket Cloud that is authenticated with a username and app password.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BitbucketCloudAppPasswordConnectionSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "connectionType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BitbucketCloudAppPasswordConnectionSummary extends ConnectionSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private Connection.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(Connection.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("appPassword")
+        private String appPassword;
+
+        public Builder appPassword(String appPassword) {
+            this.appPassword = appPassword;
+            this.__explicitlySet__.add("appPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BitbucketCloudAppPasswordConnectionSummary build() {
+            BitbucketCloudAppPasswordConnectionSummary __instance__ =
+                    new BitbucketCloudAppPasswordConnectionSummary(
+                            id,
+                            displayName,
+                            description,
+                            compartmentId,
+                            projectId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            username,
+                            appPassword);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BitbucketCloudAppPasswordConnectionSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .compartmentId(o.getCompartmentId())
+                            .projectId(o.getProjectId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .username(o.getUsername())
+                            .appPassword(o.getAppPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BitbucketCloudAppPasswordConnectionSummary(
+            String id,
+            String displayName,
+            String description,
+            String compartmentId,
+            String projectId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            Connection.LifecycleState lifecycleState,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String username,
+            String appPassword) {
+        super(
+                id,
+                displayName,
+                description,
+                compartmentId,
+                projectId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.username = username;
+        this.appPassword = appPassword;
+    }
+
+    /**
+     * Public Bitbucket Cloud Username in plain text
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    /**
+     * OCID of personal Bitbucket Cloud AppPassword saved in secret store
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("appPassword")
+    String appPassword;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudBuildRunSource.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudBuildRunSource.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies details of build run through Bitbucket Cloud.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BitbucketCloudBuildRunSource.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BitbucketCloudBuildRunSource extends BuildRunSource {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("triggerId")
+        private String triggerId;
+
+        public Builder triggerId(String triggerId) {
+            this.triggerId = triggerId;
+            this.__explicitlySet__.add("triggerId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("triggerInfo")
+        private TriggerInfo triggerInfo;
+
+        public Builder triggerInfo(TriggerInfo triggerInfo) {
+            this.triggerInfo = triggerInfo;
+            this.__explicitlySet__.add("triggerInfo");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BitbucketCloudBuildRunSource build() {
+            BitbucketCloudBuildRunSource __instance__ =
+                    new BitbucketCloudBuildRunSource(triggerId, triggerInfo);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BitbucketCloudBuildRunSource o) {
+            Builder copiedBuilder = triggerId(o.getTriggerId()).triggerInfo(o.getTriggerInfo());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BitbucketCloudBuildRunSource(String triggerId, TriggerInfo triggerInfo) {
+        super();
+        this.triggerId = triggerId;
+        this.triggerInfo = triggerInfo;
+    }
+
+    /**
+     * The trigger that invoked the build run.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("triggerId")
+    String triggerId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("triggerInfo")
+    TriggerInfo triggerInfo;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudBuildSource.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudBuildSource.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Bitbucket Cloud Build Source for Build Stage
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BitbucketCloudBuildSource.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "connectionType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BitbucketCloudBuildSource extends BuildSource {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("repositoryUrl")
+        private String repositoryUrl;
+
+        public Builder repositoryUrl(String repositoryUrl) {
+            this.repositoryUrl = repositoryUrl;
+            this.__explicitlySet__.add("repositoryUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("branch")
+        private String branch;
+
+        public Builder branch(String branch) {
+            this.branch = branch;
+            this.__explicitlySet__.add("branch");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionId")
+        private String connectionId;
+
+        public Builder connectionId(String connectionId) {
+            this.connectionId = connectionId;
+            this.__explicitlySet__.add("connectionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BitbucketCloudBuildSource build() {
+            BitbucketCloudBuildSource __instance__ =
+                    new BitbucketCloudBuildSource(name, repositoryUrl, branch, connectionId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BitbucketCloudBuildSource o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .repositoryUrl(o.getRepositoryUrl())
+                            .branch(o.getBranch())
+                            .connectionId(o.getConnectionId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BitbucketCloudBuildSource(
+            String name, String repositoryUrl, String branch, String connectionId) {
+        super(name, repositoryUrl, branch);
+        this.connectionId = connectionId;
+    }
+
+    /**
+     * Connection identifier pertinent to Bitbucket Cloud source provider
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("connectionId")
+    String connectionId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudFilter.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudFilter.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * The filter for Bitbucket Cloud events.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BitbucketCloudFilter.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "triggerSource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BitbucketCloudFilter extends Filter {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("events")
+        private java.util.List<Events> events;
+
+        public Builder events(java.util.List<Events> events) {
+            this.events = events;
+            this.__explicitlySet__.add("events");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("include")
+        private BitbucketCloudFilterAttributes include;
+
+        public Builder include(BitbucketCloudFilterAttributes include) {
+            this.include = include;
+            this.__explicitlySet__.add("include");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BitbucketCloudFilter build() {
+            BitbucketCloudFilter __instance__ = new BitbucketCloudFilter(events, include);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BitbucketCloudFilter o) {
+            Builder copiedBuilder = events(o.getEvents()).include(o.getInclude());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BitbucketCloudFilter(
+            java.util.List<Events> events, BitbucketCloudFilterAttributes include) {
+        super();
+        this.events = events;
+        this.include = include;
+    }
+
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Events {
+        Push("PUSH"),
+        PullRequestCreated("PULL_REQUEST_CREATED"),
+        PullRequestUpdated("PULL_REQUEST_UPDATED"),
+        PullRequestMerged("PULL_REQUEST_MERGED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Events> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Events v : Events.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Events(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Events create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Events', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The events, for example, PUSH, PULL_REQUEST_MERGE.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("events")
+    java.util.List<Events> events;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("include")
+    BitbucketCloudFilterAttributes include;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudFilterAttributes.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudFilterAttributes.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Attributes to filter Bitbucket Cloud events.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BitbucketCloudFilterAttributes.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BitbucketCloudFilterAttributes {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("headRef")
+        private String headRef;
+
+        public Builder headRef(String headRef) {
+            this.headRef = headRef;
+            this.__explicitlySet__.add("headRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("baseRef")
+        private String baseRef;
+
+        public Builder baseRef(String baseRef) {
+            this.baseRef = baseRef;
+            this.__explicitlySet__.add("baseRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BitbucketCloudFilterAttributes build() {
+            BitbucketCloudFilterAttributes __instance__ =
+                    new BitbucketCloudFilterAttributes(headRef, baseRef);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BitbucketCloudFilterAttributes o) {
+            Builder copiedBuilder = headRef(o.getHeadRef()).baseRef(o.getBaseRef());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Branch for push event; source branch for pull requests.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("headRef")
+    String headRef;
+
+    /**
+     * The target branch for pull requests; not applicable for push requests.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("baseRef")
+    String baseRef;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudTrigger.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudTrigger.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Trigger specific to Bitbucket Cloud
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BitbucketCloudTrigger.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "triggerSource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BitbucketCloudTrigger extends Trigger {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("actions")
+        private java.util.List<TriggerAction> actions;
+
+        public Builder actions(java.util.List<TriggerAction> actions) {
+            this.actions = actions;
+            this.__explicitlySet__.add("actions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("triggerUrl")
+        private String triggerUrl;
+
+        public Builder triggerUrl(String triggerUrl) {
+            this.triggerUrl = triggerUrl;
+            this.__explicitlySet__.add("triggerUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BitbucketCloudTrigger build() {
+            BitbucketCloudTrigger __instance__ =
+                    new BitbucketCloudTrigger(
+                            id,
+                            displayName,
+                            description,
+                            projectId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            actions,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            triggerUrl);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BitbucketCloudTrigger o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .projectId(o.getProjectId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .actions(o.getActions())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .triggerUrl(o.getTriggerUrl());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BitbucketCloudTrigger(
+            String id,
+            String displayName,
+            String description,
+            String projectId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            java.util.List<TriggerAction> actions,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String triggerUrl) {
+        super(
+                id,
+                displayName,
+                description,
+                projectId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                actions,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.triggerUrl = triggerUrl;
+    }
+
+    /**
+     * The endpoint that listens to trigger events.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("triggerUrl")
+    String triggerUrl;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudTriggerCreateResult.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudTriggerCreateResult.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Trigger create response specific to Bitbucket Cloud.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BitbucketCloudTriggerCreateResult.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "triggerSource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BitbucketCloudTriggerCreateResult extends TriggerCreateResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private Trigger.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(Trigger.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("actions")
+        private java.util.List<TriggerAction> actions;
+
+        public Builder actions(java.util.List<TriggerAction> actions) {
+            this.actions = actions;
+            this.__explicitlySet__.add("actions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("triggerUrl")
+        private String triggerUrl;
+
+        public Builder triggerUrl(String triggerUrl) {
+            this.triggerUrl = triggerUrl;
+            this.__explicitlySet__.add("triggerUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BitbucketCloudTriggerCreateResult build() {
+            BitbucketCloudTriggerCreateResult __instance__ =
+                    new BitbucketCloudTriggerCreateResult(
+                            id,
+                            displayName,
+                            description,
+                            projectId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            actions,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            triggerUrl);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BitbucketCloudTriggerCreateResult o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .projectId(o.getProjectId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .actions(o.getActions())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .triggerUrl(o.getTriggerUrl());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BitbucketCloudTriggerCreateResult(
+            String id,
+            String displayName,
+            String description,
+            String projectId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            Trigger.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            java.util.List<TriggerAction> actions,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String triggerUrl) {
+        super(
+                id,
+                displayName,
+                description,
+                projectId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                actions,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.triggerUrl = triggerUrl;
+    }
+
+    /**
+     * The endpoint that listens to trigger events. Contains the secret as a query parameter.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("triggerUrl")
+    String triggerUrl;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudTriggerSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BitbucketCloudTriggerSummary.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Summary of the Bitbucket Cloud trigger.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BitbucketCloudTriggerSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "triggerSource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BitbucketCloudTriggerSummary extends TriggerSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private Trigger.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(Trigger.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BitbucketCloudTriggerSummary build() {
+            BitbucketCloudTriggerSummary __instance__ =
+                    new BitbucketCloudTriggerSummary(
+                            id,
+                            displayName,
+                            description,
+                            projectId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BitbucketCloudTriggerSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .projectId(o.getProjectId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BitbucketCloudTriggerSummary(
+            String id,
+            String displayName,
+            String description,
+            String projectId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            Trigger.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+        super(
+                id,
+                displayName,
+                description,
+                projectId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                freeformTags,
+                definedTags,
+                systemTags);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildOutputs.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildOutputs.java
@@ -52,13 +52,26 @@ public class BuildOutputs {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("vulnerabilityAuditSummaryCollection")
+        private VulnerabilityAuditSummaryCollection vulnerabilityAuditSummaryCollection;
+
+        public Builder vulnerabilityAuditSummaryCollection(
+                VulnerabilityAuditSummaryCollection vulnerabilityAuditSummaryCollection) {
+            this.vulnerabilityAuditSummaryCollection = vulnerabilityAuditSummaryCollection;
+            this.__explicitlySet__.add("vulnerabilityAuditSummaryCollection");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public BuildOutputs build() {
             BuildOutputs __instance__ =
                     new BuildOutputs(
-                            exportedVariables, deliveredArtifacts, artifactOverrideParameters);
+                            exportedVariables,
+                            deliveredArtifacts,
+                            artifactOverrideParameters,
+                            vulnerabilityAuditSummaryCollection);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -68,7 +81,9 @@ public class BuildOutputs {
             Builder copiedBuilder =
                     exportedVariables(o.getExportedVariables())
                             .deliveredArtifacts(o.getDeliveredArtifacts())
-                            .artifactOverrideParameters(o.getArtifactOverrideParameters());
+                            .artifactOverrideParameters(o.getArtifactOverrideParameters())
+                            .vulnerabilityAuditSummaryCollection(
+                                    o.getVulnerabilityAuditSummaryCollection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -90,6 +105,9 @@ public class BuildOutputs {
 
     @com.fasterxml.jackson.annotation.JsonProperty("artifactOverrideParameters")
     DeployArtifactOverrideArgumentCollection artifactOverrideParameters;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("vulnerabilityAuditSummaryCollection")
+    VulnerabilityAuditSummaryCollection vulnerabilityAuditSummaryCollection;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildRunSource.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildRunSource.java
@@ -41,6 +41,10 @@ package com.oracle.bmc.devops.model;
         name = "MANUAL"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BitbucketCloudBuildRunSource.class,
+        name = "BITBUCKET_CLOUD"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = GitlabBuildRunSource.class,
         name = "GITLAB"
     )
@@ -56,6 +60,7 @@ public class BuildRunSource {
         Manual("MANUAL"),
         Github("GITHUB"),
         Gitlab("GITLAB"),
+        BitbucketCloud("BITBUCKET_CLOUD"),
         DevopsCodeRepository("DEVOPS_CODE_REPOSITORY"),
 
         /**

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildSource.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/BuildSource.java
@@ -33,6 +33,10 @@ package com.oracle.bmc.devops.model;
         name = "GITHUB"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BitbucketCloudBuildSource.class,
+        name = "BITBUCKET_CLOUD"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = DevopsCodeRepositoryBuildSource.class,
         name = "DEVOPS_CODE_REPOSITORY"
     ),
@@ -69,6 +73,7 @@ public class BuildSource {
     public enum ConnectionType {
         Github("GITHUB"),
         Gitlab("GITLAB"),
+        BitbucketCloud("BITBUCKET_CLOUD"),
         DevopsCodeRepository("DEVOPS_CODE_REPOSITORY"),
 
         /**

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Connection.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Connection.java
@@ -35,6 +35,10 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = GithubAccessTokenConnection.class,
         name = "GITHUB_ACCESS_TOKEN"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BitbucketCloudAppPasswordConnection.class,
+        name = "BITBUCKET_CLOUD_APP_PASSWORD"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
@@ -157,6 +161,7 @@ public class Connection {
     public enum ConnectionType {
         GithubAccessToken("GITHUB_ACCESS_TOKEN"),
         GitlabAccessToken("GITLAB_ACCESS_TOKEN"),
+        BitbucketCloudAppPassword("BITBUCKET_CLOUD_APP_PASSWORD"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ConnectionSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/ConnectionSummary.java
@@ -29,6 +29,10 @@ package com.oracle.bmc.devops.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BitbucketCloudAppPasswordConnectionSummary.class,
+        name = "BITBUCKET_CLOUD_APP_PASSWORD"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = GithubAccessTokenConnectionSummary.class,
         name = "GITHUB_ACCESS_TOKEN"
     ),

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateBitbucketCloudAppPasswordConnectionDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateBitbucketCloudAppPasswordConnectionDetails.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * The details for creating a connection of the type {@code BITBUCKET_CLOUD_APP_PASSWORD}.
+ * This type corresponds to a connection in Bitbucket Cloud that is authenticated with username and app password.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateBitbucketCloudAppPasswordConnectionDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "connectionType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateBitbucketCloudAppPasswordConnectionDetails extends CreateConnectionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("appPassword")
+        private String appPassword;
+
+        public Builder appPassword(String appPassword) {
+            this.appPassword = appPassword;
+            this.__explicitlySet__.add("appPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateBitbucketCloudAppPasswordConnectionDetails build() {
+            CreateBitbucketCloudAppPasswordConnectionDetails __instance__ =
+                    new CreateBitbucketCloudAppPasswordConnectionDetails(
+                            description,
+                            displayName,
+                            projectId,
+                            freeformTags,
+                            definedTags,
+                            username,
+                            appPassword);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateBitbucketCloudAppPasswordConnectionDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .username(o.getUsername())
+                            .appPassword(o.getAppPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateBitbucketCloudAppPasswordConnectionDetails(
+            String description,
+            String displayName,
+            String projectId,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String username,
+            String appPassword) {
+        super(description, displayName, projectId, freeformTags, definedTags);
+        this.username = username;
+        this.appPassword = appPassword;
+    }
+
+    /**
+     * Public Bitbucket Cloud Username in plain text(not more than 30 characters)
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    /**
+     * OCID of personal Bitbucket Cloud AppPassword saved in secret store
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("appPassword")
+    String appPassword;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateBitbucketCloudTriggerDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateBitbucketCloudTriggerDetails.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * The trigger for Bitbucket Cloud as the caller.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateBitbucketCloudTriggerDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "triggerSource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateBitbucketCloudTriggerDetails extends CreateTriggerDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("actions")
+        private java.util.List<TriggerAction> actions;
+
+        public Builder actions(java.util.List<TriggerAction> actions) {
+            this.actions = actions;
+            this.__explicitlySet__.add("actions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateBitbucketCloudTriggerDetails build() {
+            CreateBitbucketCloudTriggerDetails __instance__ =
+                    new CreateBitbucketCloudTriggerDetails(
+                            displayName,
+                            description,
+                            projectId,
+                            actions,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateBitbucketCloudTriggerDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .projectId(o.getProjectId())
+                            .actions(o.getActions())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateBitbucketCloudTriggerDetails(
+            String displayName,
+            String description,
+            String projectId,
+            java.util.List<TriggerAction> actions,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+        super(displayName, description, projectId, actions, freeformTags, definedTags);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateConnectionDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateConnectionDetails.java
@@ -34,6 +34,10 @@ package com.oracle.bmc.devops.model;
         name = "GITHUB_ACCESS_TOKEN"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateBitbucketCloudAppPasswordConnectionDetails.class,
+        name = "BITBUCKET_CLOUD_APP_PASSWORD"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateGitlabAccessTokenConnectionDetails.class,
         name = "GITLAB_ACCESS_TOKEN"
     )

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateDeployStageDetails.java
@@ -81,6 +81,10 @@ package com.oracle.bmc.devops.model;
         name = "COMPUTE_INSTANCE_GROUP_CANARY_APPROVAL"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateOkeHelmChartDeployStageDetails.class,
+        name = "OKE_HELM_CHART_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateManualApprovalDeployStageDetails.class,
         name = "MANUAL_APPROVAL"
     ),

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeHelmChartDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateOkeHelmChartDeployStageDetails.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Helm chart deployment to a Kubernetes cluster stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateOkeHelmChartDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateOkeHelmChartDeployStageDetails extends CreateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("helmChartDeployArtifactId")
+        private String helmChartDeployArtifactId;
+
+        public Builder helmChartDeployArtifactId(String helmChartDeployArtifactId) {
+            this.helmChartDeployArtifactId = helmChartDeployArtifactId;
+            this.__explicitlySet__.add("helmChartDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("valuesArtifactIds")
+        private java.util.List<String> valuesArtifactIds;
+
+        public Builder valuesArtifactIds(java.util.List<String> valuesArtifactIds) {
+            this.valuesArtifactIds = valuesArtifactIds;
+            this.__explicitlySet__.add("valuesArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+        private String releaseName;
+
+        public Builder releaseName(String releaseName) {
+            this.releaseName = releaseName;
+            this.__explicitlySet__.add("releaseName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeoutInSeconds")
+        private Integer timeoutInSeconds;
+
+        public Builder timeoutInSeconds(Integer timeoutInSeconds) {
+            this.timeoutInSeconds = timeoutInSeconds;
+            this.__explicitlySet__.add("timeoutInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rollbackPolicy")
+        private DeployStageRollbackPolicy rollbackPolicy;
+
+        public Builder rollbackPolicy(DeployStageRollbackPolicy rollbackPolicy) {
+            this.rollbackPolicy = rollbackPolicy;
+            this.__explicitlySet__.add("rollbackPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateOkeHelmChartDeployStageDetails build() {
+            CreateOkeHelmChartDeployStageDetails __instance__ =
+                    new CreateOkeHelmChartDeployStageDetails(
+                            description,
+                            displayName,
+                            deployPipelineId,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            okeClusterDeployEnvironmentId,
+                            helmChartDeployArtifactId,
+                            valuesArtifactIds,
+                            releaseName,
+                            namespace,
+                            timeoutInSeconds,
+                            rollbackPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateOkeHelmChartDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .helmChartDeployArtifactId(o.getHelmChartDeployArtifactId())
+                            .valuesArtifactIds(o.getValuesArtifactIds())
+                            .releaseName(o.getReleaseName())
+                            .namespace(o.getNamespace())
+                            .timeoutInSeconds(o.getTimeoutInSeconds())
+                            .rollbackPolicy(o.getRollbackPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateOkeHelmChartDeployStageDetails(
+            String description,
+            String displayName,
+            String deployPipelineId,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String okeClusterDeployEnvironmentId,
+            String helmChartDeployArtifactId,
+            java.util.List<String> valuesArtifactIds,
+            String releaseName,
+            String namespace,
+            Integer timeoutInSeconds,
+            DeployStageRollbackPolicy rollbackPolicy) {
+        super(
+                description,
+                displayName,
+                deployPipelineId,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.helmChartDeployArtifactId = helmChartDeployArtifactId;
+        this.valuesArtifactIds = valuesArtifactIds;
+        this.releaseName = releaseName;
+        this.namespace = namespace;
+        this.timeoutInSeconds = timeoutInSeconds;
+        this.rollbackPolicy = rollbackPolicy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * Helm chart artifact OCID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("helmChartDeployArtifactId")
+    String helmChartDeployArtifactId;
+
+    /**
+     * List of values.yaml file artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("valuesArtifactIds")
+    java.util.List<String> valuesArtifactIds;
+
+    /**
+     * Default name of the chart instance. Must be unique within a Kubernetes namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+    String releaseName;
+
+    /**
+     * Default namespace to be used for Kubernetes deployment when not specified in the manifest.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    /**
+     * Time to wait for execution of a helm stage. Defaults to 300 seconds.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeoutInSeconds")
+    Integer timeoutInSeconds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rollbackPolicy")
+    DeployStageRollbackPolicy rollbackPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateTriggerDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/CreateTriggerDetails.java
@@ -37,6 +37,10 @@ package com.oracle.bmc.devops.model;
         name = "DEVOPS_CODE_REPOSITORY"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateBitbucketCloudTriggerDetails.class,
+        name = "BITBUCKET_CLOUD"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateGitlabTriggerDetails.class,
         name = "GITLAB"
     )

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployArtifact.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployArtifact.java
@@ -255,6 +255,7 @@ public class DeployArtifact {
         KubernetesManifest("KUBERNETES_MANIFEST"),
         GenericFile("GENERIC_FILE"),
         DockerImage("DOCKER_IMAGE"),
+        HelmChart("HELM_CHART"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployArtifactSource.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployArtifactSource.java
@@ -33,6 +33,10 @@ package com.oracle.bmc.devops.model;
         name = "GENERIC_ARTIFACT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = HelmRepositoryDeployArtifactSource.class,
+        name = "HELM_CHART"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = OcirDeployArtifactSource.class,
         name = "OCIR"
     ),
@@ -52,6 +56,7 @@ public class DeployArtifactSource {
         Inline("INLINE"),
         Ocir("OCIR"),
         GenericArtifact("GENERIC_ARTIFACT"),
+        HelmChart("HELM_CHART"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStage.java
@@ -77,6 +77,10 @@ package com.oracle.bmc.devops.model;
         name = "WAIT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeHelmChartDeployStage.class,
+        name = "OKE_HELM_CHART_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ComputeInstanceGroupBlueGreenDeployStage.class,
         name = "COMPUTE_INSTANCE_GROUP_BLUE_GREEN_DEPLOYMENT"
     ),
@@ -253,6 +257,7 @@ public class DeployStage {
         InvokeFunction("INVOKE_FUNCTION"),
         LoadBalancerTrafficShift("LOAD_BALANCER_TRAFFIC_SHIFT"),
         ManualApproval("MANUAL_APPROVAL"),
+        OkeHelmChartDeployment("OKE_HELM_CHART_DEPLOYMENT"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStageExecutionProgress.java
@@ -81,6 +81,10 @@ package com.oracle.bmc.devops.model;
         name = "OKE_BLUE_GREEN_TRAFFIC_SHIFT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeHelmChartDeploymentStageExecutionProgress.class,
+        name = "OKE_HELM_CHART_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = InvokeFunctionDeployStageExecutionProgress.class,
         name = "INVOKE_FUNCTION"
     ),

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/DeployStageSummary.java
@@ -57,6 +57,10 @@ package com.oracle.bmc.devops.model;
         name = "INVOKE_FUNCTION"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OkeHelmChartDeployStageSummary.class,
+        name = "OKE_HELM_CHART_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = OkeCanaryTrafficShiftDeployStageSummary.class,
         name = "OKE_CANARY_TRAFFIC_SHIFT"
     ),

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Filter.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Filter.java
@@ -33,6 +33,10 @@ package com.oracle.bmc.devops.model;
         name = "DEVOPS_CODE_REPOSITORY"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BitbucketCloudFilter.class,
+        name = "BITBUCKET_CLOUD"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = GitlabFilter.class,
         name = "GITLAB"
     ),

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/HelmRepositoryDeployArtifactSource.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/HelmRepositoryDeployArtifactSource.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies Helm chart source details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = HelmRepositoryDeployArtifactSource.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployArtifactSourceType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class HelmRepositoryDeployArtifactSource extends DeployArtifactSource {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("chartUrl")
+        private String chartUrl;
+
+        public Builder chartUrl(String chartUrl) {
+            this.chartUrl = chartUrl;
+            this.__explicitlySet__.add("chartUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactVersion")
+        private String deployArtifactVersion;
+
+        public Builder deployArtifactVersion(String deployArtifactVersion) {
+            this.deployArtifactVersion = deployArtifactVersion;
+            this.__explicitlySet__.add("deployArtifactVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public HelmRepositoryDeployArtifactSource build() {
+            HelmRepositoryDeployArtifactSource __instance__ =
+                    new HelmRepositoryDeployArtifactSource(chartUrl, deployArtifactVersion);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(HelmRepositoryDeployArtifactSource o) {
+            Builder copiedBuilder =
+                    chartUrl(o.getChartUrl()).deployArtifactVersion(o.getDeployArtifactVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public HelmRepositoryDeployArtifactSource(String chartUrl, String deployArtifactVersion) {
+        super();
+        this.chartUrl = chartUrl;
+        this.deployArtifactVersion = deployArtifactVersion;
+    }
+
+    /**
+     * The URL of an OCIR repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("chartUrl")
+    String chartUrl;
+
+    /**
+     * Users can set this as a placeholder value that refers to a pipeline parameter, for example, ${appVersion}.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deployArtifactVersion")
+    String deployArtifactVersion;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/NetworkChannel.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/NetworkChannel.java
@@ -5,8 +5,8 @@
 package com.oracle.bmc.devops.model;
 
 /**
- * Specifies the configuration needed when the target OCI resource, OKE cluster resides
- *  in the customer's private network.
+ * Specifies the configuration needed when the target OCI resource, i.e., OKE cluster, resides
+ *  in customer's private network.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeHelmChartDeployStage.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeHelmChartDeployStage.java
@@ -1,0 +1,383 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the OKE cluster deployment stage using helm charts.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeHelmChartDeployStage.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeHelmChartDeployStage extends DeployStage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("helmChartDeployArtifactId")
+        private String helmChartDeployArtifactId;
+
+        public Builder helmChartDeployArtifactId(String helmChartDeployArtifactId) {
+            this.helmChartDeployArtifactId = helmChartDeployArtifactId;
+            this.__explicitlySet__.add("helmChartDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("valuesArtifactIds")
+        private java.util.List<String> valuesArtifactIds;
+
+        public Builder valuesArtifactIds(java.util.List<String> valuesArtifactIds) {
+            this.valuesArtifactIds = valuesArtifactIds;
+            this.__explicitlySet__.add("valuesArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+        private String releaseName;
+
+        public Builder releaseName(String releaseName) {
+            this.releaseName = releaseName;
+            this.__explicitlySet__.add("releaseName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeoutInSeconds")
+        private Integer timeoutInSeconds;
+
+        public Builder timeoutInSeconds(Integer timeoutInSeconds) {
+            this.timeoutInSeconds = timeoutInSeconds;
+            this.__explicitlySet__.add("timeoutInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rollbackPolicy")
+        private DeployStageRollbackPolicy rollbackPolicy;
+
+        public Builder rollbackPolicy(DeployStageRollbackPolicy rollbackPolicy) {
+            this.rollbackPolicy = rollbackPolicy;
+            this.__explicitlySet__.add("rollbackPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeHelmChartDeployStage build() {
+            OkeHelmChartDeployStage __instance__ =
+                    new OkeHelmChartDeployStage(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeClusterDeployEnvironmentId,
+                            helmChartDeployArtifactId,
+                            valuesArtifactIds,
+                            releaseName,
+                            namespace,
+                            timeoutInSeconds,
+                            rollbackPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeHelmChartDeployStage o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .helmChartDeployArtifactId(o.getHelmChartDeployArtifactId())
+                            .valuesArtifactIds(o.getValuesArtifactIds())
+                            .releaseName(o.getReleaseName())
+                            .namespace(o.getNamespace())
+                            .timeoutInSeconds(o.getTimeoutInSeconds())
+                            .rollbackPolicy(o.getRollbackPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeHelmChartDeployStage(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeClusterDeployEnvironmentId,
+            String helmChartDeployArtifactId,
+            java.util.List<String> valuesArtifactIds,
+            String releaseName,
+            String namespace,
+            Integer timeoutInSeconds,
+            DeployStageRollbackPolicy rollbackPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.helmChartDeployArtifactId = helmChartDeployArtifactId;
+        this.valuesArtifactIds = valuesArtifactIds;
+        this.releaseName = releaseName;
+        this.namespace = namespace;
+        this.timeoutInSeconds = timeoutInSeconds;
+        this.rollbackPolicy = rollbackPolicy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * Helm chart artifact OCID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("helmChartDeployArtifactId")
+    String helmChartDeployArtifactId;
+
+    /**
+     * List of values.yaml file artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("valuesArtifactIds")
+    java.util.List<String> valuesArtifactIds;
+
+    /**
+     * Release name of the Helm chart.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+    String releaseName;
+
+    /**
+     * Default namespace to be used for Kubernetes deployment when not specified in the manifest.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    /**
+     * Time to wait for execution of a helm stage. Defaults to 300 seconds.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeoutInSeconds")
+    Integer timeoutInSeconds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rollbackPolicy")
+    DeployStageRollbackPolicy rollbackPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeHelmChartDeployStageSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeHelmChartDeployStageSummary.java
@@ -1,0 +1,383 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the OKE cluster deployment stage using Helm charts.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeHelmChartDeployStageSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeHelmChartDeployStageSummary extends DeployStageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployPipelineId")
+        private String deployPipelineId;
+
+        public Builder deployPipelineId(String deployPipelineId) {
+            this.deployPipelineId = deployPipelineId;
+            this.__explicitlySet__.add("deployPipelineId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private DeployStage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(DeployStage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("helmChartDeployArtifactId")
+        private String helmChartDeployArtifactId;
+
+        public Builder helmChartDeployArtifactId(String helmChartDeployArtifactId) {
+            this.helmChartDeployArtifactId = helmChartDeployArtifactId;
+            this.__explicitlySet__.add("helmChartDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("valuesArtifactIds")
+        private java.util.List<String> valuesArtifactIds;
+
+        public Builder valuesArtifactIds(java.util.List<String> valuesArtifactIds) {
+            this.valuesArtifactIds = valuesArtifactIds;
+            this.__explicitlySet__.add("valuesArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+        private String releaseName;
+
+        public Builder releaseName(String releaseName) {
+            this.releaseName = releaseName;
+            this.__explicitlySet__.add("releaseName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeoutInSeconds")
+        private Integer timeoutInSeconds;
+
+        public Builder timeoutInSeconds(Integer timeoutInSeconds) {
+            this.timeoutInSeconds = timeoutInSeconds;
+            this.__explicitlySet__.add("timeoutInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rollbackPolicy")
+        private DeployStageRollbackPolicy rollbackPolicy;
+
+        public Builder rollbackPolicy(DeployStageRollbackPolicy rollbackPolicy) {
+            this.rollbackPolicy = rollbackPolicy;
+            this.__explicitlySet__.add("rollbackPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeHelmChartDeployStageSummary build() {
+            OkeHelmChartDeployStageSummary __instance__ =
+                    new OkeHelmChartDeployStageSummary(
+                            id,
+                            description,
+                            displayName,
+                            projectId,
+                            deployPipelineId,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            okeClusterDeployEnvironmentId,
+                            helmChartDeployArtifactId,
+                            valuesArtifactIds,
+                            releaseName,
+                            namespace,
+                            timeoutInSeconds,
+                            rollbackPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeHelmChartDeployStageSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .projectId(o.getProjectId())
+                            .deployPipelineId(o.getDeployPipelineId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .helmChartDeployArtifactId(o.getHelmChartDeployArtifactId())
+                            .valuesArtifactIds(o.getValuesArtifactIds())
+                            .releaseName(o.getReleaseName())
+                            .namespace(o.getNamespace())
+                            .timeoutInSeconds(o.getTimeoutInSeconds())
+                            .rollbackPolicy(o.getRollbackPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeHelmChartDeployStageSummary(
+            String id,
+            String description,
+            String displayName,
+            String projectId,
+            String deployPipelineId,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            DeployStage.LifecycleState lifecycleState,
+            String lifecycleDetails,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Map<String, java.util.Map<String, Object>> systemTags,
+            String okeClusterDeployEnvironmentId,
+            String helmChartDeployArtifactId,
+            java.util.List<String> valuesArtifactIds,
+            String releaseName,
+            String namespace,
+            Integer timeoutInSeconds,
+            DeployStageRollbackPolicy rollbackPolicy) {
+        super(
+                id,
+                description,
+                displayName,
+                projectId,
+                deployPipelineId,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                lifecycleDetails,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags,
+                systemTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.helmChartDeployArtifactId = helmChartDeployArtifactId;
+        this.valuesArtifactIds = valuesArtifactIds;
+        this.releaseName = releaseName;
+        this.namespace = namespace;
+        this.timeoutInSeconds = timeoutInSeconds;
+        this.rollbackPolicy = rollbackPolicy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * Helm chart artifact OCID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("helmChartDeployArtifactId")
+    String helmChartDeployArtifactId;
+
+    /**
+     * List of values.yaml file artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("valuesArtifactIds")
+    java.util.List<String> valuesArtifactIds;
+
+    /**
+     * Release name of the Helm chart.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+    String releaseName;
+
+    /**
+     * Default namespace to be used for Kubernetes deployment when not specified in the manifest.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    /**
+     * Time to wait for execution of a helm stage. Defaults to 300 seconds.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeoutInSeconds")
+    Integer timeoutInSeconds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rollbackPolicy")
+    DeployStageRollbackPolicy rollbackPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeHelmChartDeploymentStageExecutionProgress.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/OkeHelmChartDeploymentStageExecutionProgress.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the execution details for Kubernetes (OKE) helm chart deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OkeHelmChartDeploymentStageExecutionProgress.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OkeHelmChartDeploymentStageExecutionProgress extends DeployStageExecutionProgress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageDisplayName")
+        private String deployStageDisplayName;
+
+        public Builder deployStageDisplayName(String deployStageDisplayName) {
+            this.deployStageDisplayName = deployStageDisplayName;
+            this.__explicitlySet__.add("deployStageDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageId")
+        private String deployStageId;
+
+        public Builder deployStageId(String deployStageId) {
+            this.deployStageId = deployStageId;
+            this.__explicitlySet__.add("deployStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessors")
+        private DeployStagePredecessorCollection deployStagePredecessors;
+
+        public Builder deployStagePredecessors(
+                DeployStagePredecessorCollection deployStagePredecessors) {
+            this.deployStagePredecessors = deployStagePredecessors;
+            this.__explicitlySet__.add("deployStagePredecessors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStageExecutionProgressDetails")
+        private java.util.List<DeployStageExecutionProgressDetails>
+                deployStageExecutionProgressDetails;
+
+        public Builder deployStageExecutionProgressDetails(
+                java.util.List<DeployStageExecutionProgressDetails>
+                        deployStageExecutionProgressDetails) {
+            this.deployStageExecutionProgressDetails = deployStageExecutionProgressDetails;
+            this.__explicitlySet__.add("deployStageExecutionProgressDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+        private String releaseName;
+
+        public Builder releaseName(String releaseName) {
+            this.releaseName = releaseName;
+            this.__explicitlySet__.add("releaseName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("chartUrl")
+        private String chartUrl;
+
+        public Builder chartUrl(String chartUrl) {
+            this.chartUrl = chartUrl;
+            this.__explicitlySet__.add("chartUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OkeHelmChartDeploymentStageExecutionProgress build() {
+            OkeHelmChartDeploymentStageExecutionProgress __instance__ =
+                    new OkeHelmChartDeploymentStageExecutionProgress(
+                            deployStageDisplayName,
+                            deployStageId,
+                            timeStarted,
+                            timeFinished,
+                            status,
+                            deployStagePredecessors,
+                            deployStageExecutionProgressDetails,
+                            releaseName,
+                            chartUrl,
+                            version,
+                            namespace);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OkeHelmChartDeploymentStageExecutionProgress o) {
+            Builder copiedBuilder =
+                    deployStageDisplayName(o.getDeployStageDisplayName())
+                            .deployStageId(o.getDeployStageId())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .status(o.getStatus())
+                            .deployStagePredecessors(o.getDeployStagePredecessors())
+                            .deployStageExecutionProgressDetails(
+                                    o.getDeployStageExecutionProgressDetails())
+                            .releaseName(o.getReleaseName())
+                            .chartUrl(o.getChartUrl())
+                            .version(o.getVersion())
+                            .namespace(o.getNamespace());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OkeHelmChartDeploymentStageExecutionProgress(
+            String deployStageDisplayName,
+            String deployStageId,
+            java.util.Date timeStarted,
+            java.util.Date timeFinished,
+            Status status,
+            DeployStagePredecessorCollection deployStagePredecessors,
+            java.util.List<DeployStageExecutionProgressDetails> deployStageExecutionProgressDetails,
+            String releaseName,
+            String chartUrl,
+            String version,
+            String namespace) {
+        super(
+                deployStageDisplayName,
+                deployStageId,
+                timeStarted,
+                timeFinished,
+                status,
+                deployStagePredecessors,
+                deployStageExecutionProgressDetails);
+        this.releaseName = releaseName;
+        this.chartUrl = chartUrl;
+        this.version = version;
+        this.namespace = namespace;
+    }
+
+    /**
+     * Release name of the Helm chart.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+    String releaseName;
+
+    /**
+     * The URL of an OCIR repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("chartUrl")
+    String chartUrl;
+
+    /**
+     * The version of the helm chart stored in OCIR repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    /**
+     * Default namespace to be used for Kubernetes deployment when not specified in the manifest.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/PrivateEndpointChannel.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/PrivateEndpointChannel.java
@@ -83,7 +83,7 @@ public class PrivateEndpointChannel extends NetworkChannel {
     }
 
     /**
-     * The OCID of the subnet where Virtual Network Interface Cards (VNIC) resources are created for private endpoint access.
+     * The OCID of the subnet where VNIC resources will be created for private endpoint.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
     String subnetId;

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Trigger.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/Trigger.java
@@ -39,6 +39,10 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = DevopsCodeRepositoryTrigger.class,
         name = "DEVOPS_CODE_REPOSITORY"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BitbucketCloudTrigger.class,
+        name = "BITBUCKET_CLOUD"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
@@ -167,12 +171,13 @@ public class Trigger {
     java.util.Map<String, java.util.Map<String, Object>> systemTags;
 
     /**
-     * Source of the trigger. Allowed values are, GITHUB, GITLAB and DEVOPS_CODE_REPOSITORY.
+     * Source of the trigger.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum TriggerSource {
         Github("GITHUB"),
         Gitlab("GITLAB"),
+        BitbucketCloud("BITBUCKET_CLOUD"),
         DevopsCodeRepository("DEVOPS_CODE_REPOSITORY"),
 
         /**

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/TriggerCreateResult.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/TriggerCreateResult.java
@@ -39,6 +39,10 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = DevopsCodeRepositoryTriggerCreateResult.class,
         name = "DEVOPS_CODE_REPOSITORY"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BitbucketCloudTriggerCreateResult.class,
+        name = "BITBUCKET_CLOUD"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/TriggerSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/TriggerSummary.java
@@ -29,6 +29,10 @@ package com.oracle.bmc.devops.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BitbucketCloudTriggerSummary.class,
+        name = "BITBUCKET_CLOUD"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = GitlabTriggerSummary.class,
         name = "GITLAB"
     ),

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateBitbucketCloudAppPasswordConnectionDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateBitbucketCloudAppPasswordConnectionDetails.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * The details for updating a connection of the type {@code BITBUCKET_CLOUD_APP_PASSWORD}.
+ * This type corresponds to a connection in Bitbucket Cloud that is authenticated with username and app password.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateBitbucketCloudAppPasswordConnectionDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "connectionType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateBitbucketCloudAppPasswordConnectionDetails extends UpdateConnectionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("appPassword")
+        private String appPassword;
+
+        public Builder appPassword(String appPassword) {
+            this.appPassword = appPassword;
+            this.__explicitlySet__.add("appPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateBitbucketCloudAppPasswordConnectionDetails build() {
+            UpdateBitbucketCloudAppPasswordConnectionDetails __instance__ =
+                    new UpdateBitbucketCloudAppPasswordConnectionDetails(
+                            description,
+                            displayName,
+                            freeformTags,
+                            definedTags,
+                            username,
+                            appPassword);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateBitbucketCloudAppPasswordConnectionDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .username(o.getUsername())
+                            .appPassword(o.getAppPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateBitbucketCloudAppPasswordConnectionDetails(
+            String description,
+            String displayName,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String username,
+            String appPassword) {
+        super(description, displayName, freeformTags, definedTags);
+        this.username = username;
+        this.appPassword = appPassword;
+    }
+
+    /**
+     * Public Bitbucket Cloud Username in plain text(not more than 30 characters)
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    /**
+     * OCID of personal Bitbucket Cloud AppPassword saved in secret store
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("appPassword")
+    String appPassword;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateBitbucketCloudTriggerDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateBitbucketCloudTriggerDetails.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Update trigger specific to Bitbucket Cloud.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateBitbucketCloudTriggerDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "triggerSource"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateBitbucketCloudTriggerDetails extends UpdateTriggerDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("actions")
+        private java.util.List<TriggerAction> actions;
+
+        public Builder actions(java.util.List<TriggerAction> actions) {
+            this.actions = actions;
+            this.__explicitlySet__.add("actions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateBitbucketCloudTriggerDetails build() {
+            UpdateBitbucketCloudTriggerDetails __instance__ =
+                    new UpdateBitbucketCloudTriggerDetails(
+                            displayName, description, actions, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateBitbucketCloudTriggerDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .actions(o.getActions())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateBitbucketCloudTriggerDetails(
+            String displayName,
+            String description,
+            java.util.List<TriggerAction> actions,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+        super(displayName, description, actions, freeformTags, definedTags);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateConnectionDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateConnectionDetails.java
@@ -36,6 +36,10 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateGitlabAccessTokenConnectionDetails.class,
         name = "GITLAB_ACCESS_TOKEN"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateBitbucketCloudAppPasswordConnectionDetails.class,
+        name = "BITBUCKET_CLOUD_APP_PASSWORD"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateDeployStageDetails.java
@@ -37,6 +37,10 @@ package com.oracle.bmc.devops.model;
         name = "OKE_CANARY_DEPLOYMENT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateOkeHelmChartDeployStageDetails.class,
+        name = "OKE_HELM_CHART_DEPLOYMENT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateComputeInstanceGroupDeployStageDetails.class,
         name = "COMPUTE_INSTANCE_GROUP_ROLLING_DEPLOYMENT"
     ),

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeHelmChartDeployStageDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateOkeHelmChartDeployStageDetails.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Specifies the Kubernetes cluster deployment stage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOkeHelmChartDeployStageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deployStageType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOkeHelmChartDeployStageDetails extends UpdateDeployStageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deployStagePredecessorCollection")
+        private DeployStagePredecessorCollection deployStagePredecessorCollection;
+
+        public Builder deployStagePredecessorCollection(
+                DeployStagePredecessorCollection deployStagePredecessorCollection) {
+            this.deployStagePredecessorCollection = deployStagePredecessorCollection;
+            this.__explicitlySet__.add("deployStagePredecessorCollection");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+        private String okeClusterDeployEnvironmentId;
+
+        public Builder okeClusterDeployEnvironmentId(String okeClusterDeployEnvironmentId) {
+            this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+            this.__explicitlySet__.add("okeClusterDeployEnvironmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("helmChartDeployArtifactId")
+        private String helmChartDeployArtifactId;
+
+        public Builder helmChartDeployArtifactId(String helmChartDeployArtifactId) {
+            this.helmChartDeployArtifactId = helmChartDeployArtifactId;
+            this.__explicitlySet__.add("helmChartDeployArtifactId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("valuesArtifactIds")
+        private java.util.List<String> valuesArtifactIds;
+
+        public Builder valuesArtifactIds(java.util.List<String> valuesArtifactIds) {
+            this.valuesArtifactIds = valuesArtifactIds;
+            this.__explicitlySet__.add("valuesArtifactIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+        private String releaseName;
+
+        public Builder releaseName(String releaseName) {
+            this.releaseName = releaseName;
+            this.__explicitlySet__.add("releaseName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeoutInSeconds")
+        private Integer timeoutInSeconds;
+
+        public Builder timeoutInSeconds(Integer timeoutInSeconds) {
+            this.timeoutInSeconds = timeoutInSeconds;
+            this.__explicitlySet__.add("timeoutInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rollbackPolicy")
+        private DeployStageRollbackPolicy rollbackPolicy;
+
+        public Builder rollbackPolicy(DeployStageRollbackPolicy rollbackPolicy) {
+            this.rollbackPolicy = rollbackPolicy;
+            this.__explicitlySet__.add("rollbackPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOkeHelmChartDeployStageDetails build() {
+            UpdateOkeHelmChartDeployStageDetails __instance__ =
+                    new UpdateOkeHelmChartDeployStageDetails(
+                            description,
+                            displayName,
+                            deployStagePredecessorCollection,
+                            freeformTags,
+                            definedTags,
+                            okeClusterDeployEnvironmentId,
+                            helmChartDeployArtifactId,
+                            valuesArtifactIds,
+                            releaseName,
+                            namespace,
+                            timeoutInSeconds,
+                            rollbackPolicy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOkeHelmChartDeployStageDetails o) {
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .displayName(o.getDisplayName())
+                            .deployStagePredecessorCollection(
+                                    o.getDeployStagePredecessorCollection())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .okeClusterDeployEnvironmentId(o.getOkeClusterDeployEnvironmentId())
+                            .helmChartDeployArtifactId(o.getHelmChartDeployArtifactId())
+                            .valuesArtifactIds(o.getValuesArtifactIds())
+                            .releaseName(o.getReleaseName())
+                            .namespace(o.getNamespace())
+                            .timeoutInSeconds(o.getTimeoutInSeconds())
+                            .rollbackPolicy(o.getRollbackPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateOkeHelmChartDeployStageDetails(
+            String description,
+            String displayName,
+            DeployStagePredecessorCollection deployStagePredecessorCollection,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String okeClusterDeployEnvironmentId,
+            String helmChartDeployArtifactId,
+            java.util.List<String> valuesArtifactIds,
+            String releaseName,
+            String namespace,
+            Integer timeoutInSeconds,
+            DeployStageRollbackPolicy rollbackPolicy) {
+        super(
+                description,
+                displayName,
+                deployStagePredecessorCollection,
+                freeformTags,
+                definedTags);
+        this.okeClusterDeployEnvironmentId = okeClusterDeployEnvironmentId;
+        this.helmChartDeployArtifactId = helmChartDeployArtifactId;
+        this.valuesArtifactIds = valuesArtifactIds;
+        this.releaseName = releaseName;
+        this.namespace = namespace;
+        this.timeoutInSeconds = timeoutInSeconds;
+        this.rollbackPolicy = rollbackPolicy;
+    }
+
+    /**
+     * Kubernetes cluster environment OCID for deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("okeClusterDeployEnvironmentId")
+    String okeClusterDeployEnvironmentId;
+
+    /**
+     * Helm chart artifact OCID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("helmChartDeployArtifactId")
+    String helmChartDeployArtifactId;
+
+    /**
+     * List of values.yaml file artifact OCIDs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("valuesArtifactIds")
+    java.util.List<String> valuesArtifactIds;
+
+    /**
+     * Name of the Helm chart release.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("releaseName")
+    String releaseName;
+
+    /**
+     * Default namespace to be used for Kubernetes deployment when not specified in the manifest.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    /**
+     * Time to wait for execution of a helm stage. Defaults to 300 seconds.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeoutInSeconds")
+    Integer timeoutInSeconds;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rollbackPolicy")
+    DeployStageRollbackPolicy rollbackPolicy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateTriggerDetails.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/UpdateTriggerDetails.java
@@ -39,6 +39,10 @@ package com.oracle.bmc.devops.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateGitlabTriggerDetails.class,
         name = "GITLAB"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateBitbucketCloudTriggerDetails.class,
+        name = "BITBUCKET_CLOUD"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/VulnerabilityAuditSummary.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/VulnerabilityAuditSummary.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * Summary of vulnerability audit.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VulnerabilityAuditSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VulnerabilityAuditSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("vulnerabilityAuditId")
+        private String vulnerabilityAuditId;
+
+        public Builder vulnerabilityAuditId(String vulnerabilityAuditId) {
+            this.vulnerabilityAuditId = vulnerabilityAuditId;
+            this.__explicitlySet__.add("vulnerabilityAuditId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("commitHash")
+        private String commitHash;
+
+        public Builder commitHash(String commitHash) {
+            this.commitHash = commitHash;
+            this.__explicitlySet__.add("commitHash");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("buildStageId")
+        private String buildStageId;
+
+        public Builder buildStageId(String buildStageId) {
+            this.buildStageId = buildStageId;
+            this.__explicitlySet__.add("buildStageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VulnerabilityAuditSummary build() {
+            VulnerabilityAuditSummary __instance__ =
+                    new VulnerabilityAuditSummary(vulnerabilityAuditId, commitHash, buildStageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VulnerabilityAuditSummary o) {
+            Builder copiedBuilder =
+                    vulnerabilityAuditId(o.getVulnerabilityAuditId())
+                            .commitHash(o.getCommitHash())
+                            .buildStageId(o.getBuildStageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the vulnerability audit.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vulnerabilityAuditId")
+    String vulnerabilityAuditId;
+
+    /**
+     * Commit hash used while retrieving the pom file for vulnerabilityAudit.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("commitHash")
+    String commitHash;
+
+    /**
+     * Build stage OCID where scan was configured.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("buildStageId")
+    String buildStageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-devops/src/main/java/com/oracle/bmc/devops/model/VulnerabilityAuditSummaryCollection.java
+++ b/bmc-devops/src/main/java/com/oracle/bmc/devops/model/VulnerabilityAuditSummaryCollection.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.devops.model;
+
+/**
+ * List of vulnerability audit summary.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VulnerabilityAuditSummaryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VulnerabilityAuditSummaryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<VulnerabilityAuditSummary> items;
+
+        public Builder items(java.util.List<VulnerabilityAuditSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VulnerabilityAuditSummaryCollection build() {
+            VulnerabilityAuditSummaryCollection __instance__ =
+                    new VulnerabilityAuditSummaryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VulnerabilityAuditSummaryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of vulnerability audit summary.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<VulnerabilityAuditSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.27.0</version>
+        <version>2.28.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identitydataplane/pom.xml
+++ b/bmc-identitydataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-identitydataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequests.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequests.java
@@ -76,6 +76,19 @@ public interface AccessRequests extends AutoCloseable {
     GetAccessRequestResponse getAccessRequest(GetAccessRequestRequest request);
 
     /**
+     * Posts query for additional information for the given access request.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/operatoraccesscontrol/InteractionRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use InteractionRequest API.
+     */
+    InteractionRequestResponse interactionRequest(InteractionRequestRequest request);
+
+    /**
      * Returns a history of all status associated with the accessRequestId.
      *
      * @param request The request object containing the details to send
@@ -101,6 +114,19 @@ public interface AccessRequests extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/operatoraccesscontrol/ListAccessRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAccessRequests API.
      */
     ListAccessRequestsResponse listAccessRequests(ListAccessRequestsRequest request);
+
+    /**
+     * Lists the MoreInformation interaction between customer and operators.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/operatoraccesscontrol/ListInteractionsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListInteractions API.
+     */
+    ListInteractionsResponse listInteractions(ListInteractionsRequest request);
 
     /**
      * Rejects an access request.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsAsync.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsAsync.java
@@ -82,6 +82,23 @@ public interface AccessRequestsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Posts query for additional information for the given access request.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<InteractionRequestResponse> interactionRequest(
+            InteractionRequestRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            InteractionRequestRequest, InteractionRequestResponse>
+                    handler);
+
+    /**
      * Returns a history of all status associated with the accessRequestId.
      *
      *
@@ -113,6 +130,22 @@ public interface AccessRequestsAsync extends AutoCloseable {
             ListAccessRequestsRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ListAccessRequestsRequest, ListAccessRequestsResponse>
+                    handler);
+
+    /**
+     * Lists the MoreInformation interaction between customer and operators.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListInteractionsResponse> listInteractions(
+            ListInteractionsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListInteractionsRequest, ListInteractionsResponse>
                     handler);
 
     /**

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsAsyncClient.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsAsyncClient.java
@@ -475,6 +475,56 @@ public class AccessRequestsAsyncClient implements AccessRequestsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<InteractionRequestResponse> interactionRequest(
+            InteractionRequestRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            InteractionRequestRequest, InteractionRequestResponse>
+                    handler) {
+        LOG.trace("Called async interactionRequest");
+        final InteractionRequestRequest interceptedRequest =
+                InteractionRequestConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                InteractionRequestConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, InteractionRequestResponse>
+                transformer = InteractionRequestConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "AccessRequests",
+                "InteractionRequest",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/operatoraccesscontrol/20200630/AccessRequest/InteractionRequest");
+
+        com.oracle.bmc.responses.AsyncHandler<InteractionRequestRequest, InteractionRequestResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                InteractionRequestRequest, InteractionRequestResponse>,
+                        java.util.concurrent.Future<InteractionRequestResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getInteractionRequestDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    InteractionRequestRequest, InteractionRequestResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListAccessRequestHistoriesResponse>
             listAccessRequestHistories(
                     ListAccessRequestHistoriesRequest request,
@@ -555,6 +605,50 @@ public class AccessRequestsAsyncClient implements AccessRequestsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListAccessRequestsRequest, ListAccessRequestsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListInteractionsResponse> listInteractions(
+            ListInteractionsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListInteractionsRequest, ListInteractionsResponse>
+                    handler) {
+        LOG.trace("Called async listInteractions");
+        final ListInteractionsRequest interceptedRequest =
+                ListInteractionsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListInteractionsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListInteractionsResponse>
+                transformer = ListInteractionsConverter.fromResponse();
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "AccessRequests",
+                "ListInteractions",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/operatoraccesscontrol/20200630/AccessRequest/ListInteractions");
+
+        com.oracle.bmc.responses.AsyncHandler<ListInteractionsRequest, ListInteractionsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListInteractionsRequest, ListInteractionsResponse>,
+                        java.util.concurrent.Future<ListInteractionsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListInteractionsRequest, ListInteractionsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsClient.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsClient.java
@@ -535,6 +535,45 @@ public class AccessRequestsClient implements AccessRequests {
     }
 
     @Override
+    public InteractionRequestResponse interactionRequest(InteractionRequestRequest request) {
+        LOG.trace("Called interactionRequest");
+        final InteractionRequestRequest interceptedRequest =
+                InteractionRequestConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                InteractionRequestConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, InteractionRequestResponse>
+                transformer = InteractionRequestConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "AccessRequests",
+                "InteractionRequest",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/operatoraccesscontrol/20200630/AccessRequest/InteractionRequest");
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getInteractionRequestDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListAccessRequestHistoriesResponse listAccessRequestHistories(
             ListAccessRequestHistoriesRequest request) {
         LOG.trace("Called listAccessRequestHistories");
@@ -589,6 +628,40 @@ public class AccessRequestsClient implements AccessRequests {
                 "ListAccessRequests",
                 ib.getRequestUri().toString(),
                 "https://docs.oracle.com/iaas/api/#/en/operatoraccesscontrol/20200630/AccessRequest/ListAccessRequests");
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListInteractionsResponse listInteractions(ListInteractionsRequest request) {
+        LOG.trace("Called listInteractions");
+        final ListInteractionsRequest interceptedRequest =
+                ListInteractionsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListInteractionsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListInteractionsResponse>
+                transformer = ListInteractionsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        com.oracle.bmc.ServiceDetails.setServiceDetails(
+                "AccessRequests",
+                "ListInteractions",
+                ib.getRequestUri().toString(),
+                "https://docs.oracle.com/iaas/api/#/en/operatoraccesscontrol/20200630/AccessRequest/ListInteractions");
         return retrier.execute(
                 interceptedRequest,
                 retryRequest -> {

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsPaginators.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsPaginators.java
@@ -267,4 +267,118 @@ public class AccessRequestsPaginators {
                     }
                 });
     }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listInteractions operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListInteractionsResponse> listInteractionsResponseIterator(
+            final ListInteractionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListInteractionsRequest.Builder, ListInteractionsRequest, ListInteractionsResponse>(
+                new com.google.common.base.Supplier<ListInteractionsRequest.Builder>() {
+                    @Override
+                    public ListInteractionsRequest.Builder get() {
+                        return ListInteractionsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListInteractionsResponse, String>() {
+                    @Override
+                    public String apply(ListInteractionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListInteractionsRequest.Builder>,
+                        ListInteractionsRequest>() {
+                    @Override
+                    public ListInteractionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListInteractionsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListInteractionsRequest, ListInteractionsResponse>() {
+                    @Override
+                    public ListInteractionsResponse apply(ListInteractionsRequest request) {
+                        return client.listInteractions(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.operatoraccesscontrol.model.InteractionSummary} objects
+     * contained in responses from the listInteractions operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.operatoraccesscontrol.model.InteractionSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.operatoraccesscontrol.model.InteractionSummary>
+            listInteractionsRecordIterator(final ListInteractionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListInteractionsRequest.Builder, ListInteractionsRequest, ListInteractionsResponse,
+                com.oracle.bmc.operatoraccesscontrol.model.InteractionSummary>(
+                new com.google.common.base.Supplier<ListInteractionsRequest.Builder>() {
+                    @Override
+                    public ListInteractionsRequest.Builder get() {
+                        return ListInteractionsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListInteractionsResponse, String>() {
+                    @Override
+                    public String apply(ListInteractionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListInteractionsRequest.Builder>,
+                        ListInteractionsRequest>() {
+                    @Override
+                    public ListInteractionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListInteractionsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListInteractionsRequest, ListInteractionsResponse>() {
+                    @Override
+                    public ListInteractionsResponse apply(ListInteractionsRequest request) {
+                        return client.listInteractions(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListInteractionsResponse,
+                        java.util.List<
+                                com.oracle.bmc.operatoraccesscontrol.model.InteractionSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.operatoraccesscontrol.model.InteractionSummary>
+                            apply(ListInteractionsResponse response) {
+                        return response.getInteractionCollection().getItems();
+                    }
+                });
+    }
 }

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/InteractionRequestConverter.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/InteractionRequestConverter.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.operatoraccesscontrol.model.*;
+import com.oracle.bmc.operatoraccesscontrol.requests.*;
+import com.oracle.bmc.operatoraccesscontrol.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class InteractionRequestConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.operatoraccesscontrol.requests.InteractionRequestRequest
+            interceptRequest(
+                    com.oracle.bmc.operatoraccesscontrol.requests.InteractionRequestRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.operatoraccesscontrol.requests.InteractionRequestRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getAccessRequestId(), "accessRequestId must not be blank");
+        Validate.notNull(
+                request.getInteractionRequestDetails(), "interactionRequestDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200630")
+                        .path("accessRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAccessRequestId()))
+                        .path("action")
+                        .path("interactionRequest");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.operatoraccesscontrol.responses.InteractionRequestResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.operatoraccesscontrol.responses.InteractionRequestResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.operatoraccesscontrol.responses
+                                        .InteractionRequestResponse>() {
+                            @Override
+                            public com.oracle.bmc.operatoraccesscontrol.responses
+                                            .InteractionRequestResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.operatoraccesscontrol.responses.InteractionRequestResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.operatoraccesscontrol.model
+                                                                .AccessRequest>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.operatoraccesscontrol.model
+                                                                        .AccessRequest
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.operatoraccesscontrol.model
+                                                        .AccessRequest>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.operatoraccesscontrol.responses
+                                                .InteractionRequestResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.operatoraccesscontrol.responses
+                                                        .InteractionRequestResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.accessRequest(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.operatoraccesscontrol.responses
+                                                .InteractionRequestResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListInteractionsConverter.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListInteractionsConverter.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.operatoraccesscontrol.model.*;
+import com.oracle.bmc.operatoraccesscontrol.requests.*;
+import com.oracle.bmc.operatoraccesscontrol.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.extern.slf4j.Slf4j
+public class ListInteractionsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.operatoraccesscontrol.requests.ListInteractionsRequest
+            interceptRequest(
+                    com.oracle.bmc.operatoraccesscontrol.requests.ListInteractionsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.operatoraccesscontrol.requests.ListInteractionsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getAccessRequestId(), "accessRequestId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200630")
+                        .path("accessRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAccessRequestId()))
+                        .path("interactions");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.operatoraccesscontrol.responses.ListInteractionsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.operatoraccesscontrol.responses.ListInteractionsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.operatoraccesscontrol.responses
+                                        .ListInteractionsResponse>() {
+                            @Override
+                            public com.oracle.bmc.operatoraccesscontrol.responses
+                                            .ListInteractionsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.operatoraccesscontrol.responses.ListInteractionsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.operatoraccesscontrol.model
+                                                                .InteractionCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.operatoraccesscontrol.model
+                                                                        .InteractionCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.operatoraccesscontrol.model
+                                                        .InteractionCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.operatoraccesscontrol.responses
+                                                .ListInteractionsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.operatoraccesscontrol.responses
+                                                        .ListInteractionsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.interactionCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.operatoraccesscontrol.responses
+                                                .ListInteractionsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/AccessRequestLifecycleStates.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/AccessRequestLifecycleStates.java
@@ -14,6 +14,7 @@ public enum AccessRequestLifecycleStates {
     Approvalwaiting("APPROVALWAITING"),
     Preapproved("PREAPPROVED"),
     Approved("APPROVED"),
+    Moreinfo("MOREINFO"),
     Rejected("REJECTED"),
     Deployed("DEPLOYED"),
     Deployfailed("DEPLOYFAILED"),

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/InteractionCollection.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/InteractionCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.model;
+
+/**
+ * Results of access request additionalInfo search, which contains details of the conversation between customer and operator.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InteractionCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InteractionCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<InteractionSummary> items;
+
+        public Builder items(java.util.List<InteractionSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InteractionCollection build() {
+            InteractionCollection __instance__ = new InteractionCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InteractionCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * contains InteractionSummary
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<InteractionSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/InteractionRequestDetails.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/InteractionRequestDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.model;
+
+/**
+ * Details for asking to provide more information to operators.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InteractionRequestDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InteractionRequestDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("moreInfoDetails")
+        private String moreInfoDetails;
+
+        public Builder moreInfoDetails(String moreInfoDetails) {
+            this.moreInfoDetails = moreInfoDetails;
+            this.__explicitlySet__.add("moreInfoDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InteractionRequestDetails build() {
+            InteractionRequestDetails __instance__ = new InteractionRequestDetails(moreInfoDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InteractionRequestDetails o) {
+            Builder copiedBuilder = moreInfoDetails(o.getMoreInfoDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * questions for asking to provide more information to operators.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("moreInfoDetails")
+    String moreInfoDetails;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/InteractionSummary.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/InteractionSummary.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.model;
+
+/**
+ * Summary of access request customer and operator conversation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InteractionSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InteractionSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("userId")
+        private String userId;
+
+        public Builder userId(String userId) {
+            this.userId = userId;
+            this.__explicitlySet__.add("userId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("userName")
+        private String userName;
+
+        public Builder userName(String userName) {
+            this.userName = userName;
+            this.__explicitlySet__.add("userName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("message")
+        private String message;
+
+        public Builder message(String message) {
+            this.message = message;
+            this.__explicitlySet__.add("message");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("userType")
+        private String userType;
+
+        public Builder userType(String userType) {
+            this.userType = userType;
+            this.__explicitlySet__.add("userType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeOfConversation")
+        private java.util.Date timeOfConversation;
+
+        public Builder timeOfConversation(java.util.Date timeOfConversation) {
+            this.timeOfConversation = timeOfConversation;
+            this.__explicitlySet__.add("timeOfConversation");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InteractionSummary build() {
+            InteractionSummary __instance__ =
+                    new InteractionSummary(
+                            id, userId, userName, message, userType, timeOfConversation);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InteractionSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .userId(o.getUserId())
+                            .userName(o.getUserName())
+                            .message(o.getMessage())
+                            .userType(o.getUserType())
+                            .timeOfConversation(o.getTimeOfConversation());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The uniqueId of the message.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * customer or operator id who is part of this conversation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("userId")
+    String userId;
+
+    /**
+     * customer or operator Name who is part of this conversation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("userName")
+    String userName;
+
+    /**
+     * contains the information exchanged between operator and customer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    String message;
+
+    /**
+     * Whether the userConversation is an operator or customer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("userType")
+    String userType;
+
+    /**
+     * Time when the conversation happened in [RFC 3339](https://tools.ietf.org/html/rfc3339)timestamp format. Example: '2020-05-22T21:10:29.600Z'
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeOfConversation")
+    java.util.Date timeOfConversation;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/InteractionRequestRequest.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/InteractionRequestRequest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.requests;
+
+import com.oracle.bmc.operatoraccesscontrol.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/operatoraccesscontrol/InteractionRequestExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use InteractionRequestRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class InteractionRequestRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.operatoraccesscontrol.model.InteractionRequestDetails> {
+
+    /**
+     * unique AccessRequest identifier
+     */
+    private String accessRequestId;
+
+    /**
+     * Details containing Query for additional information provided by Customer.
+     */
+    private com.oracle.bmc.operatoraccesscontrol.model.InteractionRequestDetails
+            interactionRequestDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.operatoraccesscontrol.model.InteractionRequestDetails getBody$() {
+        return interactionRequestDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    InteractionRequestRequest,
+                    com.oracle.bmc.operatoraccesscontrol.model.InteractionRequestDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(InteractionRequestRequest o) {
+            accessRequestId(o.getAccessRequestId());
+            interactionRequestDetails(o.getInteractionRequestDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of InteractionRequestRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of InteractionRequestRequest
+         */
+        public InteractionRequestRequest build() {
+            InteractionRequestRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.operatoraccesscontrol.model.InteractionRequestDetails body) {
+            interactionRequestDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListInteractionsRequest.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListInteractionsRequest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.requests;
+
+import com.oracle.bmc.operatoraccesscontrol.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/operatoraccesscontrol/ListInteractionsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListInteractionsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListInteractionsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * unique AccessRequest identifier
+     */
+    private String accessRequestId;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListInteractionsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListInteractionsRequest o) {
+            accessRequestId(o.getAccessRequestId());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListInteractionsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListInteractionsRequest
+         */
+        public ListInteractionsRequest build() {
+            ListInteractionsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/responses/InteractionRequestResponse.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/responses/InteractionRequestResponse.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.responses;
+
+import com.oracle.bmc.operatoraccesscontrol.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class InteractionRequestResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned AccessRequest instance.
+     */
+    private com.oracle.bmc.operatoraccesscontrol.model.AccessRequest accessRequest;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "etag",
+        "opcRequestId",
+        "accessRequest"
+    })
+    private InteractionRequestResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.operatoraccesscontrol.model.AccessRequest accessRequest) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.accessRequest = accessRequest;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(InteractionRequestResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            accessRequest(o.getAccessRequest());
+
+            return this;
+        }
+
+        public InteractionRequestResponse build() {
+            return new InteractionRequestResponse(
+                    __httpStatusCode__, etag, opcRequestId, accessRequest);
+        }
+    }
+}

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/responses/ListInteractionsResponse.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/responses/ListInteractionsResponse.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.responses;
+
+import com.oracle.bmc.operatoraccesscontrol.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListInteractionsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the {@code page} parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned InteractionCollection instance.
+     */
+    private com.oracle.bmc.operatoraccesscontrol.model.InteractionCollection interactionCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "interactionCollection"
+    })
+    private ListInteractionsResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            com.oracle.bmc.operatoraccesscontrol.model.InteractionCollection
+                    interactionCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.interactionCollection = interactionCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListInteractionsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            interactionCollection(o.getInteractionCollection());
+
+            return this;
+        }
+
+        public ListInteractionsResponse build() {
+            return new ListInteractionsResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, interactionCollection);
+        }
+    }
+}

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ospgateway/pom.xml
+++ b/bmc-ospgateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ospgateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubbillingschedule/pom.xml
+++ b/bmc-osubbillingschedule/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osuborganizationsubscription/pom.xml
+++ b/bmc-osuborganizationsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubsubscription/pom.xml
+++ b/bmc-osubsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubusage/pom.xml
+++ b/bmc-osubusage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubusage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemanagerproxy/pom.xml
+++ b/bmc-servicemanagerproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemesh/pom.xml
+++ b/bmc-servicemesh/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemesh</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-stackmonitoring/pom.xml
+++ b/bmc-stackmonitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-stackmonitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-threatintelligence/pom.xml
+++ b/bmc-threatintelligence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-threatintelligence</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usage/pom.xml
+++ b/bmc-usage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-visualbuilder/pom.xml
+++ b/bmc-visualbuilder/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-visualbuilder</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstance.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstance.java
@@ -92,7 +92,7 @@ public interface VbInstance extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/GetVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetVbInstance API.
@@ -104,7 +104,7 @@ public interface VbInstance extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
@@ -117,7 +117,7 @@ public interface VbInstance extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListVbInstancesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListVbInstances API.
@@ -129,7 +129,7 @@ public interface VbInstance extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestErrors API.
@@ -141,7 +141,7 @@ public interface VbInstance extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestLogs API.
@@ -154,7 +154,7 @@ public interface VbInstance extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceClient.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceClient.java
@@ -589,7 +589,7 @@ public class VbInstanceClient implements VbInstance {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "VbInstance",
@@ -623,7 +623,7 @@ public class VbInstanceClient implements VbInstance {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "VbInstance",
@@ -657,7 +657,7 @@ public class VbInstanceClient implements VbInstance {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "VbInstance",
@@ -692,7 +692,7 @@ public class VbInstanceClient implements VbInstance {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "VbInstance",
@@ -726,7 +726,7 @@ public class VbInstanceClient implements VbInstance {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "VbInstance",
@@ -760,7 +760,7 @@ public class VbInstanceClient implements VbInstance {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         com.oracle.bmc.ServiceDetails.setServiceDetails(
                 "VbInstance",

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/AttachmentDetails.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/AttachmentDetails.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Description of an attachments for this instance
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AttachmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AttachmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("targetRole")
+        private TargetRole targetRole;
+
+        public Builder targetRole(TargetRole targetRole) {
+            this.targetRole = targetRole;
+            this.__explicitlySet__.add("targetRole");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isImplicit")
+        private Boolean isImplicit;
+
+        public Builder isImplicit(Boolean isImplicit) {
+            this.isImplicit = isImplicit;
+            this.__explicitlySet__.add("isImplicit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetId")
+        private String targetId;
+
+        public Builder targetId(String targetId) {
+            this.targetId = targetId;
+            this.__explicitlySet__.add("targetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetInstanceUrl")
+        private String targetInstanceUrl;
+
+        public Builder targetInstanceUrl(String targetInstanceUrl) {
+            this.targetInstanceUrl = targetInstanceUrl;
+            this.__explicitlySet__.add("targetInstanceUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetServiceType")
+        private String targetServiceType;
+
+        public Builder targetServiceType(String targetServiceType) {
+            this.targetServiceType = targetServiceType;
+            this.__explicitlySet__.add("targetServiceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AttachmentDetails build() {
+            AttachmentDetails __instance__ =
+                    new AttachmentDetails(
+                            targetRole, isImplicit, targetId, targetInstanceUrl, targetServiceType);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AttachmentDetails o) {
+            Builder copiedBuilder =
+                    targetRole(o.getTargetRole())
+                            .isImplicit(o.getIsImplicit())
+                            .targetId(o.getTargetId())
+                            .targetInstanceUrl(o.getTargetInstanceUrl())
+                            .targetServiceType(o.getTargetServiceType());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The role of the target attachment.
+     *    * {@code PARENT} - The target instance is the parent of this attachment.
+     *    * {@code CHILD} - The target instance is the child of this attachment.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum TargetRole {
+        Parent("PARENT"),
+        Child("CHILD"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, TargetRole> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (TargetRole v : TargetRole.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        TargetRole(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static TargetRole create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'TargetRole', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The role of the target attachment.
+     *    * {@code PARENT} - The target instance is the parent of this attachment.
+     *    * {@code CHILD} - The target instance is the child of this attachment.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetRole")
+    TargetRole targetRole;
+
+    /**
+     * * If role == {@code PARENT}, the attached instance was created by this service instance
+     * * If role == {@code CHILD}, this instance was created from attached instance on behalf of a user
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isImplicit")
+    Boolean isImplicit;
+
+    /**
+     * The OCID of the target instance (which could be any other OCI PaaS/SaaS resource), to which this instance is attached.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetId")
+    String targetId;
+
+    /**
+     * The dataplane instance URL of the attached instance
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetInstanceUrl")
+    String targetInstanceUrl;
+
+    /**
+     * The type of the target instance, such as "FUSION".
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetServiceType")
+    String targetServiceType;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/IdcsInfoDetails.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/IdcsInfoDetails.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Information for IDCS access
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = IdcsInfoDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class IdcsInfoDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("idcsAppLocationUrl")
+        private String idcsAppLocationUrl;
+
+        public Builder idcsAppLocationUrl(String idcsAppLocationUrl) {
+            this.idcsAppLocationUrl = idcsAppLocationUrl;
+            this.__explicitlySet__.add("idcsAppLocationUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("idcsAppDisplayName")
+        private String idcsAppDisplayName;
+
+        public Builder idcsAppDisplayName(String idcsAppDisplayName) {
+            this.idcsAppDisplayName = idcsAppDisplayName;
+            this.__explicitlySet__.add("idcsAppDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("idcsAppId")
+        private String idcsAppId;
+
+        public Builder idcsAppId(String idcsAppId) {
+            this.idcsAppId = idcsAppId;
+            this.__explicitlySet__.add("idcsAppId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("idcsAppName")
+        private String idcsAppName;
+
+        public Builder idcsAppName(String idcsAppName) {
+            this.idcsAppName = idcsAppName;
+            this.__explicitlySet__.add("idcsAppName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instancePrimaryAudienceUrl")
+        private String instancePrimaryAudienceUrl;
+
+        public Builder instancePrimaryAudienceUrl(String instancePrimaryAudienceUrl) {
+            this.instancePrimaryAudienceUrl = instancePrimaryAudienceUrl;
+            this.__explicitlySet__.add("instancePrimaryAudienceUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public IdcsInfoDetails build() {
+            IdcsInfoDetails __instance__ =
+                    new IdcsInfoDetails(
+                            idcsAppLocationUrl,
+                            idcsAppDisplayName,
+                            idcsAppId,
+                            idcsAppName,
+                            instancePrimaryAudienceUrl);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(IdcsInfoDetails o) {
+            Builder copiedBuilder =
+                    idcsAppLocationUrl(o.getIdcsAppLocationUrl())
+                            .idcsAppDisplayName(o.getIdcsAppDisplayName())
+                            .idcsAppId(o.getIdcsAppId())
+                            .idcsAppName(o.getIdcsAppName())
+                            .instancePrimaryAudienceUrl(o.getInstancePrimaryAudienceUrl());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * URL for the location of the IDCS Application (used by IDCS APIs)
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("idcsAppLocationUrl")
+    String idcsAppLocationUrl;
+
+    /**
+     * The IDCS application display name associated with the instance
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("idcsAppDisplayName")
+    String idcsAppDisplayName;
+
+    /**
+     * The IDCS application ID associated with the instance
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("idcsAppId")
+    String idcsAppId;
+
+    /**
+     * The IDCS application name associated with the instance
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("idcsAppName")
+    String idcsAppName;
+
+    /**
+     * The URL used as the primary audience for visual builder flows in this instance
+     * type: string
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instancePrimaryAudienceUrl")
+    String instancePrimaryAudienceUrl;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/VbInstance.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/VbInstance.java
@@ -170,6 +170,24 @@ public class VbInstance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("idcsInfo")
+        private IdcsInfoDetails idcsInfo;
+
+        public Builder idcsInfo(IdcsInfoDetails idcsInfo) {
+            this.idcsInfo = idcsInfo;
+            this.__explicitlySet__.add("idcsInfo");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachments")
+        private java.util.List<AttachmentDetails> attachments;
+
+        public Builder attachments(java.util.List<AttachmentDetails> attachments) {
+            this.attachments = attachments;
+            this.__explicitlySet__.add("attachments");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -191,7 +209,9 @@ public class VbInstance {
                             isVisualBuilderEnabled,
                             customEndpoint,
                             alternateCustomEndpoints,
-                            consumptionModel);
+                            consumptionModel,
+                            idcsInfo,
+                            attachments);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -214,7 +234,9 @@ public class VbInstance {
                             .isVisualBuilderEnabled(o.getIsVisualBuilderEnabled())
                             .customEndpoint(o.getCustomEndpoint())
                             .alternateCustomEndpoints(o.getAlternateCustomEndpoints())
-                            .consumptionModel(o.getConsumptionModel());
+                            .consumptionModel(o.getConsumptionModel())
+                            .idcsInfo(o.getIdcsInfo())
+                            .attachments(o.getAttachments());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -423,6 +445,16 @@ public class VbInstance {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("consumptionModel")
     ConsumptionModel consumptionModel;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("idcsInfo")
+    IdcsInfoDetails idcsInfo;
+
+    /**
+     * A list of associated attachments to other services
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("attachments")
+    java.util.List<AttachmentDetails> attachments;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.27.0</version>
+    <version>2.28.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.27.0</version>
+  <version>2.28.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for information requests in the Operator Access Control service

- Support for Helm charts and repositories on deployments in the DevOps service

- Support for Application Dependency Management service scan results on builds in the DevOps service

- Support for build resources to use Bitbucket Cloud repositories for source code in the DevOps service

- Support for character set selection on autonomous dedicated databases in the Database service

- Support for listing autonomous dedicated database supported character sets in the Database service

- Support for AMD E4 flex shapes on virtual machine database systems in the Database service

- Support for terraform and improvements for cross-region ADGs in the Database service



### Breaking Changes

- Support for retries by default on GET / LIST operations in the Visual Builder service