### PR TITLE
Add sbom_generation file

### DIFF
--- a/sbom_generation.yaml
+++ b/sbom_generation.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+
 version: 0.1
 component: build
 timeoutInSeconds: 1000

--- a/sbom_generation.yaml
+++ b/sbom_generation.yaml
@@ -1,5 +1,9 @@
 # Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
 
+# This OCI DevOps build specification file [1] generates a Software Bill of Materials (SBOM) of the repository.
+# The file is needed to run checks for third-party vulnerabilities and business approval according to Oracle’s GitHub policies.
+# [1] https://docs.oracle.com/en-us/iaas/Content/devops/using/build_specs.htm
+
 version: 0.1
 component: build
 timeoutInSeconds: 1000

--- a/sbom_generation.yaml
+++ b/sbom_generation.yaml
@@ -1,0 +1,16 @@
+version: 0.1
+component: build
+timeoutInSeconds: 1000
+shell: bash
+
+steps:
+  - type: Command
+    name: "Run Maven cycloneDX plugin command"
+    command: |
+      # For more details, visit https://github.com/CycloneDX/cyclonedx-maven-plugin/blob/master/README.md
+      mvn org.cyclonedx:cyclonedx-maven-plugin:2.7.5:makeAggregateBom -DincludeRuntimeScope=true -DincludeCompileScope=true -DincludeProvidedScope=false -DincludeSystemScope=false -DincludeTestScope=false -DoutputFormat=json -DoutputName=artifactSBOM -DschemaVersion=1.4
+      mv target/artifactSBOM.json ./artifactSBOM.json
+outputArtifacts:
+  - name: artifactSBOM
+    type: BINARY
+    location: ${OCI_PRIMARY_SOURCE_DIR}/artifactSBOM.json


### PR DESCRIPTION
This PR adds an [OCI DevOps build specification file](https://docs.oracle.com/en-us/iaas/Content/devops/using/build_specs.htm) that generates a Software Bill of Materials (SBOM) of the repository.

This file is needed to run checks for third-party vulnerabilities and business approval according to Oracle’s GitHub policies.

Please approve and merge this PR.

If you have questions, please reach out to the Oracle GitHub team.