### PR TITLE
Add support for signature based upon x-date header

### DIFF
--- a/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/Constants.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/Constants.java
@@ -75,7 +75,7 @@ public class Constants {
     public static final List<String> OPTIONAL_HEADERS_NAMES =
             Collections.unmodifiableList(
                     Arrays.asList(
-                            OPC_OBO_TOKEN, CROSS_TENANCY_REQUEST_HEADER_NAME, X_SUBSCRIPTION));
+                            OPC_OBO_TOKEN, CROSS_TENANCY_REQUEST_HEADER_NAME, X_SUBSCRIPTION, X_DATE));
 
     public static final Map<String, List<String>> OPTIONAL_SIGNING_HEADERS_MAP =
             createHeadersToSignForVerbMap(

--- a/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/Constants.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
     // Signing
     static final String REQUEST_TARGET = "(request-target)";
     static final String DATE = "date";
+    static final String X_DATE = "x-date";
     static final String CONTENT_LENGTH = "content-length";
     static final String CONTENT_TYPE = "content-type";
     static final String X_CONTENT_SHA256 = "x-content-sha256";

--- a/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/RequestSignerImpl.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/RequestSignerImpl.java
@@ -317,7 +317,8 @@ public class RequestSignerImpl implements RequestSigner {
         // all of the required headers that are currently missing
         Map<String, String> missingHeaders = new HashMap<>();
 
-        if (isRequiredHeaderMissing(Constants.DATE, requiredHeaders, existingHeaders)) {
+        if (isRequiredHeaderMissing(Constants.DATE, requiredHeaders, existingHeaders) &&
+            !existingHeaders.containsKey(Constants.X_DATE)) {
             missingHeaders.put(Constants.DATE, createFormatter().format(new Date()));
         }
 

--- a/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/RequestSignerImpl.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/RequestSignerImpl.java
@@ -163,6 +163,11 @@ public class RequestSignerImpl implements RequestSigner {
             for (String optionalHeaderName : optionalHeaders) {
                 if (headers.get(optionalHeaderName) != null) {
                     requiredHeaders.add(optionalHeaderName);
+                    //If X-Date is present Date header is skipped
+                    if (Constants.X_DATE.equals(optionalHeaderName)) {
+                        requiredHeaders.remove(Constants.DATE);
+                    }
+
                 }
             }
 
@@ -317,8 +322,7 @@ public class RequestSignerImpl implements RequestSigner {
         // all of the required headers that are currently missing
         Map<String, String> missingHeaders = new HashMap<>();
 
-        if (isRequiredHeaderMissing(Constants.DATE, requiredHeaders, existingHeaders) &&
-            !existingHeaders.containsKey(Constants.X_DATE)) {
+        if (isRequiredHeaderMissing(Constants.DATE, requiredHeaders, existingHeaders)) {
             missingHeaders.put(Constants.DATE, createFormatter().format(new Date()));
         }
 

--- a/bmc-common/src/test/java/com/oracle/bmc/http/signing/internal/RequestSignerImplTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/http/signing/internal/RequestSignerImplTest.java
@@ -415,6 +415,32 @@ public class RequestSignerImplTest {
                 SigningStrategy.EXCLUDE_BODY);
     }
 
+    @Test
+    public void calculateMissingHeaders_whenGetRequestWithXDateHeader()
+            throws IOException {
+        final URI uri = URI.create("https://identity.us-phoenix-1.oraclecloud.com/20160918/users");
+        final Map<String, List<String>> temp = new HashMap<>();
+        temp.put("x-date",Collections.singletonList("Wed, 11 Oct 2023 12:23:17 GMT"));
+        final Map<String, List<String>> existingHeaders = Collections.unmodifiableMap(temp);
+        SigningStrategy signingStrategy = SigningStrategy.STANDARD;
+        final RequestSignerImpl.SigningConfiguration signingConfiguration =
+                new RequestSignerImpl.SigningConfiguration(
+                        signingStrategy.getHeadersToSign(),
+                        signingStrategy.getOptionalHeadersToSign(),
+                        signingStrategy.isSkipContentHeadersForStreamingPutRequests());
+        final Map<String, String> missingHeaders =
+                RequestSignerImpl.calculateMissingHeaders(
+                        "get",
+                        uri,
+                        existingHeaders,
+                        null,
+                        Constants.ALL_HEADERS_LIST,
+                        signingConfiguration);
+        assertNotNull(missingHeaders);
+        assertEquals(1, missingHeaders.size());
+        assertFalse(missingHeaders.containsKey("date"));
+    }
+
     private void calculateAndVerifyMissingHeaders(
             final String httpMethod,
             final String contentType,


### PR DESCRIPTION
Added support for signature generation using x-date request header.
If x-date and date is passed in header then only x-date is considered in signature string.
Date header will be set if both x-date and date header is missing from user request

Closes #554 