### PR TITLE
Minor fix of ArrayIndexOutOfBounds Exception

### DIFF
--- a/bmc-examples/src/main/java/ApiGatewayExample.java
+++ b/bmc-examples/src/main/java/ApiGatewayExample.java
@@ -108,7 +108,7 @@ public class ApiGatewayExample {
         }
 
         final String compartmentId = args[0];
-        final Region region = args.length == 1 ? Region.US_PHOENIX_1 : Region.fromRegionId(args[2]);
+        final Region region = args.length == 1 ? Region.US_PHOENIX_1 : Region.fromRegionId(args[1]);
 
         // Configuring the AuthenticationDetailsProvider. It's assuming there is a default OCI
         // config file


### PR DESCRIPTION
Class requires 1 arg (compartment-id) and can optionally accept a 2nd arg (region). Validation incorrectly addressed 2nd arg in the 2 index position and not 1.