### PR TITLE
ticket-777: Fix the bug when IMDS fails during auth token refresh whi…

### DIFF
--- a/bmc-common/src/main/java/com/oracle/bmc/auth/internal/X509FederationClient.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/auth/internal/X509FederationClient.java
@@ -237,55 +237,14 @@ public class X509FederationClient implements FederationClient, ProvidesConfigura
         }
 
         if (iAmTheLeader) {
-            LOG.info("[Leader] About to refresh security token.");
-
-            if (refreshKeys) {
-                LOG.info("Refreshing session keys.");
-                sessionKeySupplier.refreshKeys();
-            }
-            if (leafCertificateSupplier instanceof Refreshable) {
-                try {
-                    ((Refreshable) leafCertificateSupplier).refresh();
-                } catch (RefreshFailedException ex) {
-                    throw new BmcException(
-                            false, "Can't refresh the leaf certification!", ex, null);
-                }
-                // When using default purpose (ex, instance principals), the token request should always be signed with the same tenant id as the certificate.
-                // For other purposes, the tenant id can be different.
-                if (this.purpose.equals(DEFAULT_PURPOSE)) {
-                    String newTenancyId =
-                            AuthUtils.getTenantIdFromCertificate(
-                                    leafCertificateSupplier
-                                            .getCertificateAndKeyPair()
-                                            .getCertificate());
-
-                    if (!this.tenancyId.equals(newTenancyId)) {
-                        throw new IllegalArgumentException(
-                                "The tenancy id should never be changed in cert file!");
-                    }
-                }
-            }
-
-            for (X509CertificateSupplier supplier : intermediateCertificateSuppliers) {
-                if (supplier instanceof Refreshable) {
-                    try {
-                        ((Refreshable) supplier).refresh();
-                    } catch (RefreshFailedException ex) {
-                        throw new BmcException(
-                                false, "Can't refresh the intermediate certification!", ex, null);
-                    }
-                }
-            }
-
             try {
-                securityTokenAdapter = getSecurityTokenFromServer();
-                String token = securityTokenAdapter.getSecurityToken();
+                LOG.info("[Leader] About to refresh security token.");
+                String token = refreshSecurityToken(refreshKeys);
                 future.complete(token);
                 return token;
-            } catch (Exception e) {
-                LOG.error("Error refreshing security token", e);
+            } catch (RuntimeException e) {
                 future.completeExceptionally(e);
-                throw new BmcException(false, "Error refreshing security token.", e, null);
+                throw e;
             } finally {
                 inFlightRefresh = null;
             }
@@ -307,6 +266,55 @@ public class X509FederationClient implements FederationClient, ProvidesConfigura
                 throw new BmcException(
                         false, "Timed out waiting for security token refresh.", e, null);
             }
+        }
+    }
+
+    private String refreshSecurityToken(boolean refreshKeys) {
+        if (refreshKeys) {
+            LOG.info("Refreshing session keys.");
+            sessionKeySupplier.refreshKeys();
+        }
+        if (leafCertificateSupplier instanceof Refreshable) {
+            try {
+                ((Refreshable) leafCertificateSupplier).refresh();
+            } catch (RefreshFailedException ex) {
+                throw new BmcException(
+                        false,
+                        "Unable to refresh the client certificate used to obtain an OCI security token.",
+                        ex,
+                        null);
+            }
+            // When using default purpose (ex, instance principals), the token request should always be signed with the same tenant id as the certificate.
+            // For other purposes, the tenant id can be different.
+            if (this.purpose.equals(DEFAULT_PURPOSE)) {
+                String newTenancyId =
+                        AuthUtils.getTenantIdFromCertificate(
+                                leafCertificateSupplier.getCertificateAndKeyPair().getCertificate());
+
+                if (!this.tenancyId.equals(newTenancyId)) {
+                    throw new IllegalArgumentException(
+                            "The tenancy id should never be changed in cert file!");
+                }
+            }
+        }
+
+        for (X509CertificateSupplier supplier : intermediateCertificateSuppliers) {
+            if (supplier instanceof Refreshable) {
+                try {
+                    ((Refreshable) supplier).refresh();
+                } catch (RefreshFailedException ex) {
+                    throw new BmcException(
+                            false, "Can't refresh the intermediate certification!", ex, null);
+                }
+            }
+        }
+
+        try {
+            securityTokenAdapter = getSecurityTokenFromServer();
+            return securityTokenAdapter.getSecurityToken();
+        } catch (Exception e) {
+            LOG.error("Error refreshing security token", e);
+            throw new BmcException(false, "Error refreshing security token.", e, null);
         }
     }
 

--- a/bmc-common/src/test/java/com/oracle/bmc/auth/internal/X509FederationClientTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/auth/internal/X509FederationClientTest.java
@@ -14,9 +14,12 @@ import com.oracle.bmc.http.internal.WrappedInvocationBuilder;
 import com.oracle.bmc.model.BmcException;
 import com.oracle.bmc.requests.BmcRequest;
 import java.security.KeyPairGenerator;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +33,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Response;
+import javax.security.auth.RefreshFailedException;
+import javax.security.auth.Refreshable;
 
 import java.io.IOException;
 import java.net.URI;
@@ -311,5 +316,145 @@ public class X509FederationClientTest {
                 "Concurrent requests should coalesce into one server call",
                 1,
                 serverCallCount.get());
+    }
+
+    /**
+     * Regression test for:
+     *
+     * <ul>
+     *   <li><a href="https://jira.oci.oraclecorp.com/browse/TOSIM-3623">TOSIM-3623</a></li>
+     *   <li><a href="https://github.com/oracle/oci-java-sdk/issues/777">OCI Java SDK issue 777</a></li>
+     *   <li><a href="https://jira.oci.oraclecorp.com/browse/DEX-25556">DEX-25556</a></li>
+     * </ul>
+     *
+     * <p>This test simulates the Instance Metadata Service (IMDS) returning HTTP 404 while the
+     * leader refreshes {@code cert.pem}. The leader has already created {@code inFlightRefresh}; a
+     * concurrent follower therefore waits on that Future instead of starting another refresh.
+     *
+     * <p>The test verifies that the leader completes {@code inFlightRefresh} exceptionally before
+     * it returns. The follower must then receive the same error promptly, rather than waiting for
+     * the one-minute single-flight timeout.
+     */
+    @Test
+    public void
+            refreshFailureBeforeTokenRequest_completesInFlightRefreshSoFollowerDoesNotWait()
+                    throws Exception {
+        CountDownLatch leaderStartedCertificateRefresh = new CountDownLatch(1);
+        CountDownLatch failCertificateRefresh = new CountDownLatch(1);
+        AtomicReference<Throwable> leaderFailure = new AtomicReference<>();
+        AtomicReference<Throwable> followerFailure = new AtomicReference<>();
+
+        class RefreshableFailingLeafCertificateSupplier
+                implements X509CertificateSupplier, Refreshable {
+            @Override
+            public boolean isCurrent() {
+                return false;
+            }
+
+            @Override
+            public void refresh() throws RefreshFailedException {
+                leaderStartedCertificateRefresh.countDown();
+                try {
+                    if (!failCertificateRefresh.await(5, TimeUnit.SECONDS)) {
+                        throw new RefreshFailedException(
+                                "Timed out waiting to simulate cert.pem failure");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RefreshFailedException("Interrupted while simulating cert.pem failure");
+                }
+                throw new RefreshFailedException("IMDS GET cert.pem returned HTTP 404");
+            }
+
+            @Override
+            @Deprecated
+            public X509Certificate getCertificate() {
+                return null;
+            }
+
+            @Override
+            @Deprecated
+            public java.security.interfaces.RSAPrivateKey getPrivateKey() {
+                return null;
+            }
+
+            @Override
+            public CertificateAndPrivateKeyPair getCertificateAndKeyPair() {
+                return null;
+            }
+        }
+
+        X509CertificateSupplier refreshableLeafCertificateSupplier =
+                new RefreshableFailingLeafCertificateSupplier();
+
+        X509FederationClient client =
+                new X509FederationClient(
+                        "https://auth.example.com",
+                        "testTenantId",
+                        refreshableLeafCertificateSupplier,
+                        mock(SessionKeySupplier.class),
+                        Collections.emptySet(),
+                        mock(ClientConfigurator.class),
+                        Collections.emptyList(),
+                        mock(CircuitBreakerConfiguration.class));
+
+        Thread leader =
+                new Thread(
+                        () -> {
+                            try {
+                                client.getSecurityToken();
+                            } catch (Throwable e) {
+                                leaderFailure.set(e);
+                            }
+                        },
+                        "refresh-leader");
+        leader.start();
+        assertEquals(
+                "Leader should begin the simulated cert.pem refresh",
+                true,
+                leaderStartedCertificateRefresh.await(5, TimeUnit.SECONDS));
+
+        Thread follower =
+                new Thread(
+                        () -> {
+                            try {
+                                client.getSecurityToken();
+                            } catch (Throwable e) {
+                                followerFailure.set(e);
+                            }
+                        },
+                        "refresh-follower");
+        follower.start();
+
+        try {
+            final Object waitObject = new Object();
+            long deadline = System.currentTimeMillis() + 5_000;
+            while (follower.getState() != Thread.State.TIMED_WAITING
+                    && System.currentTimeMillis() < deadline) {
+                synchronized (waitObject) {
+                    waitObject.wait(10);
+                }
+            }
+            assertEquals(
+                    "Follower should wait on the leader's in-flight refresh before it fails",
+                    Thread.State.TIMED_WAITING,
+                    follower.getState());
+
+            failCertificateRefresh.countDown();
+            leader.join(5_000);
+            follower.join(2_000);
+
+            assertFalse("Leader should return the certificate refresh error", leader.isAlive());
+            assertFalse(
+                    "Follower must receive the leader failure instead of waiting for inFlightRefresh",
+                    follower.isAlive());
+            assertEquals(BmcException.class, leaderFailure.get().getClass());
+            assertEquals(BmcException.class, followerFailure.get().getClass());
+        } finally {
+            failCertificateRefresh.countDown();
+            follower.interrupt();
+            leader.join(5_000);
+            follower.join(5_000);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #777.

When a token refresh fails before the federation request is made, concurrent callers can remain blocked waiting for the shared in-flight refresh result until the timeout expires.

This change ensures that every leader-side refresh failure:

- completes the shared refresh future exceptionally, releasing current waiting callers immediately;
- clears the in-flight state so a subsequent caller can begin a new refresh.

The refresh logic is extracted into a focused helper while preserving the existing public API and error behavior.

## Testing

- Added a regression test that simulates a failed refresh of the client certificate before the token request.
- Verified that a concurrent caller receives the leader’s failure promptly rather than waiting for the single-flight timeout.
- Ran:

  ```text
  mvn -pl bmc-common -Dtest=X509FederationClientTest test
  ```

  Result: 7 tests passed.
```
[2026/07/29 14:47:02] vianovak ~/workspace/oci-java-sdk [github-777] $ export JAVA_HOME=/Users/vianovak/Library/Java/JavaVirtualMachines/corretto-1.8.0_422/Contents/Home                             
export PATH="$JAVA_HOME/bin:$PATH"
mvn -pl bmc-common -Dtest=X509FederationClientTest test
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.oracle.bmc.auth.internal.X509FederationClientTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.894 s -- in com.oracle.bmc.auth.internal.X509FederationClientTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- animal-sniffer:1.16:check (animal-sniffer-check) @ oci-java-sdk-common ---
[INFO] Checking unresolved references to org.codehaus.mojo.signature:java18:1.0
[INFO] /Users/vianovak/workspace/oci-java-sdk/bmc-common/src/main/java/com/oracle/bmc/http/signing/pki/Eraser.java:23: Covariant return type change detected: java.nio.Buffer java.nio.ByteBuffer.clear() has been changed to java.nio.ByteBuffer java.nio.ByteBuffer.clear()
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.576 s
[INFO] Finished at: 2026-07-29T14:49:19Z
[INFO] ------------------------------------------------------------------------
```